### PR TITLE
Add more permissions safeguards, plus an end-to-end test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,9 @@ Most clusters use the same path for both.
 |---------|--------------|-----------------------|
 | `della` | `/scratch/gpfs/ROSENGROUP/common/rootstock` | (same as install root) |
 | `sophia` | `/eagle/Garden-Ai/rootstock` | (same as install root) |
+| `polaris` | `/eagle/Garden-Ai/rootstock` (shared with sophia) | (same as install root) |
 | `perlmutter` | `/global/cfs/cdirs/m4845/rootstock` | `/pscratch/sd/w/wengler/rootstock-cache` |
+| `delta` | `/work/hdd/data/rootstock` | (same as install root) |
 
 ## API
 

--- a/docs/cluster-setup.md
+++ b/docs/cluster-setup.md
@@ -76,7 +76,7 @@ rootstock setup-perms --cluster perlmutter --group m4845 --retrofit --apply
 
 `rootstock install` re-checks these permissions up front on every run and prints a warning if the root doesn't look world-readable (wrong mode bits, missing setgid, missing default ACL, or a mask clamp from too-restrictive a umask). The check is read-only and never blocks the build; pass `--no-perm-check` to silence it.
 
-Then **the maintainer's shell** needs `umask 002` so newly written files honor the inherited group-write bits. (This is the one piece `setup-perms` can't do for you — it's a per-shell setting.) Add to `~/.bashrc` (or whatever rc the cluster sources for non-interactive shells):
+`rootstock install` and `rootstock add` force `umask 002` for their own duration (uv subprocesses inherit it), so files they create are born world-readable and group-writable regardless of your personal umask. For anything you write into the shared root *by hand* (e.g. dropping an env file into `environments/`), your shell still needs `umask 002`. Add to `~/.bashrc` (or whatever rc the cluster sources for non-interactive shells):
 
 ```bash
 umask 002
@@ -91,6 +91,28 @@ export UV_LINK_MODE=copy
 `uv` defaults to hardlinking from its cache into target venvs, which fails across filesystem boundaries and falls back to copy with a noisy warning. Setting `copy` mode silences the warning and is the correct mode for cross-filesystem builds anyway.
 
 After `rootstock init` runs, verify ACLs landed correctly with `getfacl` on a freshly created file. Group should show `rwx` (effective `rw-` or `rwx`) and `mask::rw-` or stronger. If you see `mask::---` or `#effective:---`, the maintainer's umask was too restrictive when the file was created — rerun with `umask 002` and rewrite the file.
