### PR TITLE
Abort the worker on unknown protocol messages

### DIFF
--- a/rootstock/worker.py
+++ b/rootstock/worker.py
@@ -229,7 +229,15 @@ class MLIPWorker:
                     state = "NEEDINIT"
 
                 else:
-                    self._log(f"Unknown message: {msg}")
+                    # The wire format is untagged 12-byte headers followed by
+                    # raw payloads; an unrecognized message means the stream
+                    # is desynced and every subsequent read would be garbage.
+                    self._log(f"Unknown message: {msg!r}, aborting")
+                    raise RuntimeError(
+                        f"Unknown protocol message {msg!r}: the i-PI byte stream is "
+                        "desynced (or the peer speaks a newer protocol); aborting "
+                        "rather than reading garbage."
+                    )
 
         finally:
             if self._socket:

--- a/tests/worker/test_unknown_message.py
+++ b/tests/worker/test_unknown_message.py
@@ -1,0 +1,41 @@
+"""An unknown protocol message must kill the worker, not be skipped.
+
+The wire format is untagged 12-byte headers followed by raw payloads, so an
+unrecognized message means the stream is desynced; logging and continuing
+(the old behavior) yields garbage reads or a hang.
+"""
+
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from rootstock.protocol import IPIProtocol
+from rootstock.worker import MLIPWorker
+
+
+def _wired_worker() -> tuple[MLIPWorker, IPIProtocol]:
+    """Worker pre-wired to one end of a socketpair; no real connect."""
+    server_sock, worker_sock = socket.socketpair()
+    worker = MLIPWorker(socket_name="test", calculator=None)
+    worker._socket = worker_sock
+    worker._protocol = IPIProtocol(worker_sock)
+    worker._connect = lambda: None
+    return worker, IPIProtocol(server_sock)
+
+
+def test_unknown_message_raises():
+    worker, server = _wired_worker()
+    server.sendmsg("BOGUSMSG")
+    with pytest.raises(RuntimeError, match="BOGUSMSG"):
+        worker.run()
+
+
+def test_known_messages_still_handled():
+    """Sanity check: STATUS/EXIT round-trip still works after the change."""
+    worker, server = _wired_worker()
+    server.sendmsg("STATUS")
+    server.sendmsg("EXIT")
+    worker.run()  # returns cleanly on EXIT
+    assert server.recvmsg() == "NEEDINIT"


### PR DESCRIPTION
## Summary

Part of the [#77](https://github.com/Garden-AI/rootstock/issues/77) worker-hardening series.

The worker's message loop logged `Unknown message: ...` and kept reading. The i-PI wire format is untagged 12-byte headers followed by raw numpy payloads, so an unrecognized message means the stream is desynced — every subsequent read is garbage or a hang. The worker now raises `RuntimeError` with a clear message instead; the worker process exits nonzero and the server sees the socket close.

This also locks in the right forward-compatibility posture for the frozen worker: new message types are never a valid extension channel (new INIT JSON keys / env vars / FORCEREADY extras are), so a 1.0 worker refusing loudly is correct by policy, not just defensively.

## Test plan

- `uv run pytest tests/` — 164 passed (2 new: unknown message raises with the offending bytes named; STATUS/EXIT round-trip over a socketpair still works)
- `uv run ruff check` / `ruff format --check` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)