### PR TITLE
Make run_worker tolerate unknown keyword arguments

### DIFF
--- a/rootstock/worker.py
+++ b/rootstock/worker.py
@@ -244,6 +244,7 @@ def run_worker(
     socket_path: str,
     setup_kwargs: dict | None = None,
     log=None,
+    **_ignored,
 ):
     """
     Run worker with a provided setup function.
@@ -260,8 +261,17 @@ def run_worker(
         socket_path: Full Unix socket path to connect to
         setup_kwargs: Extra keyword arguments forwarded to setup_fn
         log: Optional logging file object
+        **_ignored: Unknown options are ignored. Workers are frozen inside
+            built envs, so a newer client passing a new option must not
+            TypeError against an already-deployed worker.
     """
     setup_kwargs = setup_kwargs or {}
+    if _ignored and log:
+        print(
+            f"[Worker] Ignoring unknown run_worker options: {sorted(_ignored)}",
+            file=log,
+            flush=True,
+        )
     if log:
         print(
             f"[Worker] Calling setup({checkpoint!r}, {device!r}, **{setup_kwargs!r})",

--- a/tests/worker/test_run_worker_forward_compat.py
+++ b/tests/worker/test_run_worker_forward_compat.py
@@ -1,0 +1,44 @@
+"""run_worker must tolerate options it doesn't know about.
+
+Workers are frozen inside built envs; a newer client passing a new kwarg
+must not TypeError against an already-deployed worker.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from rootstock.worker import run_worker
+
+
+def _bail_out_setup(checkpoint, device, **kwargs):
+    # Short-circuit before any socket work — signature acceptance is the test.
+    raise SystemExit(0)
+
+
+def test_run_worker_ignores_unknown_kwargs():
+    with pytest.raises(SystemExit):
+        run_worker(
+            setup_fn=_bail_out_setup,
+            checkpoint="mace-mp-0-medium",
+            device="cpu",
+            socket_path="/tmp/does_not_matter",
+            option_from_the_future=True,
+            another_new_option={"nested": 1},
+        )
+
+
+def test_run_worker_logs_ignored_kwargs():
+    log = io.StringIO()
+    with pytest.raises(SystemExit):
+        run_worker(
+            setup_fn=_bail_out_setup,
+            checkpoint="mace-mp-0-medium",
+            device="cpu",
+            socket_path="/tmp/does_not_matter",
+            log=log,
+            option_from_the_future=True,
+        )
+    assert "option_from_the_future" in log.getvalue()


### PR DESCRIPTION
## Summary

Part of the [#77](https://github.com/Garden-AI/rootstock/issues/77) worker-hardening series.

`run_worker` is the wrapper-script entry point baked into every built env. Its signature is frozen per env, so a future client passing a new option would get an opaque `TypeError` from every already-deployed worker. This adds a `**_ignored` catch-all: unknown options are dropped (and logged when a log file is attached), so new client options degrade gracefully against old envs.

## Test plan

- `uv run pytest tests/` — 164 passed (2 new: signature acceptance + logging of ignored options)
- `uv run ruff check` / `ruff format --check` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)