+
+### Verifying world-readability before launch
+
+Two scripts in `scripts/` check the world-readable contract end-to-end. Neither needs rootstock installed in the caller's own Python.
+
+**Functional test (the ground truth).** Have a colleague — someone who does *not* own the install and is *not* in the project group — run, on a login node:
+
+```bash
+unshare --user --map-user=$(id -u) \
+    ./scripts/test_as_outsider.sh /global/cfs/cdirs/m4845/rootstock \
+    --cache-root /pscratch/sd/w/wengler/rootstock-cache
+```
+
+`unshare` strips supplementary groups (defeating group bits); the different uid defeats owner bits; what remains is exactly what an arbitrary cluster user experiences. The script loads every fetched checkpoint of every built env through the real `RootstockCalculator` path, runs one forward pass, and prints PASS/FAIL per checkpoint with permission errors called out explicitly. Do not run it as the maintainer and trust a pass — owner bits mask everything (the script warns when this is the case).
+
+**Static audit (diagnosis).** When the functional test fails — or to check the full tree without loading models — run:
+
+```bash
+./scripts/check_world_readable.sh /global/cfs/cdirs/m4845/rootstock
+```
+
+It walks the ancestor directories (every one needs `o+x` — if the project parent on CFS lacks it, that's a facilities ticket, not a chmod), checks other-bits on every file and directory, resolves symlink targets, and scans for per-user ACL entries and mask clamps that `ls -l` won't show. It prints actionable per-path fixes and exits nonzero on any violation.
 
 ### Initial setup
 

--- a/rootstock/clusters.py
+++ b/rootstock/clusters.py
@@ -36,6 +36,11 @@ CLUSTER_REGISTRY: dict[str, Cluster] = {
     "sophia": Cluster(
         root=Path("/eagle/Garden-Ai/rootstock"),
     ),
+    # Polaris mounts the same Eagle filesystem as Sophia, so both ALCF
+    # machines share one install.
+    "polaris": Cluster(
+        root=Path("/eagle/Garden-Ai/rootstock"),
+    ),
     "perlmutter": Cluster(
         root=Path("/global/cfs/cdirs/m4845/rootstock"),
         cache_root=Path("/pscratch/sd/w/wengler/rootstock-cache"),

--- a/rootstock/commands/add.py
+++ b/rootstock/commands/add.py
@@ -180,6 +180,11 @@ def _print_checkpoint_catalog(root: Path) -> int:
 
 
 def cmd_add(args) -> int:
+    # Downloaded model weights land in the shared cache and must be readable
+    # by every user (and writable by co-maintainers), whatever the
+    # maintainer's personal umask says.
+    os.umask(0o002)
+
     root = get_root_or_exit(args)
 
     if getattr(args, "list", False):

--- a/rootstock/commands/install.py
+++ b/rootstock/commands/install.py
@@ -305,12 +305,55 @@ def _install_single_environment(
     print("4. Copying environment source...")
     shutil.copy(env_source, env_target / "env_source.py")
 
+    print("5. Pre-compiling bytecode...")
+    _precompile_environment(env_python, env_target)
+
     print(f"\nBuilt environment: {env_target}")
 
     # Update manifest (quiet=True to avoid cluttering build output)
     update_and_push_manifest(root, quiet=False, push=not no_push)
 
     return 0
+
+
+def _precompile_environment(env_python: Path, env_target: Path) -> None:
+    """Byte-compile the whole venv so shared-install users never need to.
+
+    Without this, the first import by each user tries to write ``__pycache__``
+    into the shared (read-only to them) venv, silently fails, and recompiles
+    in memory on every run — a per-import perf tax on everyone but the
+    maintainer.
+
+    Warn-only: large site-packages trees routinely contain files that don't
+    byte-compile (vendored test fixtures, py2 leftovers). Those fail at import
+    time too, so nothing real is importing them; they don't invalidate the
+    build.
+    """
+    env = os.environ.copy()
+    # .pyc files must land in-tree, next to their sources — not in the
+    # maintainer's per-user redirect, where other users can't see them.
+    env.pop("PYTHONPYCACHEPREFIX", None)
+
+    result = subprocess.run(
+        [str(env_python), "-m", "compileall", "-q", "-j", "0", str(env_target)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    if result.returncode != 0:
+        # compileall reports errors on stdout; -q suppresses everything else.
+        output = [
+            line
+            for line in (result.stdout + result.stderr).splitlines()
+            if line.strip()
+        ]
+        shown = "\n".join(f"    {line}" for line in output[:10])
+        print(
+            "  Warning: some files did not byte-compile (normal for vendored/"
+            "py2 files; they would fail at import time anyway):\n" + shown
+        )
+        if len(output) > 10:
+            print(f"    ... and {len(output) - 10} more lines")
 
 
 def _warn_on_permissions(root: Path) -> None:
@@ -354,6 +397,13 @@ def cmd_install(args) -> int:
         1: One or more installs failed
     """
     from ..environment import check_uv_available
+
+    # Shared installs must be world-readable and group-writable (the recipe in
+    # docs/cluster-setup.md). Everything this command creates is derived from
+    # public packages, so override any restrictive personal umask for the
+    # duration of the build — uv subprocesses inherit it — rather than
+    # retrofitting permissions afterwards.
+    os.umask(0o002)
 
     if getattr(args, "models", None):
         print(

--- a/rootstock/environment.py
+++ b/rootstock/environment.py
@@ -21,12 +21,36 @@ class CheckpointNotFoundError(LookupError):
     """Raised when a canonical checkpoint id is not declared by any installed env."""
 
 
+def get_user_cache_dir() -> Path:
+    """
+    Per-user directory for runtime write-back caches.
+
+    Shared installs are world-*readable* but only maintainer-writable, so
+    anything a worker writes at runtime (compiled Triton/Inductor kernels,
+    torch C++ extension builds, NVIDIA compute cache, bytecode) must land
+    somewhere the calling user owns — not in the shared cache root.
+
+    Resolved from the real caller's home (before any HOME redirection is
+    applied); override with ROOTSTOCK_USER_CACHE_DIR.
+    """
+    override = os.environ.get("ROOTSTOCK_USER_CACHE_DIR")
+    if override:
+        return Path(override)
+    return Path.home() / ".cache" / "rootstock"
+
+
 def get_model_cache_env(root: Path, cache_root: Path | None = None) -> dict[str, str]:
     """
-    Get environment variables to redirect model downloads to a shared cache.
+    Get environment variables to redirect model downloads to a shared cache
+    and runtime write-back to a per-user cache.
 
     HOME is redirected for libraries that hardcode `~/` for caching (e.g.,
     FAIRChem). XDG_CACHE_HOME and HF_HOME catch the well-behaved libraries.
+    Those point at the *shared* cache, which non-maintainers can only read —
+    so every cache a library writes at runtime (Triton/Inductor kernels,
+    torch extension builds, NVIDIA compute cache, bytecode) is redirected to
+    a per-user directory instead. Per-user vars respect values already set
+    in the caller's environment (e.g. TRITON_CACHE_DIR on node-local SSD).
 
     On most clusters the install root and the cache root coincide. On clusters
     where they live on different filesystems (e.g., Perlmutter — code on CFS,
@@ -43,12 +67,27 @@ def get_model_cache_env(root: Path, cache_root: Path | None = None) -> dict[str,
     base = cache_root if cache_root is not None else root
     cache_dir = base / "cache"
     home_dir = base / "home"
-    return {
+
+    user_cache = get_user_cache_dir()
+    per_user_defaults = {
+        "TRITON_CACHE_DIR": user_cache / "triton",
+        "TORCHINDUCTOR_CACHE_DIR": user_cache / "torchinductor",
+        "TORCH_EXTENSIONS_DIR": user_cache / "torch_extensions",
+        "CUDA_CACHE_PATH": user_cache / "nv" / "ComputeCache",
+        "PYTHONPYCACHEPREFIX": user_cache / "pycache",
+        "XDG_CONFIG_HOME": user_cache / "config",
+        "MPLCONFIGDIR": user_cache / "matplotlib",
+    }
+
+    env = {
         "HOME": str(home_dir),
         "XDG_CACHE_HOME": str(cache_dir),
         "HF_HOME": str(cache_dir / "huggingface"),
         "HF_HUB_CACHE": str(cache_dir / "huggingface" / "hub"),
     }
+    for var, default in per_user_defaults.items():
+        env[var] = os.environ.get(var) or str(default)
+    return env
 
 
 # Simplified wrapper template for pre-built environments.

--- a/scripts/check_world_readable.sh
+++ b/scripts/check_world_readable.sh
@@ -1,0 +1,365 @@
+#!/usr/bin/env bash
+# check_world_readable.sh — static audit that a directory tree is usable by
+# ANY user on the machine (the "world-readable contract"):
+#
+#   * every ancestor of the tree grants o+x (world can traverse down to it)
+#   * every directory in the tree grants o+rx
+#   * every file grants o+r; owner-executable files also grant o+x
+#   * symlink targets resolve and satisfy the same rules (a world-readable
+#     symlink to a 700 target still fails)
+#   * no per-user ACL entries or mask clamps silently override the mode bits
+#
+# This complements (does not replace) a functional test as a different uid:
+# static checks catch owner-bit masking that "try it yourself" never can.
+# See scripts/test_as_outsider.sh for the functional half.
+#
+# Usage:
+#   check_world_readable.sh TREE [--no-acl] [--no-prefix]
+#                                [--expect-group NAME] [--max-report N]
+#   check_world_readable.sh --self-test
+#
+#   --no-acl          skip the getfacl scan (it is the slow part on big trees)
+#   --no-prefix       skip the ancestor-directory walk
+#   --expect-group G  named-group ACL entries for G are expected (setup-perms
+#                     adds them) and not reported
+#   --max-report N    cap printed paths per category (default 50; 0 = no cap).
+#                     Totals are always printed — nothing is silently dropped.
+#   --self-test       build a deliberately broken fixture tree in $TMPDIR,
+#                     run this script against it, and verify every check fires.
+#
+# Exit codes: 0 = tree satisfies the contract, 1 = violations found,
+#             2 = usage/environment error.
+#
+# Portability: works with GNU (Linux login nodes) and BSD (macOS, for local
+# fixture testing) stat/find. NERSC caveat: getfacl does not show GPFS NFSv4
+# ACLs — if the filesystem uses them (CFS can), spot-check a few files with
+# `mmgetacl` by hand; there is no cheap recursive equivalent.
+
+set -u
+
+MAX_REPORT=50
+DO_ACL=1
+DO_PREFIX=1
+EXPECT_GROUP=""
+TREE=""
+SELF_TEST=0
+
+usage() { sed -n '2,36p' "$0" | sed 's/^# \{0,1\}//'; }
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --no-acl) DO_ACL=0 ;;
+        --no-prefix) DO_PREFIX=0 ;;
+        --expect-group) EXPECT_GROUP="${2:?--expect-group needs a value}"; shift ;;
+        --max-report) MAX_REPORT="${2:?--max-report needs a value}"; shift ;;
+        --self-test) SELF_TEST=1 ;;
+        -h|--help) usage; exit 0 ;;
+        -*) echo "Unknown option: $1" >&2; exit 2 ;;
+        *) TREE="$1" ;;
+    esac
+    shift
+done
+
+# ---------------------------------------------------------------------------
+# Portable stat helpers
+# ---------------------------------------------------------------------------
+
+if stat -c '%a' / >/dev/null 2>&1; then
+    mode_of() { stat -c '%a' -- "$1" 2>/dev/null; }
+    lsmode_of() { stat -c '%A %U %G' -- "$1" 2>/dev/null; }
+else
+    mode_of() { stat -f '%Lp' -- "$1" 2>/dev/null; }
+    lsmode_of() { stat -f '%Sp %Su %Sg' -- "$1" 2>/dev/null; }
+fi
+
+# Other-permission digit (last octal digit) of a path's mode.
+other_digit() {
+    local m
+    m=$(mode_of "$1") || return 1
+    printf '%s' "${m: -1}"
+}
+
+has_o_r() { local d; d=$(other_digit "$1") || return 1; [ $((d & 4)) -ne 0 ]; }
+has_o_x() { local d; d=$(other_digit "$1") || return 1; [ $((d & 1)) -ne 0 ]; }
+
+resolve_path() {
+    readlink -f -- "$1" 2>/dev/null \
+        || python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$1"
+}
+
+# ---------------------------------------------------------------------------
+# Violation accumulation and reporting
+# ---------------------------------------------------------------------------
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/check_world_readable.XXXXXX") || exit 2
+trap 'rm -rf "$WORK"' EXIT
+
+add_violation() { # add_violation CATEGORY "detail line"
+    printf '%s\n' "$2" >> "$WORK/$1"
+}
+
+report_category() { # report_category CATEGORY "header" "fix hint"
+    local f="$WORK/$1" n
+    [ -s "$f" ] || return 0
+    n=$(wc -l < "$f" | tr -d ' ')
+    echo
+    echo "VIOLATION [$1] $2 — $n path(s):"
+    if [ "$MAX_REPORT" -gt 0 ] && [ "$n" -gt "$MAX_REPORT" ]; then
+        head -n "$MAX_REPORT" "$f" | sed 's/^/  /'
+        echo "  ... and $((n - MAX_REPORT)) more (rerun with --max-report 0 to list all)"
+    else
+        sed 's/^/  /' "$f"
+    fi
+    echo "  fix: $3"
+    FAILED=1
+}
+
+# ---------------------------------------------------------------------------
+# Checks
+# ---------------------------------------------------------------------------
+
+check_prefix() {
+    # Every ancestor directory needs o+x or nobody outside the owner/group can
+    # even reach the tree, no matter how open the tree itself is (namei -l
+    # shows the same walk).
+    local p
+    p=$(dirname "$TREE")
+    while :; do
+        if ! has_o_x "$p"; then
+            add_violation prefix "$(lsmode_of "$p") $p"
+        fi
+        [ "$p" = "/" ] && break
+        p=$(dirname "$p")
+    done
+}
+
+check_tree_modes() {
+    # Octal -perm forms work in both GNU and BSD find:
+    #   -perm -0004 = other-read set, -perm -0001 = other-execute set.
+    find "$TREE" -type d \( ! -perm -0004 -o ! -perm -0001 \) 2>>"$WORK/errors" \
+        | while IFS= read -r p; do add_violation dirs "$(lsmode_of "$p") $p"; done
+
+    find "$TREE" -type f ! -perm -0004 2>>"$WORK/errors" \
+        | while IFS= read -r p; do add_violation files "$(lsmode_of "$p") $p"; done
+
+    # Owner-executable but not world-executable: bin/python et al. would be
+    # readable yet not runnable by other users.
+    find "$TREE" -type f -perm -0100 ! -perm -0001 2>>"$WORK/errors" \
+        | while IFS= read -r p; do add_violation execs "$(lsmode_of "$p") $p"; done
+}
+
+check_symlinks() {
+    local link target
+    find "$TREE" -type l 2>>"$WORK/errors" | while IFS= read -r link; do
+        target=$(resolve_path "$link")
+        if [ ! -e "$target" ]; then
+            add_violation symlinks "$link -> $target (broken)"
+            continue
+        fi
+        if [ -d "$target" ]; then
+            if ! has_o_r "$target" || ! has_o_x "$target"; then
+                add_violation symlinks "$link -> $(lsmode_of "$target") $target (target dir not o+rx)"
+            fi
+        else
+            if ! has_o_r "$target"; then
+                add_violation symlinks "$link -> $(lsmode_of "$target") $target (target not o+r)"
+            fi
+        fi
+        # A target outside the tree needs its own traversable ancestry.
+        case "$target" in
+            "$TREE"/*) : ;;
+            *)  local d seen
+                d=$(dirname "$target")
+                seen="$WORK/seen_prefixes"
+                while [ "$d" != "/" ]; do
+                    grep -qxF "$d" "$seen" 2>/dev/null && break
+                    printf '%s\n' "$d" >> "$seen"
+                    if ! has_o_x "$d"; then
+                        add_violation symlinks "$link -> $target ($(lsmode_of "$d") $d not o+x on target's path)"
+                    fi
+                    d=$(dirname "$d")
+                done ;;
+        esac
+    done
+}
+
+check_acls() {
+    if ! command -v getfacl >/dev/null 2>&1; then
+        echo "note: getfacl not available — skipping ACL scan." >&2
+        return 0
+    fi
+    echo "note: scanning ACLs (slow on large trees; --no-acl to skip)." >&2
+    echo "note: GPFS NFSv4 ACLs do not appear in getfacl output;" \
+         "spot-check with mmgetacl if the filesystem uses them." >&2
+    # -s: only files with entries beyond the base mode bits; -p: absolute paths.
+    getfacl -R -s -p "$TREE" 2>>"$WORK/errors" | awk -v expect="$EXPECT_GROUP" '
+        /^# file:/ { path = substr($0, 9); next }
+        /^user:[^:]/ {                      # named-user entry: per-uid grant/deny
+            print "acl-user\t" path ": " $0; next
+        }
+        /#effective:/ {                     # mask clamps a granted entry
+            print "acl-mask\t" path ": " $0; next
+        }
+        /^group:[^:]/ {                     # named-group entry other than expected
+            split($0, a, ":")
+            if (a[2] != expect) print "acl-group\t" path ": " $0
+            next
+        }
+    ' | while IFS=$(printf '\t') read -r category detail; do
+        add_violation "$category" "$detail"
+    done
+}
+
+run_checks() {
+    FAILED=0
+
+    if [ -z "$TREE" ]; then
+        echo "Error: no tree path given (see --help)." >&2
+        exit 2
+    fi
+    if [ ! -d "$TREE" ]; then
+        echo "Error: not a directory: $TREE" >&2
+        exit 2
+    fi
+    # Physical path (-P) so in-tree symlink targets, which resolve physically,
+    # compare correctly against the tree prefix.
+    TREE=$(cd "$TREE" && pwd -P)
+
+    echo "Checking world-readability of: $TREE"
+
+    [ "$DO_PREFIX" -eq 1 ] && check_prefix
+    check_tree_modes
+    check_symlinks
+    [ "$DO_ACL" -eq 1 ] && check_acls
+
+    report_category prefix \
+        "ancestor directory not world-traversable (o+x missing)" \
+        "chmod o+x <dir> — if you do not own it (e.g. the project parent on CFS), this is a facilities ticket, not a chmod"
+    report_category dirs \
+        "directory in tree missing o+rx" \
+        "chmod o+rx <dir>   (bulk: setfacl -R -m o::r-X $TREE && setfacl -R -dm o::r-X $TREE, or rootstock setup-perms --retrofit)"
+    report_category files \
+        "file missing o+r" \
+        "chmod o+r <file>   (bulk: as above; capital X avoids marking data files executable)"
+    report_category execs \
+        "owner-executable file missing o+x" \
+        "chmod o+x <file>"
+    report_category symlinks \
+        "symlink target unreachable for other users" \
+        "fix the target's mode/ancestry (listed per link above)"
+    report_category acl-user \
+        "per-user ACL entry (invisible in ls -l; can grant or deny a specific uid)" \
+        "setfacl -x u:<user> <path> after confirming it is not intentional"
+    report_category acl-mask \
+        "ACL mask clamps a granted entry (classic too-restrictive-umask artifact)" \
+        "setfacl -m m::rwX <path>"
+    report_category acl-group \
+        "unexpected named-group ACL entry" \
+        "review; pass --expect-group <g> if this group is intentional"
+
+    if [ -s "$WORK/errors" ]; then
+        echo
+        echo "warning: some paths could not be inspected:" >&2
+        sed 's/^/  /' "$WORK/errors" >&2
+    fi
+
+    if [ "$FAILED" -eq 1 ]; then
+        echo
+        echo "RESULT: FAIL — $TREE does not satisfy the world-readable contract."
+        return 1
+    fi
+    echo "RESULT: OK — $TREE is world-readable (mode bits, symlinks$( [ "$DO_ACL" -eq 1 ] && echo ", ACLs" ))."
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Self-test: build a broken fixture, assert every check fires
+# ---------------------------------------------------------------------------
+
+self_test() {
+    local fixture out rc failures=0
+    fixture=$(mktemp -d "${TMPDIR:-/tmp}/cwr_fixture.XXXXXX") || exit 2
+    # shellcheck disable=SC2064
+    trap "rm -rf '$fixture' '$WORK'" EXIT
+
+    expect() { # expect "label" "pattern" <<< output
+        local label="$1" pattern="$2"
+        if grep -q "$pattern" <<< "$out"; then
+            echo "  ok: detects $label"
+        else
+            echo "  MISSING: did not detect $label (pattern: $pattern)" >&2
+            failures=$((failures + 1))
+        fi
+    }
+
+    echo "== self-test: clean tree passes =="
+    mkdir -p "$fixture/good/sub"
+    echo data > "$fixture/good/sub/file"
+    echo bin > "$fixture/good/sub/tool"
+    ln -s file "$fixture/good/sub/link"
+    chmod 755 "$fixture/good" "$fixture/good/sub" "$fixture/good/sub/tool"
+    chmod 644 "$fixture/good/sub/file"
+    out=$("$0" "$fixture/good" --no-prefix --no-acl 2>&1); rc=$?
+    if [ $rc -eq 0 ]; then
+        echo "  ok: clean tree exits 0"
+    else
+        echo "  FAILED: clean tree exited $rc:" >&2
+        printf '%s\n' "$out" >&2
+        failures=$((failures + 1))
+    fi
+
+    echo "== self-test: broken tree fails with each violation reported =="
+    mkdir -p "$fixture/bad/dir_no_ox"
+    echo secret > "$fixture/bad/file_600"
+    echo bin > "$fixture/bad/exec_744"
+    echo hidden > "$fixture/bad/target_600"
+    ln -s target_600 "$fixture/bad/link_to_600"
+    ln -s does-not-exist "$fixture/bad/broken_link"
+    chmod 755 "$fixture/bad"
+    chmod 750 "$fixture/bad/dir_no_ox"
+    chmod 600 "$fixture/bad/file_600" "$fixture/bad/target_600"
+    chmod 744 "$fixture/bad/exec_744"
+    out=$("$0" "$fixture/bad" --no-prefix --no-acl 2>&1); rc=$?
+    if [ $rc -eq 1 ]; then
+        echo "  ok: broken tree exits 1"
+    else
+        echo "  FAILED: broken tree exited $rc (expected 1)" >&2
+        failures=$((failures + 1))
+    fi
+    expect "dir missing o+rx"        "dir_no_ox"
+    expect "file missing o+r"        "file_600"
+    expect "exec missing o+x"        "exec_744"
+    expect "symlink to unreadable"   "link_to_600 ->"
+    expect "broken symlink"          "broken)"
+
+    echo "== self-test: non-traversable ancestor detected =="
+    mkdir -p "$fixture/wrap/tree"
+    echo data > "$fixture/wrap/tree/file"
+    chmod 750 "$fixture/wrap"
+    chmod 755 "$fixture/wrap/tree"
+    chmod 644 "$fixture/wrap/tree/file"
+    out=$("$0" "$fixture/wrap/tree" --no-acl 2>&1); rc=$?
+    if [ $rc -eq 1 ]; then
+        echo "  ok: prefix violation exits 1"
+    else
+        echo "  FAILED: prefix case exited $rc (expected 1)" >&2
+        failures=$((failures + 1))
+    fi
+    expect "ancestor missing o+x" "\[prefix\]"
+
+    echo
+    if [ "$failures" -eq 0 ]; then
+        echo "SELF-TEST PASS"
+        return 0
+    fi
+    echo "SELF-TEST FAIL ($failures problem(s))" >&2
+    return 1
+}
+
+if [ "$SELF_TEST" -eq 1 ]; then
+    self_test
+    exit $?
+fi
+
+run_checks
+exit $?

--- a/scripts/test_as_outsider.sh
+++ b/scripts/test_as_outsider.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# test_as_outsider.sh — functional test that a rootstock install is usable by
+# a NON-MAINTAINER. For each built env it drives the real user path
+# (RootstockCalculator -> worker subprocess -> model load -> forward pass)
+# and reports PASS/FAIL per checkpoint, watching for permission errors on
+# runtime writes (Triton/Inductor kernels, torch extensions, HF locks, ...).
+#
+# For a conclusive result this must run as a uid that does NOT own the tree,
+# with no membership in the tree's group. On a login node the recommended
+# harness (run by a colleague, not the maintainer) is:
+#
+#     unshare --user --map-user=$(id -u) \
+#         ./test_as_outsider.sh /global/cfs/cdirs/m4845/rootstock \
+#         --cache-root /pscratch/sd/w/wengler/rootstock-cache
+#
+# unshare strips supplementary groups (defeats group bits); the different uid
+# defeats owner bits; what remains is the other-bits contract this verifies.
+# The script warns — but does not stop — when run in a masked configuration,
+# so the maintainer can still use it as a smoke test.
+#
+# Usage:
+#   test_as_outsider.sh ROOT [--cache-root PATH] [--device DEV]
+#                            [--env NAME ...] [--checkpoint ID ...] [--strace]
+#
+#   ROOT              rootstock install root (or use a registered cluster path)
+#   --cache-root      separate model-weight cache root (Perlmutter: PSCRATCH)
+#   --device          device for inference (default: cpu — works on login nodes)
+#   --env NAME        only test this env (repeatable; default: all built envs)
+#   --checkpoint ID   only test this checkpoint id (repeatable)
+#   --strace          wrap each probe in strace and report EACCES file ops
+#                     (needs strace on PATH; Linux only)
+#
+# Exit codes: 0 = all tested checkpoints pass, 1 = failures, 2 = usage error.
+
+set -u
+
+ROOT=""
+CACHE_ROOT=""
+DEVICE="cpu"
+STRACE=0
+ENV_FILTER=()
+CKPT_FILTER=()
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --cache-root) CACHE_ROOT="${2:?--cache-root needs a value}"; shift ;;
+        --device) DEVICE="${2:?--device needs a value}"; shift ;;
+        --env) ENV_FILTER+=("${2:?--env needs a value}"); shift ;;
+        --checkpoint) CKPT_FILTER+=("${2:?--checkpoint needs a value}"); shift ;;
+        --strace) STRACE=1 ;;
+        -h|--help) sed -n '2,33p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        -*) echo "Unknown option: $1" >&2; exit 2 ;;
+        *) ROOT="$1" ;;
+    esac
+    shift
+done
+
+if [ -z "$ROOT" ]; then
+    echo "Error: install root required (see --help)." >&2
+    exit 2
+fi
+if [ ! -d "$ROOT" ]; then
+    echo "Error: cannot access $ROOT — either it does not exist or an ancestor" >&2
+    echo "denies traversal. Run scripts/check_world_readable.sh from an account" >&2
+    echo "that can see it." >&2
+    exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Preflight: is this run actually conclusive?
+# ---------------------------------------------------------------------------
+
+MASKED=0
+
+if stat -c '%u %g' / >/dev/null 2>&1; then
+    read -r TREE_UID TREE_GID <<< "$(stat -c '%u %g' "$ROOT")"
+else
+    read -r TREE_UID TREE_GID <<< "$(stat -f '%u %g' "$ROOT")"
+fi
+
+if [ "$TREE_UID" = "$(id -u)" ]; then
+    echo "WARNING: you OWN $ROOT — owner bits satisfy every access check, so"
+    echo "         this run cannot prove world-readability. Have a different"
+    echo "         user run it (inside 'unshare --user --map-user=\$(id -u)')."
+    MASKED=1
+fi
+if id -G | tr ' ' '\n' | grep -qx "$TREE_GID"; then
+    echo "WARNING: you are in the tree's group (gid $TREE_GID) — group bits may"
+    echo "         mask failures. Run inside: unshare --user --map-user=\$(id -u)"
+    MASKED=1
+fi
+if ! touch "${HOME}/.rootstock_outsider_write_test" 2>/dev/null; then
+    echo "Error: \$HOME ($HOME) is not writable — per-user runtime caches need it." >&2
+    exit 2
+fi
+rm -f "${HOME}/.rootstock_outsider_write_test"
+
+if [ "$STRACE" -eq 1 ] && ! command -v strace >/dev/null 2>&1; then
+    echo "WARNING: --strace requested but strace not found; continuing without it."
+    STRACE=0
+fi
+
+# Cheap read canary before spending minutes loading models.
+CANARY=$(find "$ROOT/envs" -name 'env_source.py' -print 2>/dev/null | head -1)
+if [ -n "$CANARY" ] && ! cat "$CANARY" >/dev/null 2>&1; then
+    echo "FAIL (fast): cannot read $CANARY"
+    echo "The tree is not world-readable. Diagnose with:"
+    echo "  scripts/check_world_readable.sh $ROOT"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# The probe, run once per env with that env's own interpreter. It exercises
+# the real code path: rootstock (installed inside the venv) resolves the env,
+# spawns the worker, applies the cache-redirection env vars, loads the model,
+# and runs one forward pass on the standard smoke-test structure.
+# ---------------------------------------------------------------------------
+
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/rootstock_outsider.XXXXXX") || exit 2
+trap 'rm -rf "$WORK"' EXIT
+
+PROBE="$WORK/probe.py"
+cat > "$PROBE" << 'PY'
+import argparse
+import sys
+import time
+import traceback
+
+PERM_MARKERS = ("Errno 13", "EACCES", "Permission denied", "Read-only file system")
+
+
+def perm_hint(text: str) -> str:
+    hits = [line.strip() for line in text.splitlines() if any(m in line for m in PERM_MARKERS)]
+    if not hits:
+        return ""
+    return "  PERMISSION ERROR detected:\n    " + "\n    ".join(hits[:5])
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", required=True)
+    ap.add_argument("--cache-root", default=None)
+    ap.add_argument("--device", default="cpu")
+    ap.add_argument("--env", required=True)
+    ap.add_argument("checkpoints", nargs="*")
+    args = ap.parse_args()
+
+    from pathlib import Path
+
+    from rootstock.environment import get_model_cache_env, parse_checkpoints_dict
+
+    root = Path(args.root)
+    cache_root = Path(args.cache_root) if args.cache_root else None
+
+    print("cache/env redirection for workers (from get_model_cache_env):")
+    for key, value in sorted(get_model_cache_env(root, cache_root).items()):
+        print(f"  {key}={value}")
+
+    declared = parse_checkpoints_dict(root / "envs" / args.env / "env_source.py")
+
+    if args.checkpoints:
+        checkpoints = [c for c in args.checkpoints if c in declared]
+        skipped = [c for c in args.checkpoints if c not in declared]
+        for c in skipped:
+            print(f"SKIP {args.env}/{c}: not declared by this env")
+    else:
+        # Only fetched checkpoints are testable by a non-maintainer (an
+        # outsider cannot write weights into the shared cache — by design).
+        checkpoints = list(declared)
+        try:
+            from rootstock.manifest import load_manifest
+
+            manifest = load_manifest(root)
+            if manifest is not None and args.env in manifest.environments:
+                states = manifest.environments[args.env].checkpoints
+                fetched = [c for c in checkpoints if c in states and states[c].fetched_at]
+                for c in checkpoints:
+                    if c not in fetched:
+                        print(f"SKIP {args.env}/{c}: not fetched (rootstock add {c})")
+                checkpoints = fetched
+            else:
+                print("note: no manifest entry; testing all declared checkpoints")
+        except Exception as exc:  # manifest unreadable is itself worth knowing
+            print(f"note: could not read manifest ({exc}); testing all declared checkpoints")
+
+    if not checkpoints:
+        print(f"SKIP {args.env}: no fetched checkpoints to test")
+        return 0
+
+    from rootstock.calculator import RootstockCalculator
+    from rootstock.verify import _smoke_test_atoms
+
+    failures = 0
+    for ckpt in checkpoints:
+        atoms = _smoke_test_atoms()
+        start = time.monotonic()
+        try:
+            with RootstockCalculator(
+                checkpoint=ckpt,
+                root=root,
+                cache_root=cache_root,
+                device=args.device,
+            ) as calc:
+                atoms.calc = calc
+                energy = atoms.get_potential_energy()
+                atoms.get_forces()
+            elapsed = time.monotonic() - start
+            print(f"PASS {args.env}/{ckpt}  energy={energy:.6f} eV  ({elapsed:.1f}s)")
+        except Exception:
+            elapsed = time.monotonic() - start
+            failures += 1
+            text = traceback.format_exc()
+            print(f"FAIL {args.env}/{ckpt}  ({elapsed:.1f}s)")
+            tail = text.strip().splitlines()
+            print("  " + "\n  ".join(tail[-6:]))
+            hint = perm_hint(text)
+            if hint:
+                print(hint)
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+PY
+
+# ---------------------------------------------------------------------------
+# Drive the probe per env
+# ---------------------------------------------------------------------------
+
+want_env() {
+    [ ${#ENV_FILTER[@]} -eq 0 ] && return 0
+    local e
+    for e in "${ENV_FILTER[@]}"; do [ "$e" = "$1" ] && return 0; done
+    return 1
+}
+
+TOTAL_FAIL=0
+TESTED=0
+
+for env_dir in "$ROOT"/envs/*/; do
+    [ -x "$env_dir/bin/python" ] || continue
+    env_name=$(basename "$env_dir")
+    want_env "$env_name" || continue
+    TESTED=$((TESTED + 1))
+
+    echo
+    echo "=== env: $env_name ==="
+
+    cmd=("$env_dir/bin/python" "$PROBE" --root "$ROOT" --env "$env_name" --device "$DEVICE")
+    [ -n "$CACHE_ROOT" ] && cmd+=(--cache-root "$CACHE_ROOT")
+    [ ${#CKPT_FILTER[@]} -gt 0 ] && cmd+=("${CKPT_FILTER[@]}")
+
+    if [ "$STRACE" -eq 1 ]; then
+        tracefile="$WORK/strace_$env_name"
+        strace -f -qq -e trace=%file -o "$tracefile" "${cmd[@]}"
+        rc=$?
+        if [ -f "$tracefile" ] && grep -q 'EACCES' "$tracefile"; then
+            echo "  strace: EACCES file ops (unique paths):"
+            grep 'EACCES' "$tracefile" \
+                | grep -oE '"[^"]+"' | sort -u | head -20 | sed 's/^/    /'
+        fi
+    else
+        "${cmd[@]}"
+        rc=$?
+    fi
+
+    [ $rc -ne 0 ] && TOTAL_FAIL=$((TOTAL_FAIL + 1))
+done
+
+echo
+if [ "$TESTED" -eq 0 ]; then
+    echo "Error: no built envs found under $ROOT/envs (or --env filter matched none)." >&2
+    exit 2
+fi
+
+if [ "$MASKED" -eq 1 ]; then
+    echo "NOTE: run was masked (owner/group access applied) — a pass here does"
+    echo "      NOT prove world-readability. See warnings above."
+fi
+
+if [ "$TOTAL_FAIL" -gt 0 ]; then
+    echo "RESULT: FAIL — $TOTAL_FAIL of $TESTED env(s) had failures."
+    exit 1
+fi
+echo "RESULT: OK — all tested envs passed as an outside user."
+exit 0

--- a/tests/cache/test_cache_root.py
+++ b/tests/cache/test_cache_root.py
@@ -16,7 +16,23 @@ from rootstock.clusters import (
     get_root_for_cluster,
 )
 from rootstock.commands.common import resolve_cache_root
-from rootstock.environment import EnvironmentManager, get_model_cache_env
+from rootstock.environment import (
+    EnvironmentManager,
+    get_model_cache_env,
+    get_user_cache_dir,
+)
+
+# Runtime write-back caches that must NEVER point into the shared roots —
+# non-maintainers can only read there.
+_PER_USER_VARS = (
+    "TRITON_CACHE_DIR",
+    "TORCHINDUCTOR_CACHE_DIR",
+    "TORCH_EXTENSIONS_DIR",
+    "CUDA_CACHE_PATH",
+    "PYTHONPYCACHEPREFIX",
+    "XDG_CONFIG_HOME",
+    "MPLCONFIGDIR",
+)
 
 # ---------- get_model_cache_env: pure function ----------------------------
 
@@ -43,6 +59,53 @@ def test_get_model_cache_env_none_cache_root_falls_back_to_root():
     a = get_model_cache_env(Path("/install"), cache_root=None)
     b = get_model_cache_env(Path("/install"))
     assert a == b
+
+
+# ---------- per-user write-back redirection --------------------------------
+
+
+def test_write_back_caches_never_point_into_shared_roots(monkeypatch, tmp_path: Path):
+    for var in _PER_USER_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("ROOTSTOCK_USER_CACHE_DIR", str(tmp_path / "user-cache"))
+
+    out = get_model_cache_env(Path("/install"), cache_root=Path("/cache"))
+    for var in _PER_USER_VARS:
+        assert out[var].startswith(str(tmp_path / "user-cache")), f"{var} = {out[var]}"
+        assert not out[var].startswith("/install")
+        assert not out[var].startswith("/cache")
+
+
+def test_write_back_caches_respect_preexisting_values(monkeypatch):
+    """A user pointing e.g. Triton at node-local SSD in a job script wins."""
+    monkeypatch.setenv("TRITON_CACHE_DIR", "/local/scratch/triton")
+    out = get_model_cache_env(Path("/install"))
+    assert out["TRITON_CACHE_DIR"] == "/local/scratch/triton"
+
+
+def test_write_back_caches_ignore_empty_preexisting_values(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("ROOTSTOCK_USER_CACHE_DIR", str(tmp_path))
+    monkeypatch.setenv("TRITON_CACHE_DIR", "")
+    out = get_model_cache_env(Path("/install"))
+    assert out["TRITON_CACHE_DIR"] == str(tmp_path / "triton")
+
+
+def test_get_user_cache_dir_defaults_to_real_home(monkeypatch):
+    monkeypatch.delenv("ROOTSTOCK_USER_CACHE_DIR", raising=False)
+    assert get_user_cache_dir() == Path.home() / ".cache" / "rootstock"
+
+
+def test_get_user_cache_dir_env_override(monkeypatch):
+    monkeypatch.setenv("ROOTSTOCK_USER_CACHE_DIR", "/pscratch/u/me/rs")
+    assert get_user_cache_dir() == Path("/pscratch/u/me/rs")
+
+
+def test_shared_read_redirects_unaffected_by_user_cache(monkeypatch, tmp_path: Path):
+    """Weights are still found in the shared cache — only writes move."""
+    monkeypatch.setenv("ROOTSTOCK_USER_CACHE_DIR", str(tmp_path))
+    out = get_model_cache_env(Path("/install"), cache_root=Path("/cache"))
+    assert out["HOME"] == "/cache/home"
+    assert out["HF_HUB_CACHE"] == "/cache/cache/huggingface/hub"
 
 
 # ---------- Cluster registry ---------------------------------------------
@@ -73,6 +136,12 @@ def test_perlmutter_registered_with_split():
     # CFS for code, PSCRATCH for cache.
     assert "cfs" in str(pm.root).lower()
     assert "pscratch" in str(pm.cache_root).lower()
+
+
+def test_polaris_shares_sophia_eagle_root():
+    """Both ALCF machines mount Eagle and share one install."""
+    assert get_cluster("polaris").root == get_cluster("sophia").root
+    assert get_cluster("polaris").cache_root is None
 
 
 def test_get_root_for_cluster_returns_install_root():

--- a/tests/cli/test_add.py
+++ b/tests/cli/test_add.py
@@ -111,6 +111,22 @@ def test_add_no_verify_sets_fetched_at(fake_root, monkeypatch):
     assert ckpt.last_error is None
 
 
+def test_add_overrides_restrictive_umask(fake_root, monkeypatch):
+    """Weights written to the shared cache must be world-readable regardless
+    of the maintainer's personal umask."""
+    import os
+
+    monkeypatch.setattr(add_module, "_run_download", lambda *a, **kw: (True, None))
+
+    old = os.umask(0o077)
+    try:
+        assert cmd_add(_make_args(fake_root, no_verify=True)) == 0
+        # cmd_add must have replaced the restrictive umask with 002.
+        assert os.umask(0o022) == 0o002
+    finally:
+        os.umask(old)
+
+
 def test_add_then_add_is_idempotent(fake_root, monkeypatch):
     download_calls = []
     verify_calls = []

--- a/tests/commands/test_install_precompile.py
+++ b/tests/commands/test_install_precompile.py
@@ -1,0 +1,40 @@
+"""Tests for the bytecode pre-compilation step of ``rootstock install``."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from rootstock.commands.install import _precompile_environment
+
+
+def _make_tree(tmp_path: Path) -> Path:
+    tree = tmp_path / "env"
+    tree.mkdir()
+    (tree / "good.py").write_text("x = 1\n")
+    return tree
+
+
+def test_precompile_writes_pyc_in_tree(tmp_path: Path, monkeypatch):
+    """.pyc must land next to the sources (world-visible), even when the
+    maintainer's shell has a per-user PYTHONPYCACHEPREFIX exported."""
+    monkeypatch.setenv("PYTHONPYCACHEPREFIX", str(tmp_path / "elsewhere"))
+    tree = _make_tree(tmp_path)
+
+    _precompile_environment(Path(sys.executable), tree)
+
+    assert list((tree / "__pycache__").glob("good.*.pyc"))
+    assert not (tmp_path / "elsewhere").exists()
+
+
+def test_precompile_warns_but_does_not_raise_on_bad_files(tmp_path: Path, capsys):
+    tree = _make_tree(tmp_path)
+    (tree / "bad.py").write_text("def broken(:\n")
+
+    _precompile_environment(Path(sys.executable), tree)  # must not raise
+
+    out = capsys.readouterr().out
+    assert "Warning: some files did not byte-compile" in out
+    assert "bad.py" in out
+    # The good file still got compiled.
+    assert list((tree / "__pycache__").glob("good.*.pyc"))


### PR DESCRIPTION
Claude-genned PR description below (and double-checked by me)

 Make shared installs actually usable by non-maintainers

  Prep for launch on sophia, perlmutter, delta, and polaris. The world-readable
  contract was already enforced at setup time (setup-perms), but three gaps
  meant an install that works for the maintainer could still break for everyone
  else — and our own testing couldn't catch it, because owner bits satisfy every
  access check when the maintainer runs it.

  Runtime write-back was aimed at read-only directories

  get_model_cache_env redirects HOME/XDG_CACHE_HOME/HF_HOME into the
  shared cache so workers find pre-fetched weights. But those same paths are
  where MLIP stacks write at runtime (Triton/Inductor kernel caches, torch
  extension builds, NVIDIA compute cache, matplotlib config) — and the shared
  cache is maintainer-write-only by design. First JIT compile as a non-maintainer
  → EACCES.

  Fix: write-back caches now redirect to a per-user dir (~/.cache/rootstock,
  override with ROOTSTOCK_USER_CACHE_DIR). Values the user already exported
  win. Shared read redirects are unchanged.

  Deploy path hardening

  - rootstock install and rootstock add force umask 002 for their duration,
  so new files are born world-readable/group-writable instead of depending on
  the maintainer's shell config. (002, not 022 — co-maintainer group-write is
  part of the documented recipe.)
  - install now byte-compiles the venv as a final build step, so users' Pythons
  don't attempt (and silently fail) __pycache__ writes into the shared tree
  on every import. Warn-only: big site-packages always contain a few
  non-compilable vendored files.

  Verification scripts

  - scripts/test_as_outsider.sh — the ground-truth functional test. Run by a
  different-uid user under unshare --user --map-user=$(id -u), it drives the
  real RootstockCalculator path for every fetched checkpoint and reports
  PASS/FAIL, flagging permission errors specifically. Warns when owner/group
  bits mask the result.
  - scripts/check_world_readable.sh — standalone static audit for diagnosing
  failures: ancestor-dir traversal walk, other-bits on every file/dir, symlink
  target resolution, ACL scan. Has a --self-test that builds a deliberately
  broken fixture tree.

  We deliberately did not wire a recursive perms scan into install/status —
  recursive stats on Lustre/GPFS are why check_permissions is bounded. The
  functional test is the contract check; the static script is for diagnosis.

  Misc

  - Added polaris to the cluster registry (shares sophia's Eagle root).
  - Docs: forced-umask behavior and a pre-launch verification runbook in
  cluster-setup.md.

  ---

