### PR TITLE
Serve orb weights from a local file so cached_path never locks the shared root

### DIFF
--- a/docs/environments.md
+++ b/docs/environments.md
@@ -197,6 +197,10 @@ def setup(checkpoint: str, device: str = "cuda"):
 
 The canonical ids in `CHECKPOINTS` are the join key with the Almanac. If the Almanac registers `mace-mp-0-medium` and you ship a `CHECKPOINTS` key of `mace_mp_0_medium`, the two never join and no row in the matrix lights up. Match the registered id exactly. The Almanac is the registry of canonical ids; this env file is the local dispatch.
 
+### Serve time must not write to the shared install
+
+`rootstock add` (run by a maintainer, who can write the shared cache) is when weights download; after that, `setup()` runs as arbitrary users who can only *read* the install. So `setup()` must not write under the shared root on a warm cache — no lock files, no re-downloads, no "touch to check". Libraries that take a write-lock even on cache hits (e.g. `cached_path`, which orb-models uses) break this: hand them a local file path instead of a URL, pre-fetching the file into `$XDG_CACHE_HOME` yourself — see `nvidia_configs/orb.py`. Runtime scratch (compiled kernels, config dirs) is already redirected per-user by rootstock; this rule is about what your `setup()` and its libraries do with model files.
+
 ### Expect cluster-specific edits
 
 The same model rarely drops onto every cluster unchanged. Driver and CUDA versions, the available Python, and filesystem behavior all vary, so adapting a sample's dependency pins or `setup()` for a given cluster is routine, not exceptional. A file can also declare a strict subset of the canonical ids the standard sample carries — keys it doesn't list simply won't resolve to it, and `rootstock add` finds the right env for each id.

