### PR TITLE
automated smoke testing

### DIFF
--- a/.github/workflows/nightly-smoke-test.yml
+++ b/.github/workflows/nightly-smoke-test.yml
@@ -1,0 +1,29 @@
+name: Nightly smoke-test
+
+on:
+  schedule:
+    - cron: "0 7 * * *"   # 07:00 UTC, off-peak for US clusters
+  workflow_dispatch:       # manual trigger for debugging
+
+jobs:
+  smoke-test:
+    strategy:
+      fail-fast: false      # one cluster's failure shouldn't cancel others
+      matrix:
+        # Expand as endpoints come online: [delta, della, sophia, perlmutter, frontier]
+        cluster: [delta]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60     # smoke-test is minutes; 60 absorbs queue waits
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+
+      - name: Install groundhog-hpc
+        run: uv tool install --python 3.13 groundhog-hpc@latest
+
+      - name: Dispatch smoke-test to ${{ matrix.cluster }}
+        env:
+          GLOBUS_COMPUTE_CLIENT_ID: ${{ secrets.GLOBUS_COMPUTE_CLIENT_ID }}
+          GLOBUS_COMPUTE_CLIENT_SECRET: ${{ secrets.GLOBUS_COMPUTE_CLIENT_SECRET }}
+        run: hog run scripts/nightly_smoke_test.py main -- ${{ matrix.cluster }}

--- a/docs/cluster-setup.md
+++ b/docs/cluster-setup.md
@@ -155,11 +155,12 @@ If a node has both network access and a GPU, run without `--no-verify` to do eve
 
 `rootstock add` is idempotent — re-running it after a successful download will skip the download phase and just re-verify.
 
