### PR TITLE
fix: use importlib to get rootstock version spec

### DIFF
--- a/rootstock/commands/install.py
+++ b/rootstock/commands/install.py
@@ -252,13 +252,15 @@ def _install_single_environment(
 
     # Install rootstock
     print("3. Installing rootstock...")
-    # Find rootstock package path
-    import rootstock
+    # Pin to the running rootstock's version so the env matches the driver,
+    # without depending on where the driver itself was installed from.
+    from importlib.metadata import version as _pkg_version
 
-    rootstock_path = Path(rootstock.__file__).parent.parent
+    rootstock_spec = f"rootstock=={_pkg_version('rootstock')}"
+    print(f"  Installing: {rootstock_spec}")
 
     result = subprocess.run(
-        ["uv", "pip", "install", "--python", str(env_python), str(rootstock_path)],
+        ["uv", "pip", "install", "--python", str(env_python), rootstock_spec],
         capture_output=not verbose,
         text=True,
         env=uv_env,

--- a/uv.lock
+++ b/uv.lock
@@ -2312,7 +2312,7 @@ wheels = [
 
 [[package]]
 name = "rootstock"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "ase" },


### PR DESCRIPTION
this is a quick fix to get myself unblocked on delta, but heads-up: this could cause subtle problems for dev installs if you're expecting a local change to appear in the environment (this now limits us to only installing rootstock from pypi for the rootstock we install in each venv).

I have a more ✨sophisticated✨ [util](https://github.com/Garden-AI/groundhog/blob/1a6c8b77ce289d8d6a4e53893bbe0de7584b110d/src/groundhog_hpc/utils.py#L33) for this exact problem in groundhog to detect if it should install from github using a commit hash instead of pypi; I can reimplement that for rootstock later in a follow-up PR 