--- a/rootstock/environment.py
+++ b/rootstock/environment.py
@@ -77,6 +77,13 @@ def get_model_cache_env(root: Path, cache_root: Path | None = None) -> dict[str,
         "PYTHONPYCACHEPREFIX": user_cache / "pycache",
         "XDG_CONFIG_HOME": user_cache / "config",
         "MPLCONFIGDIR": user_cache / "matplotlib",
+        # cached_path (an orb-models dep) ignores XDG_CACHE_HOME and defaults
+        # to ~/.cache/cached_path under the redirected HOME — i.e. the shared
+        # root — where it takes a FileLock even on warm cache hits (#67).
+        # Point it per-user; envs that serve from the shared cache must hand
+        # cached_path a *local* file (see nvidia_configs/orb.py), which it
+        # returns without locking.
+        "CACHED_PATH_CACHE_ROOT": user_cache / "cached_path",
     }
 
     env = {

--- a/sample_model_configurations/nvidia_configs/orb.py
+++ b/sample_model_configurations/nvidia_configs/orb.py
@@ -16,11 +16,47 @@
 # ///
 """Orb env — hosts Orbital Materials' Orb universal potentials."""
 
+import os
+import shutil
+import urllib.request
+from pathlib import Path
+
 CHECKPOINTS = {
     "orb-v2": "orb-v2",
     "orb-d3-v2": "orb-d3-v2",
     "orb-mptraj-only-v2": "orb-mptraj-only-v2",
 }
+
+
+def _default_weights_url(load_fn) -> str:
+    """The upstream URL baked into the loader's ``weights_path`` default."""
+    import inspect
+
+    default = inspect.signature(load_fn).parameters["weights_path"].default
+    if not isinstance(default, str) or not default.startswith(("http://", "https://")):
+        raise RuntimeError(
+            f"{load_fn.__name__} has no URL default for weights_path "
+            f"(got {default!r}); update this env file for the installed orb-models"
+        )
+    return default
+
+
+def _local_weights_path(url: str) -> Path:
+    """Where the checkpoint lives in the shared model cache."""
+    cache = Path(os.environ.get("XDG_CACHE_HOME") or Path.home() / ".cache")
+    return cache / "orb" / os.path.basename(url)
+
+
+def _fetch(url: str, dest: Path) -> None:
+    """Download ``url`` to ``dest`` atomically (tmp file + rename)."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_name(f"{dest.name}.tmp.{os.getpid()}")
+    try:
+        with urllib.request.urlopen(url) as resp, open(tmp, "wb") as out:
+            shutil.copyfileobj(resp, out)
+        os.replace(tmp, dest)
+    finally:
+        tmp.unlink(missing_ok=True)
 
 
 def setup(checkpoint: str, device: str = "cuda"):
@@ -31,5 +67,17 @@ def setup(checkpoint: str, device: str = "cuda"):
     # orb-models exposes one function per checkpoint, e.g. pretrained.orb_v2().
     fn_name = CHECKPOINTS[checkpoint].replace("-", "_")
     load_fn = getattr(pretrained, fn_name)
-    orbff = load_fn(device=torch.device(device))
+
+    # orb-models resolves its default weights URL through `cached_path`, which
+    # write-locks its cache dir even on warm hits — EACCES for anyone who can't
+    # write the shared install (Garden-AI/rootstock#67). Handed a *local* path
+    # instead, cached_path returns it without locking. So the weights are
+    # pre-fetched into the shared model cache at `rootstock add` time
+    # (maintainer, cache writable) and every later serve loads that file.
+    url = _default_weights_url(load_fn)
+    weights = _local_weights_path(url)
+    if not weights.exists():
+        _fetch(url, weights)
+
+    orbff = load_fn(weights_path=str(weights), device=torch.device(device))
     return ORBCalculator(orbff, device=torch.device(device))

--- a/sample_model_configurations/nvidia_configs/orb.py
+++ b/sample_model_configurations/nvidia_configs/orb.py
@@ -4,6 +4,10 @@
 #     "orb-models>=0.4.0",
 #     "ase>=3.22",
 #     "torch>=2.0",
+#     # Not imported here — constrains orb-models' transitive dep. setup()'s
+#     # no-lock serve path relies on cached_path returning local files without
+#     # locking or writing, verified against exactly this version (#67).
+#     "cached_path==1.8.10",
 # ]
 #
 # [tool.uv.sources]

--- a/sample_model_configurations/nvidia_configs/orb_v3.py
+++ b/sample_model_configurations/nvidia_configs/orb_v3.py
@@ -4,6 +4,10 @@
 #     "orb-models>=0.6.2",
 #     "ase>=3.25",
 #     "torch>=2.8",
+#     # Not imported here — constrains orb-models' transitive dep. setup()'s
+#     # no-lock serve path relies on cached_path returning local files without
+#     # locking or writing, verified against exactly this version (#67).
+#     "cached_path==1.8.10",
 # ]
 #
 # [tool.uv.sources]

--- a/sample_model_configurations/nvidia_configs/orb_v3.py
+++ b/sample_model_configurations/nvidia_configs/orb_v3.py
@@ -21,6 +21,11 @@ Separate from orb.py because orb-models>=0.5 changed the loader API
 import path) and 0.6.x bumped the Python floor to 3.12 and torch to 2.8.
 """
 
+import os
+import shutil
+import urllib.request
+from pathlib import Path
+
 CHECKPOINTS = {
     "orb-v3-conservative-inf-omat": "orb-v3-conservative-inf-omat",
     "orb-v3-conservative-20-omat":  "orb-v3-conservative-20-omat",
@@ -35,6 +40,37 @@ CHECKPOINTS = {
 }
 
 
+def _default_weights_url(load_fn) -> str:
+    """The upstream URL baked into the loader's ``weights_path`` default."""
+    import inspect
+
+    default = inspect.signature(load_fn).parameters["weights_path"].default
+    if not isinstance(default, str) or not default.startswith(("http://", "https://")):
+        raise RuntimeError(
+            f"{load_fn.__name__} has no URL default for weights_path "
+            f"(got {default!r}); update this env file for the installed orb-models"
+        )
+    return default
+
+
+def _local_weights_path(url: str) -> Path:
+    """Where the checkpoint lives in the shared model cache."""
+    cache = Path(os.environ.get("XDG_CACHE_HOME") or Path.home() / ".cache")
+    return cache / "orb" / os.path.basename(url)
+
+
+def _fetch(url: str, dest: Path) -> None:
+    """Download ``url`` to ``dest`` atomically (tmp file + rename)."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_name(f"{dest.name}.tmp.{os.getpid()}")
+    try:
+        with urllib.request.urlopen(url) as resp, open(tmp, "wb") as out:
+            shutil.copyfileobj(resp, out)
+        os.replace(tmp, dest)
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
 def setup(checkpoint: str, device: str = "cuda", precision: str = "float32-high"):
     import torch
     from orb_models.forcefield import pretrained
@@ -42,5 +78,19 @@ def setup(checkpoint: str, device: str = "cuda", precision: str = "float32-high"
 
     fn_name = CHECKPOINTS[checkpoint].replace("-", "_")
     load_fn = getattr(pretrained, fn_name)
-    orbff, atoms_adapter = load_fn(device=torch.device(device), precision=precision)
+
+    # orb-models resolves its default weights URL through `cached_path`, which
+    # write-locks its cache dir even on warm hits — EACCES for anyone who can't
+    # write the shared install (Garden-AI/rootstock#67). Handed a *local* path
+    # instead, cached_path returns it without locking. So the weights are
+    # pre-fetched into the shared model cache at `rootstock add` time
+    # (maintainer, cache writable) and every later serve loads that file.
+    url = _default_weights_url(load_fn)
+    weights = _local_weights_path(url)
+    if not weights.exists():
+        _fetch(url, weights)
+
+    orbff, atoms_adapter = load_fn(
+        weights_path=str(weights), device=torch.device(device), precision=precision
+    )
     return ORBCalculator(orbff, atoms_adapter=atoms_adapter, device=torch.device(device))

--- a/tests/cache/test_cache_root.py
+++ b/tests/cache/test_cache_root.py
@@ -32,6 +32,7 @@ _PER_USER_VARS = (
     "PYTHONPYCACHEPREFIX",
     "XDG_CONFIG_HOME",
     "MPLCONFIGDIR",
+    "CACHED_PATH_CACHE_ROOT",
 )
 
 # ---------- get_model_cache_env: pure function ----------------------------

--- a/tests/sample_configs/test_orb_local_weights.py
+++ b/tests/sample_configs/test_orb_local_weights.py
@@ -1,0 +1,227 @@
+"""Tests for the orb env files' cached_path bypass (#67).
+
+At serve time the worker must write nothing under the shared root. orb-models
+routes its default weights URL through `cached_path`, which write-locks its
+cache dir even on warm hits — so the orb env files pre-fetch the checkpoint
+into the shared model cache at `rootstock add` time and hand the loader a
+local `weights_path`, which cached_path returns without locking.
+
+The env files' module level is stdlib-only, so they import without
+torch/orb-models installed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+_CONFIGS_DIR = (
+    Path(__file__).parent.parent.parent / "sample_model_configurations" / "nvidia_configs"
+)
+
+
+def _load_env_module(name: str):
+    spec = importlib.util.spec_from_file_location(name, _CONFIGS_DIR / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(params=["orb", "orb_v3"])
+def env_module(request):
+    return _load_env_module(request.param)
+
+
+# ---------- _default_weights_url -------------------------------------------
+
+
+def test_default_weights_url_reads_signature_default(env_module):
+    def load_fn(
+        weights_path: str = "https://example.com/orb-v2-20241011.ckpt",
+        device=None,
+    ):
+        pass
+
+    assert env_module._default_weights_url(load_fn) == "https://example.com/orb-v2-20241011.ckpt"
+
+
+def test_default_weights_url_rejects_non_url_default(env_module):
+    def load_fn(weights_path: str = "/some/local/default.ckpt", device=None):
+        pass
+
+    with pytest.raises(RuntimeError, match="no URL default"):
+        env_module._default_weights_url(load_fn)
+
+
+def test_default_weights_url_fails_loudly_without_weights_path_param(env_module):
+    """If a future orb-models drops the kwarg, populate/serve must not silently
+    fall back to the locking cached_path route."""
+
+    def load_fn(device=None):
+        pass
+
+    with pytest.raises(KeyError):
+        env_module._default_weights_url(load_fn)
+
+
+# ---------- _local_weights_path ---------------------------------------------
+
+
+def test_local_weights_path_lands_in_shared_cache(env_module, monkeypatch):
+    monkeypatch.setenv("XDG_CACHE_HOME", "/shared/cache")
+    out = env_module._local_weights_path("https://example.com/models/orb-v2-20241011.ckpt")
+    assert out == Path("/shared/cache/orb/orb-v2-20241011.ckpt")
+
+
+def test_local_weights_path_falls_back_to_home_cache(env_module, monkeypatch):
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    out = env_module._local_weights_path("https://example.com/orb-v2.ckpt")
+    assert out == Path.home() / ".cache" / "orb" / "orb-v2.ckpt"
+
+
+def test_local_weights_path_ignores_empty_xdg_cache_home(env_module, monkeypatch):
+    monkeypatch.setenv("XDG_CACHE_HOME", "")
+    out = env_module._local_weights_path("https://example.com/orb-v2.ckpt")
+    assert out == Path.home() / ".cache" / "orb" / "orb-v2.ckpt"
+
+
+# ---------- _fetch ----------------------------------------------------------
+
+
+class _FakeResponse(io.BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+
+def test_fetch_downloads_atomically(env_module, monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(
+        urllib.request, "urlopen", lambda url: _FakeResponse(b"checkpoint-bytes")
+    )
+    dest = tmp_path / "orb" / "orb-v2.ckpt"
+    env_module._fetch("https://example.com/orb-v2.ckpt", dest)
+
+    assert dest.read_bytes() == b"checkpoint-bytes"
+    # No temp litter next to the final file.
+    assert list(dest.parent.iterdir()) == [dest]
+
+
+def test_fetch_cleans_up_partial_download_on_failure(
+    env_module, monkeypatch, tmp_path: Path
+):
+    def _boom(url):
+        raise OSError("network down")
+
+    monkeypatch.setattr(urllib.request, "urlopen", _boom)
+    dest = tmp_path / "orb" / "orb-v2.ckpt"
+    with pytest.raises(OSError, match="network down"):
+        env_module._fetch("https://example.com/orb-v2.ckpt", dest)
+
+    assert not dest.exists()
+    assert list(dest.parent.iterdir()) == []
+
+
+# ---------- serve-time invariant: setup() end-to-end ------------------------
+
+_FAKE_URL = "https://example.com/models/fake-orb.ckpt"
+
+
+def _install_fake_orb_models(monkeypatch, env_name: str, calls: dict):
+    """Stub torch + orb_models in sys.modules so setup() runs without them."""
+    import sys
+    import types
+
+    torch = types.ModuleType("torch")
+    torch.device = lambda spec: f"device({spec})"
+
+    def load_fn(
+        weights_path: str = _FAKE_URL,
+        device=None,
+        precision: str = "float32-high",
+    ):
+        calls["weights_path"] = weights_path
+        if env_name == "orb_v3":
+            return "orbff", "adapter"
+        return "orbff"
+
+    pretrained = types.ModuleType("orb_models.forcefield.pretrained")
+    # One loader per canonical id, orb-models style (orb_v2, orb_v3_..., etc.).
+    for fn_name in ("orb_v2", "orb_v3_conservative_inf_omat"):
+        setattr(pretrained, fn_name, load_fn)
+
+    class ORBCalculator:
+        def __init__(self, orbff, atoms_adapter=None, device=None):
+            calls["calculator"] = (orbff, atoms_adapter, device)
+
+    calculator = types.ModuleType("orb_models.forcefield.calculator")
+    calculator.ORBCalculator = ORBCalculator
+    inference_calculator = types.ModuleType("orb_models.forcefield.inference.calculator")
+    inference_calculator.ORBCalculator = ORBCalculator
+
+    forcefield = types.ModuleType("orb_models.forcefield")
+    forcefield.pretrained = pretrained
+    inference = types.ModuleType("orb_models.forcefield.inference")
+    orb_models = types.ModuleType("orb_models")
+
+    for name, module in {
+        "torch": torch,
+        "orb_models": orb_models,
+        "orb_models.forcefield": forcefield,
+        "orb_models.forcefield.pretrained": pretrained,
+        "orb_models.forcefield.calculator": calculator,
+        "orb_models.forcefield.inference": inference,
+        "orb_models.forcefield.inference.calculator": inference_calculator,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+
+_FIRST_CHECKPOINT = {"orb": "orb-v2", "orb_v3": "orb-v3-conservative-inf-omat"}
+
+
+@pytest.fixture(params=["orb", "orb_v3"])
+def wired_env(request, monkeypatch):
+    calls: dict = {}
+    _install_fake_orb_models(monkeypatch, request.param, calls)
+    return _load_env_module(request.param), _FIRST_CHECKPOINT[request.param], calls
+
+
+def test_setup_serves_warm_cache_without_network_or_shared_writes(
+    wired_env, monkeypatch, tmp_path: Path
+):
+    """The #67 invariant: a warm serve hands the loader a local weights file
+    and never opens a URL — so cached_path takes no lock under the shared root."""
+    module, checkpoint, calls = wired_env
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    weights = module._local_weights_path(_FAKE_URL)
+    weights.parent.mkdir(parents=True)
+    weights.write_bytes(b"already here")
+
+    def _no_network(url):
+        raise AssertionError(f"urlopen({url!r}) called on a warm cache")
+
+    monkeypatch.setattr(urllib.request, "urlopen", _no_network)
+
+    module.setup(checkpoint, device="cpu")
+    assert calls["weights_path"] == str(weights)
+
+
+def test_setup_fetches_weights_on_cold_cache(wired_env, monkeypatch, tmp_path: Path):
+    """Populate path (`rootstock add`): cold cache downloads into the shared
+    model cache, then loads from the local file."""
+    module, checkpoint, calls = wired_env
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        urllib.request, "urlopen", lambda url: _FakeResponse(b"downloaded")
+    )
+
+    module.setup(checkpoint, device="cpu")
+
+    weights = module._local_weights_path(_FAKE_URL)
+    assert weights.read_bytes() == b"downloaded"
+    assert calls["weights_path"] == str(weights)


### PR DESCRIPTION
Fixes #67 (the triggering orb/`cached_path` case left open after #66).

## The bug

`orb_models.forcefield.pretrained.orb_v2()` resolves its default weights URL through `cached_path`, which takes a `FileLock` next to the cached blob **even on warm cache hits**. That blob lives in `home/.cache/cached_path/` under the redirected `HOME` — the shared install — so any user who can't write there gets `[Errno 13] Permission denied` at serve time.

## Why env vars alone can't fix it

Checked against the deployed versions (orb-models 0.5.5 on delta/perlmutter/sophia; cached_path ≥1.6.7, current 1.8.10):

- `cached_path` honors **no offline flag** — its only knobs are `CACHED_PATH_CACHE_ROOT` and a version-suffix var.
- Its `read_only_ok=True` lock only degrades to a warning when the `.lock` file already exists; creating it in an unwritable dir re-raises EACCES.
- Redirecting `CACHED_PATH_CACHE_ROOT` per-user orphans the shared blob (lock and blob are co-located), forcing a re-download on offline compute nodes.

## The fix

**Bypass the URL route.** `cached_path()` handed an existing **local file** returns it without locking or writing. Every orb loader accepts `weights_path=`, so the orb env files now:

1. Introspect the upstream URL from the loader signature's `weights_path` default (no hardcoded URLs; fails loudly if a future orb-models drops the kwarg).
2. Pre-fetch it to `$XDG_CACHE_HOME/orb/<name>.ckpt` — the *governed* shared cache — at `rootstock add` time (maintainer, writable). Atomic tmp+rename download.
3. Pass the local path to the loader, so serve-time `cached_path` never sees a URL.

Applied to both `orb.py` (v2, orb-models ≥0.4) and `orb_v3.py` (≥0.6.2 — same pattern, verified against the 0.6.2 wheel).

Both env files also pin `cached_path==1.8.10` explicitly (a transitive dep of orb-models, now declared): the no-lock local-file behavior was verified against exactly that version, and the pin freezes the assumption against upstream changes — plus its resolved version now shows up in cluster manifests.

Belt-and-braces: `get_model_cache_env` now points `CACHED_PATH_CACHE_ROOT` at the per-user cache, joining the existing per-user redirects from #66, so anything that still reaches cached_path writes outside `{root}`.

Also adds a "serve time must not write to the shared install" section to the env-authoring docs.

## Tests

- `tests/sample_configs/test_orb_local_weights.py` — drives both env files' `setup()` end-to-end against stubbed `torch`/`orb_models`: warm cache serves the local file **without touching the network**, cold cache fetches atomically; URL introspection and failure modes covered.
- `CACHED_PATH_CACHE_ROOT` added to the never-points-into-shared-roots sweep in `tests/cache/test_cache_root.py`.
- Full suite: 162 passed. `ruff check` clean on changed files.

## Deployment / acceptance

Existing installs hold orb blobs only under the old `home/.cache/cached_path/` hash names, so after updating the env source on a cluster, run `rootstock add <orb-checkpoint>` (or the smoke-test) once as a maintainer — verify's `setup()` call populates `$XDG_CACHE_HOME/orb/`. Then the #67 acceptance run:

```
scripts/test_as_outsider.sh --checkpoint orb-v2
```

as a true outsider (different uid, no group) should pass. That cluster run is still pending — this PR is the code side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
