### PR TITLE
Fix HuggingFace token handling in rootstock add

### DIFF
--- a/rootstock/environment.py
+++ b/rootstock/environment.py
@@ -94,6 +94,13 @@ def get_model_cache_env(root: Path, cache_root: Path | None = None) -> dict[str,
     }
     for var, default in per_user_defaults.items():
         env[var] = os.environ.get(var) or str(default)
+
+    # Preserve HuggingFace authentication tokens from the caller's environment.
+    # These allow access to gated models.
+    for auth_var in ("HF_TOKEN", "HF_USER_ACCESS_TOKEN"):
+        if auth_var in os.environ:
+            env[auth_var] = os.environ[auth_var]
+
     return env
 
 

--- a/tests/cache/test_cache_root.py
+++ b/tests/cache/test_cache_root.py
@@ -109,6 +109,29 @@ def test_shared_read_redirects_unaffected_by_user_cache(monkeypatch, tmp_path: P
     assert out["HF_HUB_CACHE"] == "/cache/cache/huggingface/hub"
 
 
+def test_hf_token_preserved_from_environment(monkeypatch):
+    """HF_TOKEN is preserved to allow access to gated models."""
+    monkeypatch.setenv("HF_TOKEN", "hf_fake_token_12345")
+    out = get_model_cache_env(Path("/install"))
+    assert out["HF_TOKEN"] == "hf_fake_token_12345"
+
+
+def test_hf_user_access_token_preserved_from_environment(monkeypatch):
+    """HF_USER_ACCESS_TOKEN is preserved for authentication."""
+    monkeypatch.setenv("HF_USER_ACCESS_TOKEN", "hf_user_token_67890")
+    out = get_model_cache_env(Path("/install"))
+    assert out["HF_USER_ACCESS_TOKEN"] == "hf_user_token_67890"
+
+
+def test_hf_tokens_not_added_when_not_set(monkeypatch):
+    """HF tokens are not added if not already in the environment."""
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.delenv("HF_USER_ACCESS_TOKEN", raising=False)
+    out = get_model_cache_env(Path("/install"))
+    assert "HF_TOKEN" not in out
+    assert "HF_USER_ACCESS_TOKEN" not in out
+
+
 # ---------- Cluster registry ---------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Fixes `rootstock add` not picking up HuggingFace tokens for gated model access. When downloading or verifying checkpoints, the subprocess environment wasn't preserving `HF_TOKEN` or `HF_USER_ACCESS_TOKEN` from the caller.

## Changes

- Modified `get_model_cache_env()` to explicitly preserve HuggingFace authentication tokens from the caller's environment
- Added tests to verify tokens are preserved and not added when not present

## Test plan

- New tests verify that `HF_TOKEN` and `HF_USER_ACCESS_TOKEN` are preserved from the environment
- All existing cache and add command tests pass (31 cache tests, 26 add-related tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)