-`rootstock smoke-test` re-verifies every fetched checkpoint and is suitable for nightly cron:
-
-```bash
-0 4 * * * rootstock smoke-test --json > /var/log/rootstock-smoke.log 2>&1
-```
+`rootstock smoke-test` re-verifies every fetched checkpoint. To keep a cluster's
+manifest current automatically, set it up on a nightly schedule — see
+[Nightly Automated Smoke-Testing](nightly-smoke-testing.md) for the recommended
+approach (a Globus Compute endpoint dispatched from CI). A bare local cron entry
+(`0 4 * * * rootstock smoke-test --json`) also works where the cluster permits
+user cron, but the dispatched approach is preferred and portable across sites.
 
 !!! note "Smoke-test always uses default kwargs"
     `smoke-test` calls each env's `setup()` with no extra kwargs. A checkpoint that only works with non-default kwargs (e.g., a UMA checkpoint that needs `task=omol`) will appear failing in nightly smoke-test even though `add` succeeded. The remedy is to make the preferred kwargs the env's default in the env file.

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,4 +71,12 @@ Swap the underlying potential by changing `checkpoint`: e.g. `checkpoint="uma-s-
 
     [:octicons-arrow-right-24: Cluster Setup](cluster-setup.md)
 
+-   :material-test-tube:{ .lg .middle } **Nightly Smoke-Testing**
+
+    ---
+
+    Keep a cluster's manifest current with automated nightly checks.
+
+    [:octicons-arrow-right-24: Nightly Smoke-Testing](nightly-smoke-testing.md)
+
 </div>

--- a/docs/nightly-smoke-testing.md
+++ b/docs/nightly-smoke-testing.md
@@ -1,0 +1,311 @@
+# Nightly Automated Smoke-Testing
+
+This guide is for **cluster maintainers**. It covers the one-time setup needed
+to bring a cluster into the nightly smoke-test rotation.
+
+## Overview
+
+Every night, a GitHub Actions workflow dispatches `rootstock smoke-test` to each
+participating cluster. The path is:
+
+```
+GitHub Actions (cron, 07:00 UTC)
+  └─ dispatches via groundhog-hpc, authenticating as a Globus confidential client
+       └─ per-cluster Globus Compute endpoint (persistent login-node daemon)
+            └─ submits a SLURM GPU job
+                 └─ rootstock smoke-test --device cuda --json
+                      └─ updates manifest.json and pushes it to the backend
+```
+
+The scheduling, dispatch, and authentication all live **off-cluster**. The only
+on-cluster component is the Globus Compute endpoint, and the only thing this
+guide sets up is that endpoint plus the machinery to keep it alive.
+
+Do this once per cluster. The maintainer who owns the cluster's rootstock
+install should also own the endpoint, so `rootstock smoke-test` runs as an
+identity with `is_maintainer = true` and the manifest push works.
+
+## Prerequisites
+
+- A maintainer account on the cluster that is a member of a GPU allocation.
+- Rootstock installed and configured on that account: `~/.config/rootstock/config.toml`
+  with a valid API key and `is_maintainer = true`.
+- Ability to install user-level Python packages (`pipx` or `pip install --user`).
+- A way to keep a login-node process alive across crashes and reboots — a
+  `cron` job (simplest) or a `systemd` user service with lingering. **Verify
+  which your cluster allows early**; some disable both (see
+  [Per-cluster notes](#per-cluster-notes)). The keep-alive mechanism shapes the
+  rest of the setup.
+
+## Step 1: Retrieve the Globus confidential-client credentials
+
+Nightly CI authenticates as a Globus **confidential client** (a service
+account), so it runs unattended with no browser flow. There is one client for
+the whole project, shared across all clusters.
+
+- **Client ID** (not secret, safe to commit):
+  `84102a92-84b8-40ec-9520-4ece991654f1`
+- **Client secret**: stored in AWS Secrets Manager. To mint a fresh one, open
+  the `rootstock-nightly-runner` project at <https://app.globus.org/settings/developers>
+  and click **Add Client Secret**; a client can hold several at once. AWS holds
+  the canonical copy — reuse it rather than generating a new secret per cluster.
+
+Retrieve the secret:
+
+```bash
+aws secretsmanager get-secret-value \
+  --secret-id rootstock/nightly-smoke-test-client \
+  --query SecretString --output text
+```
+
+The same `(client_id, client_secret)` pair is stored as the GitHub repo secrets
+`GLOBUS_COMPUTE_CLIENT_ID` / `GLOBUS_COMPUTE_CLIENT_SECRET` that the Actions
+workflow consumes. The credential is long-lived and does not need rotation —
+only the access tokens minted from it expire, and the SDK refreshes those
+transparently.
+
+## Step 2: Install `globus-compute-endpoint` on the login node
+
+```bash
+uv tool install globus-compute-endpoint --python 3.13 # gce has issues with 3.14 
+which globus-compute-endpoint        # note this path 
+```
+
+The install directory (usually `~/.local/bin`) matters later: the endpoint
+re-execs this binary to spawn workers, so it must be reachable from the
+service environment.
+
+The binary ships a `gce` alias for `globus-compute-endpoint`; this guide spells
+out the full name, but `gce start rootstock-nightly` and friends are equivalent.
+
+## Step 3: Create and configure the endpoint
+
+Name the endpoint `rootstock-nightly` to keep the systemd unit and these
+instructions identical across clusters:
+
+```bash
+#TODO export env vars before this step!!
+globus-compute-endpoint configure rootstock-nightly
+```
+
+This creates config files under `~/.globus_compute/rootstock-nightly/`. Copy the
+template `scripts/nightly-endpoint-config.yaml.j2` (in the rootstock repo) to `~/.globus_compute/rootstock-nightly/user_config_template.yaml.j2` as a starting point, 
+but config may need to change according to scheduler differences etc. The actual values for 
+the fields templated here will be set by the groundhog script. 
+
+There is no separate allowlist to configure. A Globus Compute endpoint is owned
+by whichever identity starts it, and submission requires authenticating as that
+same identity. Start the endpoint as the confidential client — credentials from
+Step 1 in the environment — and it is owned by the service account; the nightly
+dispatcher then submits simply by setting the *same*
+`GLOBUS_COMPUTE_CLIENT_ID` / `GLOBUS_COMPUTE_CLIENT_SECRET`.
+
+The credentials must therefore be set from the **very first start** — the
+endpoint binds its owning identity then, and there is no way to change it later
+short of recreating the endpoint.
+
+Export the credentials, then start the endpoint once to record its UUID
+(needed in Step 5):
+
+```bash
+export GLOBUS_COMPUTE_CLIENT_ID=84102a92-84b8-40ec-9520-4ece991654f1
+export GLOBUS_COMPUTE_CLIENT_SECRET=<secret from Step 1>
+
+globus-compute-endpoint start rootstock-nightly
+globus-compute-endpoint list                  # copy the Endpoint ID
+globus-compute-endpoint stop rootstock-nightly
+```
+
+Step 4 wires these same credentials into the keep-alive mechanism, so every
+subsequent start uses them too.
+
+## Step 4: Keep the endpoint alive
+
+The endpoint is a persistent login-node daemon. It must come back after a crash,
+a process sweep, or a login-node reboot. Two mechanisms work, depending on
+cluster policy — verify which is available before you pick:
+
+- **`cron`** (Option A): simplest, where plain `crontab` is allowed.
+- **`systemd` user service with lingering** (Option B): the robust fallback,
+  and the only option on clusters where `crontab` is blocked (e.g. Delta).
+
+> SLURM `scrontab` is never the right tool here: scrontab jobs run on compute
+> nodes, but the endpoint must live on the login node.
+
+### Pick one login node first
+
+Many clusters have several login nodes sharing `$HOME`. The endpoint must run on
+**exactly one** of them — two endpoints sharing one UUID continuously evict each
+other (see [Troubleshooting](#troubleshooting)). Whichever mechanism you choose,
+pin it to a single login node. Run `hostname` on the node you pick and note it.
+
+### Option A: cron
+
+Where plain `crontab` is available, re-run `start` every 15 minutes. `start` is
+a no-op when the endpoint is already running, so the job heals a crashed or
+swept endpoint at the next tick. `crontab -e`, then:
+
+```cron
+# cron injects these assignment lines into every job's environment
+GLOBUS_COMPUTE_CLIENT_ID=84102a92-84b8-40ec-9520-4ece991654f1
+GLOBUS_COMPUTE_CLIENT_SECRET=<secret from Step 1>
+PATH=/home/youruser/.local/bin:/usr/bin:/bin
+
+*/15 * * * * globus-compute-endpoint start rootstock-nightly
+```
+
+The credentials **must** be in the job's environment — set them as crontab
+assignment lines (above) so every run binds the service account, not your
+identity. Use the binary's absolute path if you would rather not set `PATH`.
+
+If the crontab spool is shared across login nodes, guard the command so only the
+node you chose runs it:
+
+```cron
+*/15 * * * * [ "$(hostname)" = dt-login03 ] && globus-compute-endpoint start rootstock-nightly
+```
+
+That is all cron needs. Skip Option B.
+
+### Option B: systemd user service
+
+The robust, self-healing mechanism for clusters where `crontab` is blocked. A
+systemd user service with lingering survives logout, crash, and reboot with no
+polling.
+
+#### 4b.1. Enable lingering on the chosen node
+
+Lingering lets your user services keep running after you log out and start on
+boot. Linger state is **per login node** — it lives in `/var/lib/systemd/linger/`,
+which is local to each node even when `$HOME` is shared — so enable it only on
+the node you chose:
+
+```bash
+loginctl enable-linger $USER
+loginctl show-user $USER | grep Linger      # want: Linger=yes
+```
+
+If `enable-linger` is denied, escalate to the cluster's support desk — ask for
+the sanctioned way to run a persistent Globus Compute endpoint.
+
+#### 4b.2. Create the credentials env file
+
+`~/.config/rootstock/rootstock-nightly.env` — **plain `KEY=value`, no quotes**.
+This file is read by systemd's `EnvironmentFile=`, which is *not* a shell, so
+shell quoting does not apply:
+
+```
+GLOBUS_COMPUTE_CLIENT_ID=84102a92-84b8-40ec-9520-4ece991654f1
+GLOBUS_COMPUTE_CLIENT_SECRET=<secret from Step 1, unquoted>
+```
+
+```bash
+chmod 600 ~/.config/rootstock/rootstock-nightly.env
+```
+
+#### 4b.3. Create the service unit
+
+`~/.config/systemd/user/rootstock-endpoint.service`. Pin `ConditionHost` to the
+login node you chose above:
+
+```ini
+[Unit]
+Description=Rootstock nightly Globus Compute endpoint
+# Pin to the single login node chosen above — full hostname, glob-friendly.
+ConditionHost=dt-login03*
+
+[Service]
+Type=simple
+Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
+EnvironmentFile=%h/.config/rootstock/rootstock-nightly.env
+ExecStartPre=-%h/.local/bin/globus-compute-endpoint stop rootstock-nightly
+ExecStart=%h/.local/bin/globus-compute-endpoint start rootstock-nightly
+ExecStop=%h/.local/bin/globus-compute-endpoint stop rootstock-nightly
+Restart=always
+RestartSec=30
+
+[Install]
+WantedBy=default.target
+```
+
+#### 4b.4. Enable and verify
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now rootstock-endpoint.service
+systemctl --user status rootstock-endpoint.service     # expect: active (running)
+```
+
+From here on, let systemd own the endpoint — do **not** run
+`globus-compute-endpoint start` by hand, or you will get a pid-file conflict.
+
+> **Logs:** `journalctl --user` is often denied on HPC login nodes ("No journal
+> files were opened due to insufficient permissions") — that is harmless and does
+> not affect the service. The endpoint writes its own logs to
+> `~/.globus_compute/rootstock-nightly/endpoint.log`; use that for
+> debugging, and `systemctl --user status` for health.
+
+## Step 5: Register the cluster in the dispatch script
+
+Edit the PEP 723 metadata in `scripts/nightly_smoke_test.py`. Add or update the
+`[tool.hog.<cluster>]` block:
+
+```toml
+# [tool.hog.delta]
+# endpoint = "27687af7-a20e-477a-8d4e-b5a7a097f864"
+# account = "bhhl-delta-gpu"
+# scheduler_options = "#SBATCH --gpus-per-node=1"
+# partition = "gpuA100x4"
+```
+
+Only `endpoint` uuid is mandatory; the rest mirror the endpoint config's SLURM
+provider and may be omitted where the endpoint config already covers them.
+
+## Step 6: Verify end-to-end
+
+From your laptop, with the credentials exported. Dispatch goes through the
+groundhog CLI (`hog run`), which authenticates as the confidential client — so
+the same env vars must be set locally, or it will not authorize:
+
+```bash
+export GLOBUS_COMPUTE_CLIENT_ID=84102a92-84b8-40ec-9520-4ece991654f1
+export GLOBUS_COMPUTE_CLIENT_SECRET=<secret from Step 1>
+
+# cheap probe — runs hello_endpoint in a worker, no SLURM GPU job
+hog run scripts/nightly_smoke_test.py hello -- --endpoint=<cluster-name>
+
+# full run — submits the real GPU smoke-test
+hog run scripts/nightly_smoke_test.py main -- <cluster-name>
+```
+
+Then confirm the manifest landed in the backend (`rootstock status`). Finally,
+add the cluster to the matrix in `.github/workflows/nightly-smoke-test.yml`.
+
+## Per-cluster notes
+
+### NCSA Delta
+
+- `crontab` (PAM-blocked) and `scrontab` (disabled) are both unavailable, so
+  Option A is out; `systemd` user lingering works — use Step 4 Option B.
+- CUDA 12 is the default toolkit; use `cu12` wheels.
+- GPU charge code: `bhhl-delta-gpu` (the official Delta deployment account).
+  Non-interactive GPU partition: `gpuA100x4`.
+- Endpoint UUID: `27687af7-a20e-477a-8d4e-b5a7a097f864`.
+- Delta has multiple login nodes sharing `$HOME`. The endpoint is pinned to
+  **`dt-login03`** (`ConditionHost=dt-login03*`), and lingering is enabled only
+  on that node.
+- See `notes/Cluster Delta.md` in the umbrella workspace for filesystem,
+  permissions, and allocation gotchas.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `exit code 83`, `FileNotFoundError ... /usr/sbin/globus-compute-endpoint` | Endpoint can't find its own binary to spawn a worker; service PATH lacks the install dir. | Add `Environment=PATH=` with `~/.local/bin` (Step 4b.3), `daemon-reload`, restart. |
+| Dispatch auth succeeds but submission is rejected | Confidential client not authorized on the endpoint. | Authorize the client identity (Step 3). |
+| Endpoint shows `Disconnected` in `globus-compute-endpoint list` | Crashed daemon left a stale pid file. | `ExecStartPre=-... stop` handles it; otherwise `stop` then `start` manually. |
+| Service restart-loops every ~2 min; `endpoint.log` shows clean `Shutdown complete` every ~90 s; `systemctl --user show` reports `Result=timeout`, `MainPID=0` | Unit uses `Type=forking`, but `globus-compute-endpoint` runs in the foreground and never forks; systemd times out the start at `TimeoutStartSec` (90 s) and restart-loops. | Set `Type=simple` and remove `PIDFile=` (Step 4b.3); `daemon-reload`, restart. |
+| Endpoint bounces; `endpoint.log` shows restarts with the same UUID but jumping PIDs | A second endpoint with the same UUID is running on another login node — they evict each other. | Pin the unit to one node with `ConditionHost=` (Step 4b.3); `stop` the strays on the other nodes. |
+| Job runs but fails with `BadStateException ... Job is marked as MISSING since the workers failed to register`; block stdout shows the worker pool starting then "exiting normally" | Workers can't reach the interchange — `address_by_hostname` resolved the login hostname to a non-routable address (e.g. link-local IPv6). | Use `address_by_interface` with a verified `ifname` (Step 3); restart the endpoint. |
+| `journalctl --user`: "insufficient permissions" | Per-user journal not readable on this node. | Harmless. Use `~/.globus_compute/<name>/endpoint.log` and `systemctl --user status`. |
+| Endpoint runs as your user identity, not the service account | Service started without the credential env vars. | Confirm `EnvironmentFile=` path and that the env file is unquoted `KEY=value`. |

--- a/rootstock/clusters.py
+++ b/rootstock/clusters.py
@@ -40,6 +40,9 @@ CLUSTER_REGISTRY: dict[str, Cluster] = {
         root=Path("/global/cfs/cdirs/m4845/rootstock"),
         cache_root=Path("/pscratch/sd/w/wengler/rootstock-cache"),
     ),
+    "delta": Cluster(
+        root=Path("/work/hdd/data/rootstock")
+    )
 }
 
 def get_cluster(cluster: str) -> Cluster:

--- a/sample_model_configurations/nvidia_configs/allegro.py
+++ b/sample_model_configurations/nvidia_configs/allegro.py
@@ -1,10 +1,10 @@
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [
-#     "allegro @ git+https://github.com/mir-group/allegro.git",
+#     "nequip-allegro @ git+https://github.com/mir-group/allegro.git",
 #     "nequip>=0.6.0",
 #     "ase>=3.22",
-#     "torch>=2.0",
+#     "torch>=2.4.0,<2.5",
 #     "torch-geometric",
 # ]
 #

--- a/sample_model_configurations/nvidia_configs/chgnet.py
+++ b/sample_model_configurations/nvidia_configs/chgnet.py
@@ -5,6 +5,14 @@
 #     "ase>=3.22",
 #     "torch>=2.0",
 # ]
+#
+# [tool.uv.sources]
+# torch = { index = "pytorch-cu128" }
+#
+# [[tool.uv.index]]
+# name = "pytorch-cu128"
+# url = "https://download.pytorch.org/whl/cu128"
+# explicit = true
 # ///
 """CHGNet env — hosts pretrained charge-informed universal potentials."""
 

--- a/sample_model_configurations/nvidia_configs/m3gnet.py
+++ b/sample_model_configurations/nvidia_configs/m3gnet.py
@@ -5,6 +5,14 @@
 #     "ase>=3.22",
 #     "torch>=2.0",
 # ]
+#
+# [tool.uv.sources]
+# torch = { index = "pytorch-cu128" }
+#
+# [[tool.uv.index]]
+# name = "pytorch-cu128"
+# url = "https://download.pytorch.org/whl/cu128"
+# explicit = true
 # ///
 """
 M3GNet environment for Rootstock — redirected to CHGNet.

--- a/sample_model_configurations/nvidia_configs/mattersim.py
+++ b/sample_model_configurations/nvidia_configs/mattersim.py
@@ -5,6 +5,14 @@
 #     "ase>=3.22",
 #     "torch>=2.0",
 # ]
+#
+# [tool.uv.sources]
+# torch = { index = "pytorch-cu128" }
+#
+# [[tool.uv.index]]
+# name = "pytorch-cu128"
+# url = "https://download.pytorch.org/whl/cu128"
+# explicit = true
 # ///
 """
 MatterSim environment for Rootstock.

--- a/sample_model_configurations/nvidia_configs/nequip.py
+++ b/sample_model_configurations/nvidia_configs/nequip.py
@@ -3,7 +3,7 @@
 # dependencies = [
 #     "nequip>=0.6.0",
 #     "ase>=3.22",
-#     "torch>=2.0",
+#     "torch>=2.4.0,<2.5",
 #     "torch-geometric",
 # ]
 #
@@ -23,9 +23,12 @@ Note: NequIP is system-specific (not universal). The checkpoint must match
 the element set of your system.
 """
 
-CHECKPOINTS = {
-    "nequip-deployed-model": "deployed_nequip.pth",
-}
+# NequIP is system-specific: there is no universal pretrained checkpoint to
+# ship. Users supply their own model deployed with `nequip-deploy`, whose file
+# must be named `*.nequip.pth` or `*.nequip.pt2` (the loader rejects other
+# names). Register one with its canonical id → path, e.g.:
+#     "my-system-nequip": "/path/to/my_model.nequip.pth",
+CHECKPOINTS: dict[str, str] = {}
 
 
 def setup(checkpoint: str, device: str = "cuda"):

--- a/sample_model_configurations/nvidia_configs/orb.py
+++ b/sample_model_configurations/nvidia_configs/orb.py
@@ -5,6 +5,14 @@
 #     "ase>=3.22",
 #     "torch>=2.0",
 # ]
+#
+# [tool.uv.sources]
+# torch = { index = "pytorch-cu128" }
+#
+# [[tool.uv.index]]
+# name = "pytorch-cu128"
+# url = "https://download.pytorch.org/whl/cu128"
+# explicit = true
 # ///
 """Orb env — hosts Orbital Materials' Orb universal potentials."""
 

--- a/sample_model_configurations/nvidia_configs/orb_v3.py
+++ b/sample_model_configurations/nvidia_configs/orb_v3.py
@@ -5,6 +5,14 @@
 #     "ase>=3.25",
 #     "torch>=2.8",
 # ]
+#
+# [tool.uv.sources]
+# torch = { index = "pytorch-cu128" }
+#
+# [[tool.uv.index]]
+# name = "pytorch-cu128"
+# url = "https://download.pytorch.org/whl/cu128"
+# explicit = true
 # ///
 """Orb v3 env — Orbital Materials' Orb v3 universal potentials.
 

--- a/sample_model_configurations/nvidia_configs/sevennet.py
+++ b/sample_model_configurations/nvidia_configs/sevennet.py
@@ -1,0 +1,54 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "sevenn>=0.10.0",
+#     "ase>=3.22",
+#     "torch>=2.0",
+# ]
+#
+# [tool.uv.sources]
+# torch = { index = "pytorch-cu128" }
+#
+# [[tool.uv.index]]
+# name = "pytorch-cu128"
+# url = "https://download.pytorch.org/whl/cu128"
+# explicit = true
+# ///
+"""SevenNet env — hosts pretrained SevenNet universal potentials.
+
+SevenNet (SCalable EquiVariance-Enabled Neural Network) ships several
+pretrained models, loaded by keyword through ``SevenNetCalculator``.
+
+Multi-fidelity models (``7net-omni``, ``7net-mf-ompa``) require a ``modal``
+argument selecting the training fidelity (e.g. ``"mpa"`` or ``"omat24"``).
+Pass it at runtime via ``setup_kwargs={"modal": ...}`` on RootstockCalculator
+(or ``--kwarg modal=...`` for ``rootstock add``); single-fidelity models
+ignore it.
+"""
+
+CHECKPOINTS = {
+    "sevennet-0": "7net-0",
+    "sevennet-l3i5": "7net-l3i5",
+    "sevennet-omat": "7net-omat",
+    "sevennet-mf-ompa": "7net-mf-ompa",
+    "sevennet-omni": "7net-omni",
+}
+
+
+def setup(checkpoint: str, device: str = "cuda", modal: str | None = None):
+    """
+    Load a SevenNet calculator.
+
+    Args:
+        checkpoint: Canonical checkpoint id, must be a key of CHECKPOINTS.
+        device: PyTorch device string (e.g., "cuda", "cuda:0", "cpu").
+        modal: Fidelity selector for multi-fidelity models (e.g. "mpa",
+            "omat24"). Required for 7net-omni / 7net-mf-ompa; ignored otherwise.
+
+    Returns:
+        ASE-compatible calculator.
+    """
+    from sevenn.calculator import SevenNetCalculator
+
+    kwargs = {"modal": modal} if modal is not None else {}
+    return SevenNetCalculator(model=CHECKPOINTS[checkpoint], device=device, **kwargs)

--- a/sample_model_configurations/nvidia_configs/tensornet.py
+++ b/sample_model_configurations/nvidia_configs/tensornet.py
@@ -1,7 +1,7 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#     "torch>=2.4.0",
+#     "torch>=2.4.0,<2.5",
 #     "ase>=3.22",
 #     "huggingface_hub",
 #     "matgl",

--- a/sample_model_configurations/nvidia_configs/torchmdnet.py
+++ b/sample_model_configurations/nvidia_configs/torchmdnet.py
@@ -1,8 +1,9 @@
 # /// script
 # requires-python = ">=3.10"
 # dependencies = [
+#     "torchmd-net",
 #     "ase>=3.22",
-#     "torch>=2.0",
+#     "torch>=2.4.0,<2.5",
 #     "torch-geometric",
 #     "torch-scatter",
 #     "torch-sparse",

--- a/scripts/nightly-endpoint-config.yaml.j2
+++ b/scripts/nightly-endpoint-config.yaml.j2
@@ -1,0 +1,37 @@
+# nightly smoke-test workflow. Renders to ~/.globus_compute/<endpoint>/config.yaml
+# on a cluster's login/workflow node. Companion to scripts/nightly_smoke_test.py.
+#
+# Defaults are tuned for the smoke-test workload: one worker per node, one GPU
+# per worker, on-demand blocks (init_blocks=0) so we don't burn allocation
+# between nightly runs. Override per-cluster as needed — e.g. NCSA Delta:
+#
+#   account: bchg-delta-gpu
+#   partition: gpuA100x4
+#   ifname: <verify on a gpuA100x4 node via `ip -br addr`>
+
+endpoint_setup: {{ endpoint_setup | default() }}
+
+engine:
+    type: GlobusComputeEngine
+    max_workers_per_node: {{ max_workers_per_node | default(1) }}
+
+    address:
+        type: address_by_hostname
+
+    provider:
+        type: SlurmProvider
+        account: {{ account | default() }}
+        constraint: {{ constraint | default() }}
+        cores_per_node: {{ cores_per_node | default(8) }}
+        exclusive: {{ exclusive | default(False) }}
+        launcher:
+           type: SrunLauncher
+        mem_per_node: {{ mem_per_node | default(48) }}
+        partition: {{ partition | default() }}
+        qos: {{ qos | default() }}
+        scheduler_options: "{{ scheduler_options | default('#SBATCH --gpus-per-node=1') }}"
+        walltime: "{{ walltime | default('00:30:00') }}"
+
+        init_blocks: {{ init_blocks | default(0) }}
+        min_blocks: {{ min_blocks | default(0) }}
+        max_blocks: {{ max_blocks | default(1) }}

--- a/scripts/nightly-endpoint-config.yaml.j2
+++ b/scripts/nightly-endpoint-config.yaml.j2
@@ -5,9 +5,17 @@
 # per worker, on-demand blocks (init_blocks=0) so we don't burn allocation
 # between nightly runs. Override per-cluster as needed — e.g. NCSA Delta:
 #
-#   account: bchg-delta-gpu
+#   account: bhhl-delta-gpu
 #   partition: gpuA100x4
-#   ifname: <verify on a gpuA100x4 node via `ip -br addr`>
+#   ifname: eth1
+#
+# `ifname` is the network interface ON THE LOGIN NODE the endpoint runs on; the
+# interchange advertises that interface's address so compute-node workers can
+# connect back to register. It MUST be verified per-cluster: run `ip -br addr`
+# on the login node and pick the interface with a routable (internal,
+# non-link-local) IPv4. Do NOT use `address_by_hostname` — on some clusters
+# (Delta) the login hostname resolves only to non-routable link-local IPv6
+# (fe80::), so workers silently fail to register and jobs are marked MISSING.
 
 endpoint_setup: {{ endpoint_setup | default() }}
 
@@ -16,7 +24,8 @@ engine:
     max_workers_per_node: {{ max_workers_per_node | default(1) }}
 
     address:
-        type: address_by_hostname
+        type: address_by_interface
+        ifname: {{ ifname | default('eth1') }}
 
     provider:
         type: SlurmProvider

--- a/scripts/nightly-endpoint-config.yaml.j2
+++ b/scripts/nightly-endpoint-config.yaml.j2
@@ -1,5 +1,4 @@
-# nightly smoke-test workflow. Renders to ~/.globus_compute/<endpoint>/config.yaml
-# on a cluster's login/workflow node. Companion to scripts/nightly_smoke_test.py.
+# nightly smoke-test workflow. Companion to scripts/nightly_smoke_test.py.
 #
 # Defaults are tuned for the smoke-test workload: one worker per node, one GPU
 # per worker, on-demand blocks (init_blocks=0) so we don't burn allocation

--- a/scripts/nightly_smoke_test.py
+++ b/scripts/nightly_smoke_test.py
@@ -3,11 +3,24 @@
 # dependencies = ['globus-compute-sdk<4.7', 'rootstock']
 #
 # [tool.uv]
-# exclude-newer = "2026-05-14T20:19:30Z"
 # python-preference = "managed"
 #
 # [tool.hog.delta]
-# endpoint = "67a5485a-4084-41f0-9863-2d5de388276e"
+# endpoint = "c2381fa2-ff0f-460e-b6ac-8286086f122e"
+# account = "bhhl-delta-gpu"                              # Type: string
+# scheduler_options = "#SBATCH --gpus-per-node=1"         # Type: string
+# # qos =                                                 # Type: string
+# # walltime =                                            # Type: string
+# # exclusive =                                           # Type: boolean
+# # partition =                                           # Type: string
+# # constraint =                                          # Type: string
+# # max_blocks =                                          # Type: integer
+# # min_blocks =                                          # Type: integer
+# # init_blocks =                                         # Type: integer
+# # mem_per_node =                                        # Type: integer
+# # cores_per_node =                                      # Type: integer
+# # endpoint_setup =                                      # Type: string
+# # max_workers_per_node =                                # Type: integer
 # ///
 
 import sys

--- a/scripts/nightly_smoke_test.py
+++ b/scripts/nightly_smoke_test.py
@@ -6,7 +6,7 @@
 # python-preference = "managed"
 #
 # [tool.hog.delta]
-# endpoint = "c2381fa2-ff0f-460e-b6ac-8286086f122e"
+# endpoint = "27687af7-a20e-477a-8d4e-b5a7a097f864"
 # account = "bhhl-delta-gpu"                              # Type: string
 # scheduler_options = "#SBATCH --gpus-per-node=1"         # Type: string
 # # qos =                                                 # Type: string
@@ -28,7 +28,7 @@ import sys
 import groundhog_hpc as hog
 
 
-@hog.function()
+@hog.function(endpoint="delta")
 def smoke_test(root: str | None = None) -> dict:
     import subprocess
 
@@ -40,9 +40,38 @@ def smoke_test(root: str | None = None) -> dict:
     return {"returncode": r.returncode, "stdout": r.stdout, "stderr": r.stderr}
 
 
+@hog.function(endpoint="delta")
+def hello_endpoint():
+    import getpass
+    import platform
+    import socket
+    import time
+
+    return {
+        "hostname": socket.gethostname(),
+        "user": getpass.getuser(),
+        "python": platform.python_version(),
+        "platform": platform.platform(),
+        "epoch": time.time(),
+    }
+
+
 @hog.harness()
-def main(target: str = "delta", root: str | None = None) -> int:
-    result = smoke_test.remote(root, endpoint=target)
+def hello(endpoint: str = "delta"):
+    from pprint import pprint
+
+    result = hello_endpoint.remote(endpoint=endpoint)
+    pprint(result)
+    return
+
+
+@hog.harness()
+def main(target: str | None = None, root: str | None = None) -> int:
+    if target:
+        result = smoke_test.remote(root, endpoint=target)
+    else:
+        result = smoke_test.remote(root)
+        
 
     print(result["stdout"])
     print(result["stderr"], file=sys.stderr)

--- a/scripts/nightly_smoke_test.py
+++ b/scripts/nightly_smoke_test.py
@@ -1,0 +1,41 @@
+# /// script
+# requires-python = ">=3.13,<3.14"
+# dependencies = ['globus-compute-sdk<4.7', 'rootstock']
+#
+# [tool.uv]
+# exclude-newer = "2026-05-14T20:19:30Z"
+# python-preference = "managed"
+#
+# [tool.hog.delta]
+# endpoint = "67a5485a-4084-41f0-9863-2d5de388276e"
+# ///
+
+import sys
+
+import groundhog_hpc as hog
+
+
+@hog.function()
+def smoke_test(root: str | None = None) -> dict:
+    import subprocess
+
+    cmd = ["rootstock", "smoke-test", "--device", "cuda", "--json"]
+    if root is not None:
+        cmd += ["--root", root]
+
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=3000)
+    return {"returncode": r.returncode, "stdout": r.stdout, "stderr": r.stderr}
+
+
+@hog.harness()
+def main(target: str = "delta", root: str | None = None) -> int:
+    result = smoke_test.remote(root, endpoint=target)
+
+    print(result["stdout"])
+    print(result["stderr"], file=sys.stderr)
+
+    # 0 = all passed; 1 = some failed but manifest was updated. Both mean the
+    # deliverable (fresh manifest) succeeded. Anything else is a transport
+    # failure and should turn CI red.
+    rc = result["returncode"]
+    return 0 if rc in (0, 1) else 2


### PR DESCRIPTION
closes #38 (for delta -- remaining clusters are up next) and includes documentation on how to get a globus compute endpoint up on new clusters for the CI to target. 

There is a designated `rootstock-nightly-runner` globus app; the dispatching github action and the endpoint process are both run under the assumed identity of the app (not your globus user). The smoke test will run on the administrator's allocation, but the endpoint will ONLY accept jobs from the `runner` app, not your user. You can see the values to set for `GLOBUS_COMPUTE_CLIENT_{ID, SECRET}` in AWS secrets manager or by logging in to the globus web app developer pane and minting a fresh secret for the project (I've added both will and hayden as admins). 

I've been able to hit the delta endpoint with the script by posing as the `runner` app, but I won't be able to test the full end-to-end flow until this is merged and I can manually click dispatch. 

this also adds 'delta' to the rootstock registry with a root of `/work/hdd/data/rootstock`, and makes some edits to the nvidia environments in response to some bugs I ran into trying to naively `rootstock install` them on delta.