### PR TITLE
Add a new permissions checking command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,9 @@ rootstock smoke-test [--env ENV] [--checkpoint CKPT] [--device cuda] [--json]
 # Show status (per-checkpoint verified/stale grid; --json for machine-readable)
 rootstock status [--root <path>] [--json]
 
+# Read-only permission check of install/cache roots + ancestors (exit 1 on issues)
+rootstock check-perms [<root>] [--cluster <name>] [--group <group>] [--json]
+
 # List environments
 rootstock list --root <path>
 ```

--- a/docs/cluster-setup.md
+++ b/docs/cluster-setup.md
@@ -94,7 +94,15 @@ After `rootstock init` runs, verify ACLs landed correctly with `getfacl` on a fr
 
 ### Verifying world-readability before launch
 
-Two scripts in `scripts/` check the world-readable contract end-to-end. Neither needs rootstock installed in the caller's own Python.
+**Quick check (first line).** `rootstock check-perms` runs the same read-only verification that `rootstock install` performs up front, as a standalone command — plus an ancestor walk, so a restricted project parent directory (which no `chmod` inside the install can fix) shows up too. It stats only the roots and their ancestors, so it is safe and fast on login nodes:
+
+```bash
+rootstock check-perms --cluster perlmutter --group m4845
+```
+
+Exit code 0 means the roots look right; 1 means issues were printed (pass `--json` for machine-readable output). It checks only the root directories, not the tree beneath them — for that, use the scripts below.
+
+**Deep checks.** Two scripts in `scripts/` check the world-readable contract end-to-end. Neither needs rootstock installed in the caller's own Python.
 
 **Functional test (the ground truth).** Have a colleague — someone who does *not* own the install and is *not* in the project group — run, on a login node:
 

--- a/rootstock/cli.py
+++ b/rootstock/cli.py
@@ -39,6 +39,12 @@ Commands:
         Render (dry-run) or apply the world-readable shared-install permission
         recipe for an install root (and split cache root):
             rootstock setup-perms --cluster perlmutter --group m4845 --apply
+
+    rootstock check-perms [<root>] [--cluster <name>] [--group <group>] [--json]
+        Read-only check that the install root, split cache root, and their
+        ancestor directories satisfy the shared-install permission recipe.
+        Exits 0 when clean, 1 when issues are found:
+            rootstock check-perms --cluster perlmutter --group m4845
 """
 
 import argparse
@@ -49,6 +55,7 @@ from . import __version__
 from .commands import (
     cmd_add,
     cmd_benchmark,
+    cmd_check_perms,
     cmd_init,
     cmd_install,
     cmd_list,
@@ -226,9 +233,7 @@ def main():
         ),
     )
     smoke_parser.add_argument("--env", help="Filter to a single environment")
-    smoke_parser.add_argument(
-        "--checkpoint", help="Filter to a single checkpoint (requires --env)"
-    )
+    smoke_parser.add_argument("--checkpoint", help="Filter to a single checkpoint (requires --env)")
     smoke_parser.add_argument("--device", default="cuda", help="Device (default: cuda)")
     smoke_parser.add_argument("--json", action="store_true", help="Emit a JSON summary")
     smoke_parser.add_argument(
@@ -324,6 +329,46 @@ def main():
         help="Also apply recursively so existing files become world-readable",
     )
     setup_perms_parser.set_defaults(func=cmd_setup_perms)
+
+    # check-perms command
+    check_perms_parser = subparsers.add_parser(
+        "check-perms",
+        help="Check shared-install permissions (read-only)",
+        description=(
+            "Read-only check that the install root, split cache root, and their "
+            "ancestor directories satisfy the shared-install permission recipe "
+            "(world read+traverse, setgid, default ACLs, co-maintainer group ACL, "
+            "no mask clamp). Never modifies anything. "
+            "Exit codes: 0 = clean, 1 = issues found, 2 = usage error."
+        ),
+    )
+    check_perms_parser.add_argument(
+        "root",
+        nargs="?",
+        default=os.environ.get(ROOTSTOCK_ROOT_ENV),
+        help=f"Install root path (default: ${ROOTSTOCK_ROOT_ENV}; or use --cluster)",
+    )
+    check_perms_parser.add_argument(
+        "--cache-root",
+        help="Cache root path, when on a separate filesystem from the install root",
+    )
+    check_perms_parser.add_argument(
+        "--cluster",
+        help="Resolve install and cache roots from the cluster registry",
+    )
+    check_perms_parser.add_argument(
+        "--group",
+        help=(
+            "Project group expected in the co-maintainer ACL "
+            "(default: the install root's owning group)"
+        ),
+    )
+    check_perms_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a machine-readable JSON report",
+    )
+    check_perms_parser.set_defaults(func=cmd_check_perms)
 
     # serve command
     serve_parser = subparsers.add_parser(

--- a/rootstock/commands/__init__.py
+++ b/rootstock/commands/__init__.py
@@ -2,6 +2,7 @@
 
 from .add import cmd_add
 from .benchmark import cmd_benchmark
+from .check_perms import cmd_check_perms
 from .create import cmd_new_env
 from .init import cmd_init
 from .install import cmd_install
@@ -15,6 +16,7 @@ from .status import cmd_list, cmd_status
 __all__ = [
     "cmd_add",
     "cmd_benchmark",
+    "cmd_check_perms",
     "cmd_init",
     "cmd_install",
     "cmd_list",

--- a/rootstock/commands/check_perms.py
+++ b/rootstock/commands/check_perms.py
@@ -1,0 +1,94 @@
+"""``rootstock check-perms`` — standalone shared-install permission check."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from ..clusters import get_cluster
+from ..config import load_config
+from ..perms import check_permissions
+from .common import ROOTSTOCK_ROOT_ENV, resolve_cache_root
+
+
+def _resolve_roots(args) -> tuple[Path, Path | None] | None:
+    """Resolve (install_root, cache_root) to check.
+
+    Priority: --cluster, then the positional root (whose argparse default is
+    $ROOTSTOCK_ROOT), then the config file. When the root isn't given via
+    --cluster, the cache root comes from --cache-root or a reverse lookup in
+    the cluster registry. Returns None (after printing an error) on bad input.
+    """
+    if args.cluster:
+        try:
+            cluster = get_cluster(args.cluster)
+        except ValueError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return None
+        return cluster.root, cluster.cache_root
+
+    root = args.root or load_config().root
+    if not root:
+        print(
+            f"Error: provide an install root path, --cluster <name>, or set {ROOTSTOCK_ROOT_ENV}.",
+            file=sys.stderr,
+        )
+        return None
+
+    install_root = Path(root)
+    cache_root = Path(args.cache_root) if args.cache_root else resolve_cache_root(install_root)
+    return install_root, cache_root
+
+
+def cmd_check_perms(args) -> int:
+    """Read-only permission check of the install root, cache root, and ancestors.
+
+    Exit codes:
+        0: No issues found
+        1: One or more issues found
+        2: Usage error (couldn't resolve roots)
+    """
+    resolved = _resolve_roots(args)
+    if resolved is None:
+        return 2
+    install_root, cache_root = resolved
+
+    issues = check_permissions(
+        install_root,
+        cache_root,
+        group=args.group,
+        include_ancestors=True,
+    )
+
+    separate_cache = cache_root is not None and cache_root != install_root
+
+    if args.json:
+        payload = {
+            "install_root": str(install_root),
+            "cache_root": str(cache_root) if separate_cache else str(install_root),
+            "ok": not issues,
+            "issues": [{"path": str(i.path), "problem": i.problem} for i in issues],
+        }
+        print(json.dumps(payload, indent=2))
+        return 1 if issues else 0
+
+    print(f"Install root: {install_root}")
+    if separate_cache:
+        print(f"Cache root:   {cache_root}")
+
+    if not issues:
+        print("OK: no permission issues found.")
+        return 0
+
+    print(f"\nFound {len(issues)} issue(s):")
+    for issue in issues:
+        print(f"  - {issue.path}: {issue.problem}")
+    print(
+        "\nRoot-level issues: rootstock setup-perms --group <project-group> --apply"
+        " (add --retrofit for existing files)."
+        "\nAncestor-directory issues are outside the install — fixing them takes"
+        " the directory's owner or a facilities ticket."
+        "\nFor a full-tree audit, run scripts/check_world_readable.sh <root>."
+    )
+    return 1

--- a/rootstock/perms.py
+++ b/rootstock/perms.py
@@ -9,7 +9,9 @@ should be able to use it. Maintainer secrets live in the maintainer's
 This module is the single source of truth for what "correct permissions" means.
 ``render_commands`` produces the recipe the ``setup-perms`` command renders or
 applies; ``check_permissions`` is the bounded, non-recursive verification that
-``rootstock install`` runs up front to warn when a root looks misconfigured.
+``rootstock install`` runs up front to warn when a root looks misconfigured,
+and that ``rootstock check-perms`` exposes as a standalone command (with
+ancestor-directory checks added).
 
 The recipe:
 
@@ -112,6 +114,37 @@ class PermIssue:
 def _world_readable_traversable(mode: int) -> bool:
     """True if ``other`` has both read and execute (traverse) bits."""
     return (mode & 0o5) == 0o5
+
+
+def _check_ancestors(path: Path) -> list[PermIssue]:
+    """Flag ancestor directories that block world traversal to ``path``.
+
+    A perfectly world-readable install is unreachable if any directory above
+    it lacks ``o+x`` (e.g., a project parent directory that was created
+    group-only). One stat per path component — cheap on HPC filesystems.
+    """
+    issues: list[PermIssue] = []
+    for ancestor in reversed(path.resolve().parents):
+        if ancestor == Path("/"):
+            continue
+        try:
+            mode = ancestor.stat().st_mode
+        except FileNotFoundError:
+            break  # the missing-root issue is reported by _check_root
+        except PermissionError:
+            issues.append(
+                PermIssue(ancestor, "cannot stat ancestor (permission denied for you, too)")
+            )
+            break
+        if not (mode & 0o1):
+            issues.append(
+                PermIssue(
+                    ancestor,
+                    "ancestor not world-traversable (other lacks x); "
+                    "users outside the project group cannot reach the install",
+                )
+            )
+    return issues
 
 
 def _has_setgid(mode: int) -> bool:
@@ -259,17 +292,30 @@ def check_permissions(
     cache_root: Path | str | None = None,
     *,
     group: str | None = None,
+    include_ancestors: bool = False,
 ) -> list[PermIssue]:
     """Best-effort, bounded permission check for an install (and cache) root.
 
-    Touches only the root directories themselves — never recurses — so it is
-    cheap even on slow HPC filesystems. Returns a (possibly empty) list of
-    issues; callers treat these as warnings, not errors.
+    Touches only the root directories themselves — never recurses downward —
+    so it is cheap even on slow HPC filesystems. Returns a (possibly empty)
+    list of issues; callers treat these as warnings, not errors.
+
+    ``include_ancestors`` additionally checks that every directory above each
+    root grants world traverse (``o+x``). Off by default: dev installs under a
+    ``700`` home directory are legitimate, so only the explicit pre-launch
+    check (``rootstock check-perms``) opts in.
     """
     install_root = Path(install_root)
-    issues = _check_root(install_root, kind="install", group=group, require_group_acl=True)
+    issues: list[PermIssue] = []
+    if include_ancestors:
+        issues += _check_ancestors(install_root)
+    issues += _check_root(install_root, kind="install", group=group, require_group_acl=True)
 
     if cache_root is not None and Path(cache_root) != install_root:
-        issues += _check_root(Path(cache_root), kind="cache", group=group, require_group_acl=False)
+        cache_root = Path(cache_root)
+        if include_ancestors:
+            seen = {issue.path for issue in issues}
+            issues += [i for i in _check_ancestors(cache_root) if i.path not in seen]
+        issues += _check_root(cache_root, kind="cache", group=group, require_group_acl=False)
 
     return issues

--- a/tests/cli/test_check_perms.py
+++ b/tests/cli/test_check_perms.py
@@ -1,0 +1,118 @@
+"""Tests for ``rootstock check-perms``."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import rootstock.perms as perms
+from rootstock.commands.check_perms import cmd_check_perms
+
+
+def _args(**overrides):
+    base = dict(
+        root=None,
+        cache_root=None,
+        cluster=None,
+        group=None,
+        json=False,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _make_clean_root(tmp_path: Path) -> Path:
+    root = tmp_path / "rootstock"
+    root.mkdir()
+    os.chmod(root, 0o2775)
+    return root
+
+
+def _world_traversable_ancestors(monkeypatch):
+    # tmp_path lives under per-user 700 directories on most systems; the
+    # ancestor walk would flag those and drown out what the test asserts.
+    monkeypatch.setattr(perms, "_check_ancestors", lambda path: [])
+
+
+def test_clean_root_exits_zero(tmp_path: Path, monkeypatch, capsys):
+    monkeypatch.setattr(perms, "_run_getfacl", lambda path: None)
+    _world_traversable_ancestors(monkeypatch)
+    root = _make_clean_root(tmp_path)
+
+    rc = cmd_check_perms(_args(root=str(root)))
+    assert rc == 0
+    assert "OK: no permission issues found." in capsys.readouterr().out
+
+
+def test_issues_exit_one_and_are_listed(tmp_path: Path, monkeypatch, capsys):
+    monkeypatch.setattr(perms, "_run_getfacl", lambda path: None)
+    _world_traversable_ancestors(monkeypatch)
+    root = tmp_path / "rootstock"
+    root.mkdir()
+    os.chmod(root, 0o700)
+
+    rc = cmd_check_perms(_args(root=str(root)))
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "not world-readable" in out
+    assert "setup-perms" in out
+
+
+def test_restricted_ancestor_is_flagged(tmp_path: Path, monkeypatch, capsys):
+    monkeypatch.setattr(perms, "_run_getfacl", lambda path: None)
+    parent = tmp_path / "project"
+    root = parent / "rootstock"
+    root.mkdir(parents=True)
+    os.chmod(root, 0o2775)
+    os.chmod(parent, 0o750)
+
+    rc = cmd_check_perms(_args(root=str(root)))
+    assert rc == 1
+    assert "not world-traversable" in capsys.readouterr().out
+
+
+def test_json_report(tmp_path: Path, monkeypatch, capsys):
+    monkeypatch.setattr(perms, "_run_getfacl", lambda path: None)
+    _world_traversable_ancestors(monkeypatch)
+    root = _make_clean_root(tmp_path)
+
+    rc = cmd_check_perms(_args(root=str(root), json=True))
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["issues"] == []
+    assert payload["install_root"] == str(root)
+
+
+def test_cluster_resolves_split_roots(monkeypatch):
+    checked = {}
+
+    def fake_check(install_root, cache_root=None, **kwargs):
+        checked["install"] = install_root
+        checked["cache"] = cache_root
+        return []
+
+    monkeypatch.setattr("rootstock.commands.check_perms.check_permissions", fake_check)
+
+    rc = cmd_check_perms(_args(cluster="perlmutter"))
+    assert rc == 0
+    assert checked["install"] == Path("/global/cfs/cdirs/m4845/rootstock")
+    assert checked["cache"] == Path("/pscratch/sd/w/wengler/rootstock-cache")
+
+
+def test_unknown_cluster_errors(capsys):
+    rc = cmd_check_perms(_args(cluster="nope"))
+    assert rc == 2
+    assert "Unknown cluster" in capsys.readouterr().err
+
+
+def test_missing_root_and_cluster_errors(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "rootstock.commands.check_perms.load_config",
+        lambda: SimpleNamespace(root=None),
+    )
+    rc = cmd_check_perms(_args())
+    assert rc == 2
+    assert "install root" in capsys.readouterr().err

--- a/tests/test_perms.py
+++ b/tests/test_perms.py
@@ -146,3 +146,47 @@ def test_check_acl_flags_missing_default_and_mask_clamp(tmp_path: Path, monkeypa
     problems = " ".join(i.problem for i in issues)
     assert "no default ACL" in problems
     assert "mask clamps" in problems
+
+
+# --------------------------------------------------------------------------- #
+# ancestor traversal
+# --------------------------------------------------------------------------- #
+
+
+def test_ancestor_lacking_world_x_flagged(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(perms, "_run_getfacl", lambda path: None)
+    parent = tmp_path / "project"
+    root = parent / "rootstock"
+    root.mkdir(parents=True)
+    os.chmod(root, 0o2775)
+    os.chmod(parent, 0o750)  # the ALCF failure mode: project dir blocks outsiders
+
+    issues = check_permissions(root, include_ancestors=True)
+    assert any(i.path == parent.resolve() and "not world-traversable" in i.problem for i in issues)
+
+
+def test_ancestors_not_checked_by_default(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(perms, "_run_getfacl", lambda path: None)
+    parent = tmp_path / "project"
+    root = parent / "rootstock"
+    root.mkdir(parents=True)
+    os.chmod(root, 0o2775)
+    os.chmod(parent, 0o750)
+
+    assert check_permissions(root) == []
+
+
+def test_shared_ancestors_reported_once_for_split_cache(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(perms, "_run_getfacl", lambda path: None)
+    parent = tmp_path / "project"
+    install = parent / "rootstock"
+    cache = parent / "rootstock-cache"
+    install.mkdir(parents=True)
+    cache.mkdir()
+    os.chmod(install, 0o2775)
+    os.chmod(cache, 0o2755)
+    os.chmod(parent, 0o750)
+
+    issues = check_permissions(install, cache, include_ancestors=True)
+    flagged = [i for i in issues if i.path == parent.resolve()]
+    assert len(flagged) == 1


### PR DESCRIPTION
Pulling out a permissions checking utility as I make a deeper runbook to check permissions across clusters. Adds a `rootstock check-perms` command