### PR TITLE
Document the private i-PI dialect as a frozen contract

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,4 +27,45 @@ Rootstock uses the [i-PI protocol](http://ipi-code.org/) for communication betwe
 3. Worker sends back energy, forces, and stress
 4. Main process receives results and returns them to ASE
 
-The protocol is text-based and designed for interoperability between simulation codes.
+Commands are 12-byte ASCII strings; payloads are raw numpy buffers in
+atomic units, following ASE's `ase.calculators.socketio` implementation.
+
+### Deviations from standard i-PI
+
+**Rootstock speaks a private dialect of the i-PI protocol.** The wire
+framing is standard, but the semantics deviate in two load-bearing ways.
+Read this before trying to point any other i-PI implementation at a
+rootstock worker.
+
+**The INIT payload is required, and it is JSON.** Standard i-PI transmits
+only geometry (cell and positions); a force engine is expected to already
+know its chemical species from its own input. A rootstock worker hosts a
+generic ASE calculator and knows nothing about the system at spawn time, so
+the server packs the species into the INIT message's free-form init string
+as UTF-8 JSON:
+
+```json
+{"numbers": [1, 1, 8], "pbc": [true, true, true]}
+```
+
+A worker that has not received this payload fails at the first POSDATA.
+Unknown keys in the JSON object are ignored, which makes new keys a
+sanctioned forward-compatible extension channel.
+
+**The worker demands INIT before every force evaluation.** After each
+FORCEREADY the worker returns to NEEDINIT rather than READY, and the server
+re-sends the JSON INIT every cycle. This is how composition and PBC changes
+propagate mid-run (e.g. LAMMPS `fix gcmc` alongside `fix rootstock`).
+
+Consequences:
+
+- A standard i-PI server — i-PI itself, ASE's `SocketIOCalculator`, or any
+  other implementation — **cannot drive a rootstock worker**: it won't send
+  the JSON INIT payload, so the worker aborts at the first force request.
+- The supported protocol peers are exactly `RootstockServer` (the ASE
+  calculator path and `rootstock serve`'s counterpart) and
+  `lammps/fix_rootstock.cpp` (which implements the dialect natively,
+  including the per-cycle INIT).
+- This is a deliberate, documented limitation of 1.0. The worker side of the
+  protocol is frozen inside every built environment, so the requirement
+  cannot be relaxed for environments that have already been deployed.

--- a/rootstock/cli.py
+++ b/rootstock/cli.py
@@ -226,9 +226,7 @@ def main():
         ),
     )
     smoke_parser.add_argument("--env", help="Filter to a single environment")
-    smoke_parser.add_argument(
-        "--checkpoint", help="Filter to a single checkpoint (requires --env)"
-    )
+    smoke_parser.add_argument("--checkpoint", help="Filter to a single checkpoint (requires --env)")
     smoke_parser.add_argument("--device", default="cuda", help="Device (default: cuda)")
     smoke_parser.add_argument("--json", action="store_true", help="Emit a JSON summary")
     smoke_parser.add_argument(
@@ -328,8 +326,15 @@ def main():
     # serve command
     serve_parser = subparsers.add_parser(
         "serve",
-        help="Start a worker for an external i-PI server",
-        description="Start a rootstock worker that connects to a Unix socket.",
+        help="Start a worker for a server speaking the rootstock i-PI dialect",
+        description=(
+            "Start a rootstock worker that connects to a Unix socket. The peer "
+            "must speak the rootstock i-PI dialect (JSON INIT payload, re-sent "
+            "every force cycle) — a standard i-PI server cannot drive it; see "
+            "the 'Deviations from standard i-PI' section of the architecture "
+            "docs. Known dialect peers: RootstockCalculator and the LAMMPS "
+            "fix_rootstock."
+        ),
     )
     serve_parser.add_argument(
         "checkpoint",


### PR DESCRIPTION
## Summary

Part of the [#77](https://github.com/Garden-AI/rootstock/issues/77) worker-hardening series. Docs-only (plus argparse help strings) — resolves the "document (or soften) the private i-PI dialect" item on the side of **document**: with no users asking to drive workers from other i-PI implementations, a compatibility fallback is speculation we can skip; the deviation just needs to be stated where people will trip over it.

## What it documents

Rootstock's wire framing is standard i-PI, but the semantics deviate in two load-bearing ways:

1. **The INIT payload is required and is JSON** (`{"numbers": [...], "pbc": [...]}`). Standard i-PI never transmits species; a rootstock worker can't build its ASE `Atoms` without them and fails at the first POSDATA. Unknown JSON keys are ignored (the sanctioned extension channel).
2. **The worker returns to NEEDINIT after every FORCEREADY**, so the server re-sends INIT each cycle — this is how mid-run composition/PBC changes propagate (e.g. `fix gcmc` alongside `fix rootstock`).

Consequence, now stated explicitly: no standard i-PI server can drive a rootstock worker; the supported peers are exactly `RootstockServer` and `lammps/fix_rootstock.cpp`.

## Changes

- New "Deviations from standard i-PI" section in `docs/architecture.md` (and corrected the claim that the protocol is "text-based and designed for interoperability").
- `rootstock serve --help` no longer advertises "an external i-PI server" — it names the dialect requirement and the known peers.

## Test plan

- `uv run pytest tests/` — 162 passed (no behavior change)
- `uv run rootstock serve --help` renders the new description
- `uv run ruff check` / `ruff format --check` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)