### PR TITLE
Rebuild worker Atoms cache on species or PBC change

### DIFF
--- a/rootstock/worker.py
+++ b/rootstock/worker.py
@@ -90,11 +90,21 @@ class MLIPWorker:
         Create or update ASE Atoms object.
 
         On first call, creates a new Atoms object.
-        On subsequent calls, updates positions and cell in place.
+        On subsequent calls, updates positions and cell in place — unless the
+        INIT-supplied species or PBC no longer match the cached Atoms, in
+        which case the object is rebuilt. Comparing against the cached values
+        (not just the atom count) matters: the server re-sends INIT every
+        cycle, so a same-count composition or PBC change must not silently
+        reuse the old system.
         """
         from ase import Atoms
 
-        if self._atoms is None or len(self._atoms) != len(positions):
+        pbc = self._pbc if self._pbc is not None else [True, True, True]
+        if (
+            self._atoms is None
+            or not np.array_equal(self._atoms.numbers, self._atomic_numbers)
+            or not np.array_equal(self._atoms.pbc, pbc)
+        ):
             # Need to create new Atoms object
             if self._atomic_numbers is None:
                 raise RuntimeError(
@@ -105,7 +115,7 @@ class MLIPWorker:
                 numbers=self._atomic_numbers,
                 positions=positions,
                 cell=cell,
-                pbc=self._pbc if self._pbc is not None else [True, True, True],
+                pbc=pbc,
             )
             self._atoms.calc = self._calculator
         else:

--- a/tests/worker/test_atoms_cache.py
+++ b/tests/worker/test_atoms_cache.py
@@ -1,0 +1,77 @@
+"""Tests for MLIPWorker._create_atoms cache invalidation.
+
+The server re-sends INIT (numbers + pbc) every force cycle; the worker's
+cached Atoms must be rebuilt whenever those differ from what it holds, not
+only when the atom count changes.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from rootstock.worker import MLIPWorker
+
+
+def _make_worker(numbers: list[int] | None, pbc: list[bool] | None = None) -> MLIPWorker:
+    worker = MLIPWorker(socket_name="test", calculator=None)
+    worker._atomic_numbers = numbers
+    worker._pbc = pbc
+    return worker
+
+
+def _positions(n: int) -> np.ndarray:
+    return np.arange(n * 3, dtype=float).reshape(n, 3)
+
+
+CELL = np.eye(3) * 10.0
+
+
+def test_first_call_builds_atoms_from_init_data():
+    worker = _make_worker([1, 8], pbc=[True, False, True])
+    atoms = worker._create_atoms(_positions(2), CELL)
+    assert list(atoms.numbers) == [1, 8]
+    assert list(atoms.pbc) == [True, False, True]
+
+
+def test_unchanged_system_reuses_atoms_in_place():
+    worker = _make_worker([1, 1])
+    atoms1 = worker._create_atoms(_positions(2), CELL)
+    new_positions = _positions(2) + 1.0
+    atoms2 = worker._create_atoms(new_positions, CELL * 2)
+    assert atoms2 is atoms1  # fast path: same object, updated in place
+    np.testing.assert_array_equal(atoms2.positions, new_positions)
+    np.testing.assert_array_equal(atoms2.cell[:], CELL * 2)
+
+
+def test_same_count_composition_change_rebuilds():
+    worker = _make_worker([1, 1])
+    worker._create_atoms(_positions(2), CELL)
+
+    worker._atomic_numbers = [1, 8]  # same count, different species
+    atoms = worker._create_atoms(_positions(2), CELL)
+    assert list(atoms.numbers) == [1, 8]
+
+
+def test_pbc_change_rebuilds():
+    worker = _make_worker([1, 1], pbc=[True, True, True])
+    worker._create_atoms(_positions(2), CELL)
+
+    worker._pbc = [False, False, False]  # same species, different pbc
+    atoms = worker._create_atoms(_positions(2), CELL)
+    assert list(atoms.pbc) == [False, False, False]
+
+
+def test_atom_count_change_rebuilds():
+    worker = _make_worker([1, 1])
+    worker._create_atoms(_positions(2), CELL)
+
+    worker._atomic_numbers = [1, 1, 8]
+    atoms = worker._create_atoms(_positions(3), CELL)
+    assert list(atoms.numbers) == [1, 1, 8]
+
+
+def test_missing_numbers_raises():
+    worker = _make_worker(None)
+    with pytest.raises(RuntimeError, match="No atomic numbers"):
+        worker._create_atoms(_positions(2), CELL)


### PR DESCRIPTION
## Summary

First of the [#77](https://github.com/Garden-AI/rootstock/issues/77) worker-hardening series (one PR per checklist item).

`MLIPWorker._create_atoms` only rebuilt the cached `Atoms` object when the atom *count* changed, so a same-count composition change or a PBC change silently computed forces for the **old** species/PBC. The server re-sends INIT with fresh `numbers`/`pbc` every force cycle and the worker stores them — but the reuse path never compared them. This is the one outright correctness bug on the frozen worker path.

## Changes

- `_create_atoms` now compares the INIT-supplied `numbers` and `pbc` against the cached `Atoms` and rebuilds on any mismatch. The in-place fast path (positions/cell update, preserving neighbor lists etc.) is unchanged for the common case where the system is the same.
- New `tests/worker/test_atoms_cache.py` covering: first build, in-place reuse (object identity), same-count composition change, PBC change, count change, and the missing-INIT error.

## Test plan

- `uv run pytest tests/` — 168 passed (162 pre-existing + 6 new)
- `uv run ruff check` / `ruff format --check` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)