### PR TITLE
Remove the dead MLIPWorker.socket_name parameter

### DIFF
--- a/rootstock/worker.py
+++ b/rootstock/worker.py
@@ -22,7 +22,6 @@ from .protocol import (
     IPIProtocol,
     SocketClosed,
     connect_unix_socket,
-    create_unix_socket_path,
 )
 
 if TYPE_CHECKING:
@@ -45,25 +44,19 @@ class MLIPWorker:
 
     def __init__(
         self,
-        socket_name: str,
         calculator: "Calculator",
+        socket_path: str,
         log=None,
-        socket_path: str | None = None,
     ):
         """
         Initialize the worker.
 
         Args:
-            socket_name: Name of Unix socket to connect to (used if socket_path not given)
             calculator: Pre-loaded ASE calculator
+            socket_path: Full Unix socket path to connect to
             log: Optional file object for logging
-            socket_path: Full Unix socket path (overrides socket_name if provided)
         """
-        self.socket_name = socket_name
-        if socket_path is not None:
-            self.socket_path = socket_path
-        else:
-            self.socket_path = create_unix_socket_path(socket_name)
+        self.socket_path = socket_path
         self.log = log
 
         self._calculator = calculator
@@ -319,9 +312,8 @@ def run_worker(
         print(f"[Worker] Calculator loaded: {type(calculator).__name__}", file=log, flush=True)
 
     worker = MLIPWorker(
-        socket_name="rootstock",
         calculator=calculator,
-        log=log,
         socket_path=socket_path,
+        log=log,
     )
     worker.run()

--- a/tests/worker/test_atoms_cache.py
+++ b/tests/worker/test_atoms_cache.py
@@ -14,7 +14,7 @@ from rootstock.worker import MLIPWorker
 
 
 def _make_worker(numbers: list[int] | None, pbc: list[bool] | None = None) -> MLIPWorker:
-    worker = MLIPWorker(socket_name="test", calculator=None)
+    worker = MLIPWorker(calculator=None, socket_path="/tmp/unused")
     worker._atomic_numbers = numbers
     worker._pbc = pbc
     return worker

--- a/tests/worker/test_error_reporting.py
+++ b/tests/worker/test_error_reporting.py
@@ -38,7 +38,7 @@ class StubCalculator:
 def _run_one_force_call(calculator) -> tuple[float, np.ndarray, np.ndarray, bytes]:
     """Drive a worker through INIT -> POSDATA -> GETFORCE -> EXIT."""
     server_sock, worker_sock = socket.socketpair()
-    worker = MLIPWorker(socket_name="test", calculator=calculator)
+    worker = MLIPWorker(calculator=calculator, socket_path="/tmp/unused")
     worker._socket = worker_sock
     worker._protocol = IPIProtocol(worker_sock)
     worker._connect = lambda: None
@@ -88,7 +88,7 @@ def test_worker_survives_a_failed_calculation():
 
     calc.get_potential_energy = flaky_energy
 
-    worker = MLIPWorker(socket_name="test", calculator=calc)
+    worker = MLIPWorker(calculator=calc, socket_path="/tmp/unused")
     worker._socket = worker_sock
     worker._protocol = IPIProtocol(worker_sock)
     worker._connect = lambda: None

--- a/tests/worker/test_unknown_message.py
+++ b/tests/worker/test_unknown_message.py
@@ -18,7 +18,7 @@ from rootstock.worker import MLIPWorker
 def _wired_worker() -> tuple[MLIPWorker, IPIProtocol]:
     """Worker pre-wired to one end of a socketpair; no real connect."""
     server_sock, worker_sock = socket.socketpair()
-    worker = MLIPWorker(socket_name="test", calculator=None)
+    worker = MLIPWorker(calculator=None, socket_path="/tmp/unused")
     worker._socket = worker_sock
     worker._protocol = IPIProtocol(worker_sock)
     worker._connect = lambda: None


### PR DESCRIPTION
## Summary

Part of the [#77](https://github.com/Garden-AI/rootstock/issues/77) worker-hardening series.

`run_worker` — the only place `MLIPWorker` is constructed — always passes an explicit `socket_path`, so the `socket_name` fallback (`create_unix_socket_path(socket_name)`) never executes and `socket_name="rootstock"` is vestigial. Since `MLIPWorker` freezes inside built envs at 1.0, the dead parameter goes now or lives forever. `socket_path` becomes required.

Now rebased onto main with the tests from #82/#84/#86 updated to the new `(calculator, socket_path)` signature.

> **Merge order note:** merge **after #85** — its test file also constructs `MLIPWorker(socket_name=...)` on its own branch, and no single constructor call satisfies both the old and new signatures. Once #85 lands I'll rebase and fix that one line.

## Test plan

- `uv run pytest tests/` — 196 passed, 1 skipped
- `uv run ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
