### PR TITLE
Add `rootstock add --list` to show addable checkpoint ids

### DIFF
--- a/rootstock/__init__.py
+++ b/rootstock/__init__.py
@@ -22,6 +22,7 @@ from .environment import (
     EnvironmentManager,
     get_model_cache_env,
     list_built_environments,
+    list_declared_checkpoints,
     list_environments,
 )
 from .manifest import Manifest, load_manifest, save_manifest
@@ -36,6 +37,7 @@ __all__ = [
     "EnvironmentManager",
     "list_environments",
     "list_built_environments",
+    "list_declared_checkpoints",
     "get_model_cache_env",
     "parse_pep723_metadata",
     "validate_environment_file",

--- a/rootstock/cli.py
+++ b/rootstock/cli.py
@@ -24,6 +24,8 @@ Commands:
     rootstock add <checkpoint-id> [--root <path>] [--device <dev>] [--kwarg KEY=VAL ...]
         Resolve the env that hosts <checkpoint-id> from the installed envs,
         then download and verify the weights.
+    rootstock add --list [--root <path>]
+        List every canonical checkpoint id that add accepts, grouped by env.
 
     rootstock status [--root <path>]
     rootstock list [--root <path>]
@@ -160,12 +162,19 @@ def main():
             "Idempotent download-or-verify. Resolves the hosting env from the "
             "installed envs by matching the canonical checkpoint id against each "
             "env's CHECKPOINTS dict. Skips download if already fetched. "
-            "Use --no-verify on login nodes without GPUs."
+            "Use --no-verify on login nodes without GPUs. "
+            "Pass --list to see every checkpoint id that can be added."
         ),
     )
     add_parser.add_argument(
         "checkpoint",
+        nargs="?",
         help="Canonical checkpoint id (e.g., 'mace-mp-0-medium', 'uma-s-1p1')",
+    )
+    add_parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List canonical checkpoint ids that add accepts (grouped by env) and exit",
     )
     add_parser.add_argument(
         "--kwarg",

--- a/rootstock/commands/add.py
+++ b/rootstock/commands/add.py
@@ -13,6 +13,7 @@ from ..environment import (
     CheckpointNotFoundError,
     find_env_for_checkpoint,
     get_model_cache_env,
+    list_declared_checkpoints,
 )
 from ..manifest import (
     CheckpointInfo,
@@ -156,8 +157,41 @@ def _ensure_manifest_entry(
     return manifest, env, env.checkpoints[checkpoint]
 
 
+def _print_checkpoint_catalog(root: Path) -> int:
+    """Print every canonical checkpoint id ``rootstock add`` accepts, grouped
+    by hosting env. Returns a process exit code."""
+    declared = list_declared_checkpoints(root)
+    if not declared:
+        print(
+            f"No envs are installed at {root}. "
+            f"Run `rootstock install <env-file> --root {root}` first."
+        )
+        return 0
+
+    print(f"Checkpoints available to add in {root}:")
+    for env_name, ckpts in declared.items():
+        print(f"  {env_name}:")
+        if not ckpts:
+            print("    (none)")
+            continue
+        for ckpt_id in ckpts:
+            print(f"    {ckpt_id}")
+    return 0
+
+
 def cmd_add(args) -> int:
     root = get_root_or_exit(args)
+
+    if getattr(args, "list", False):
+        return _print_checkpoint_catalog(root)
+
+    if not args.checkpoint:
+        print(
+            "Error: a checkpoint id is required (or pass --list to see available ids)",
+            file=sys.stderr,
+        )
+        return 2
+
     cache_root = resolve_cache_root(root)
     checkpoint = args.checkpoint
     device = args.device

--- a/rootstock/environment.py
+++ b/rootstock/environment.py
@@ -292,32 +292,48 @@ def parse_checkpoints_dict(env_source_path: Path) -> dict[str, str]:
     )
 
 
+def list_declared_checkpoints(root: Path | str) -> dict[str, dict[str, str]]:
+    """
+    Walk ``{root}/envs/*/env_source.py`` and return ``{env_name: CHECKPOINTS}``
+    for every installed env that declares a valid ``CHECKPOINTS`` dict.
+
+    This is the single source of truth for "which canonical checkpoint ids can
+    ``rootstock add`` accept". Envs whose source file is missing or whose
+    ``CHECKPOINTS`` dict is malformed are silently skipped. Results are ordered
+    by env name.
+    """
+    root = Path(root)
+    envs_dir = root / "envs"
+    declared: dict[str, dict[str, str]] = {}  # env_name -> {id: upstream}
+    if not envs_dir.exists():
+        return declared
+    for env_dir in sorted(envs_dir.iterdir()):
+        source = env_dir / "env_source.py"
+        if not source.exists():
+            continue
+        try:
+            declared[env_dir.name] = parse_checkpoints_dict(source)
+        except ValueError:
+            continue
+    return declared
+
+
 def find_env_for_checkpoint(
     root: Path | str, checkpoint_id: str
 ) -> tuple[str, dict[str, str]]:
     """
-    Walk ``{root}/envs/*/env_source.py`` and return ``(env_name, CHECKPOINTS)``
-    for the env that declares ``checkpoint_id``.
+    Return ``(env_name, CHECKPOINTS)`` for the installed env that declares
+    ``checkpoint_id``.
 
     Raises ``CheckpointNotFoundError`` with a message listing every canonical
     id declared by any installed env, plus a hint to ``rootstock install`` if
     nothing matches.
     """
     root = Path(root)
-    envs_dir = root / "envs"
-    declared: dict[str, list[str]] = {}  # env_name -> [ids]
-    if envs_dir.exists():
-        for env_dir in sorted(envs_dir.iterdir()):
-            source = env_dir / "env_source.py"
-            if not source.exists():
-                continue
-            try:
-                ckpts = parse_checkpoints_dict(source)
-            except ValueError:
-                continue
-            declared[env_dir.name] = list(ckpts)
-            if checkpoint_id in ckpts:
-                return env_dir.name, ckpts
+    declared = list_declared_checkpoints(root)
+    for env_name, ckpts in declared.items():
+        if checkpoint_id in ckpts:
+            return env_name, ckpts
 
     if declared:
         listing = "\n".join(

--- a/tests/cli/test_add.py
+++ b/tests/cli/test_add.py
@@ -89,6 +89,7 @@ def _make_args(root: Path, **overrides):
 
     args = _Args()
     args.checkpoint = overrides.get("checkpoint", "mace-mp-0-medium")
+    args.list = overrides.get("list", False)
     args.kwarg = overrides.get("kwarg")
     args.device = overrides.get("device", "cuda")
     args.no_verify = overrides.get("no_verify", False)
@@ -237,3 +238,34 @@ def test_add_errors_when_no_envs_installed(tmp_path):
 
     rc = cmd_add(_make_args(tmp_path, checkpoint="mace-mp-0-medium", no_verify=True))
     assert rc == 1
+
+
+# ---------- cmd_add --list (checkpoint catalog) ---------------------------
+
+
+def test_add_list_shows_declared_checkpoints(fake_root, capsys):
+    """--list prints every declared id grouped by env, without touching the
+    download/verify paths."""
+    rc = cmd_add(_make_args(fake_root, list=True, checkpoint=None))
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    assert "mace:" in out
+    for ckpt_id in ("mace-mp-0-small", "mace-mp-0-medium", "mace-mp-0-large"):
+        assert ckpt_id in out
+
+
+def test_add_list_when_no_envs_installed(tmp_path, capsys):
+    """--list on an empty root points the user at install rather than erroring."""
+    rc = cmd_add(_make_args(tmp_path, list=True, checkpoint=None))
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    assert "No envs are installed" in out
+    assert "rootstock install" in out
+
+
+def test_add_without_checkpoint_or_list_returns_2(fake_root):
+    """Omitting both the checkpoint and --list is a usage error."""
+    rc = cmd_add(_make_args(fake_root, checkpoint=None))
+    assert rc == 2


### PR DESCRIPTION
closes #58 

## What

Makes it easy to see which canonical checkpoint ids `rootstock add` will accept.

- **Single source of truth:** extracts the `envs/*/env_source.py` → `CHECKPOINTS` walk into a new `list_declared_checkpoints(root)` in `environment.py`. Previously this enumeration only existed inline inside `find_env_for_checkpoint`'s error path; `find_env_for_checkpoint` now consumes the shared helper, and it's exported from the package.
- **New `rootstock add --list`:** prints every canonical checkpoint id that `add` accepts, grouped by hosting env. On an empty root it points the user at `rootstock install`.
- The `checkpoint` positional is now optional; omitting both it and `--list` is a usage error (exit 2).

## Example

```
$ rootstock add --list
Checkpoints available to add in /path/to/root:
  mace:
    mace-mp-0-small
    mace-mp-0-medium
  uma:
    uma-s-1p1
```

## Testing

- Added 3 tests (`--list` catalog, `--list` on empty root, no-arg usage error).
- Full `tests/` suite passes (132 passed); lint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)