### PR TITLE
Add AMD/ROCm configs and workshop for ORNL Frontier

### DIFF
--- a/sample_model_configurations/_agent/failure_modes.md
+++ b/sample_model_configurations/_agent/failure_modes.md
@@ -258,6 +258,222 @@ that prevents uv from resolving it, even though the package itself works fine.
 
 ---
 
+# AMD / ROCm (droplet_workshop, targeting Frontier)
+
+## pytorch-triton-rocm not found on PyPI
+
+**Signature:** `No solution found ... Because there is no version of
+pytorch-triton-rocm==3.5.1 and torch==2.9.1+rocm6.4 depends on
+pytorch-triton-rocm==3.5.1, we can conclude that your requirements are
+unsatisfiable.`
+**Cause:** ROCm torch depends on `pytorch-triton-rocm`, which is published
+*only* on the PyTorch ROCm index, never on PyPI. With `explicit = true` on the
+index, only packages named in `[tool.uv.sources]` are drawn from it — so the
+transitive triton dep was looked up on PyPI and not found. A `[tool.uv.sources]`
+entry alone does NOT fix this: uv only applies sources to packages that appear
+in `dependencies`.
+**Fix:** List `pytorch-triton-rocm` as a *direct* dependency in the PEP 723
+block AND map it in `[tool.uv.sources]`. No CUDA analog: `triton` is on PyPI,
+so this failure cannot occur on NVIDIA.
+
+## Index shadowing silently downgrades packages (DANGEROUS)
+
+**Signature:** No error at all. The env builds, but resolves e.g.
+`torchmetrics==1.0.3` instead of `1.9.0`.
+**Cause:** "Fixing" the triton failure by dropping `explicit = true` makes the
+ROCm index a general-purpose index. It mirrors an old subset of PyPI, and uv
+takes each package from the first index that carries it — so unrelated packages
+silently resolve to stale versions. This produces a *working* env running
+different library code: the worst class of bug for reproducible science.
+**Fix:** Keep `explicit = true`. Never relax index isolation to fix a missing
+package; add the package as a direct dep instead (see above).
+
+## Lockfile install can't find pinned versions on the ROCm index
+
+**Signature:** `Because there is no version of filelock==3.29.7 and you require
+filelock==3.29.7 ...` — during `uv pip install -r <lock>`, after `uv export`
+succeeded. Hint text mentions `--index-strategy unsafe-best-match`.
+**Cause:** `uv export --script` honors the PEP 723 index rules, but the emitted
+lockfile carries only pinned versions. At install time uv again takes each
+package from the first index that carries it *at all* — and the ROCm index
+mirrors an old `filelock`/`sympy`/etc., which don't match the pins.
+**Fix:** Pass the config's index URLs plus `--index-strategy unsafe-best-match`
+to the install. Safe here precisely because the lock pins exact versions that
+were already resolved under the strict `explicit` rules.
+
+## ROCm torch wheel is ~4.2 GB (15+ GB installed)
+
+**Signature:** `No space left on device (os error 28)` mid-install, often as
+`Failed to clone .../torch/lib/libaotriton_v2.so`.
+**Cause:** ROCm torch fat-binaries kernels for many gfx targets and bundles the
+ROCm math libraries: ~2x the CUDA wheel. One venv is ~15-17 GB installed.
+**Fix:** Put the venv root AND the uv cache on a large volume, not the
+container/boot disk. Budget ~15-17 GB per env plus ~20 GB of shared wheel cache.
+
+## torch-scatter / torch-sparse on ROCm: no wheels, must source-build
+
+**Signature:** uv/pip cannot resolve `torch-scatter` on ROCm; `data.pyg.org`
+serves only `+cuXXX` wheels (any rocm URL there 404s/403s).
+**Cause:** The PyG project publishes CUDA wheels only — their build matrix
+(torch x python x CUDA) already explodes, and ROCm isn't in it. AMD ships fat
+ROCm wheels for *torch*, but nobody ships them for the third-party C++
+extensions.
+**Fix:** Source-build. VERIFIED WORKING on MI300X — full recipe below. The
+resulting .so carries both gfx90a and gfx942, so ONE artifact serves Frontier
+(MI250X) and MI300X. You do NOT need an MI250X to compile for one.
+
+    # 1. Toolchain must MATCH the torch wheel's ROCm major.minor.
+    #    A stock ROCm 5.7 hipcc CANNOT compile torch-2.9/rocm6.4 sources.
+    apt install hipcc hip-dev rocm-llvm rocm-device-libs rocm-core  # from repo.radeon.com/rocm/apt/6.4
+    export ROCM_PATH=/opt/rocm-6.4.0 HIP_PATH=/opt/rocm-6.4.0
+    export PATH=$ROCM_PATH/bin:$ROCM_PATH/llvm/bin:$PATH
+
+    # 2. Build for BOTH arches: Frontier's MI250X and the build box's MI300X.
+    export PYTORCH_ROCM_ARCH="gfx90a;gfx942"
+
+    # 3. Install from GIT, not PyPI (see warp-mask entry below).
+    pip install --no-build-isolation \
+      "torch-scatter @ git+https://github.com/rusty1s/pytorch_scatter.git"
+
+Verify with `check_isa.py <env> --require gfx90a`, and confirm the GPU op is
+actually correct — not merely importable:
+
+    torch_scatter.scatter_add(torch.tensor([1.,2.,3.,4.], device="cuda"),
+                              torch.tensor([0,0,1,1],   device="cuda"))
+    # -> [3.0, 7.0]
+
+## torch-scatter PyPI release assumes 32-lane CUDA warps (breaks on AMD)
+
+**Signature:** Source build fails with
+`static assertion failed due to requirement 'sizeof(unsigned int) == 8':
+The mask must be a 64-bit integer.` in
+`amd_warp_sync_functions.h`, from `__shfl_up_sync<unsigned int, __half>`
+instantiated at `csrc/hip/../hip/utils.cuh:13`.
+**Cause:** A HARDWARE MODEL MISMATCH, not packaging. NVIDIA executes in warps
+of 32 threads, so a warp-shuffle's lane mask is a 32-bit int. AMD executes in
+wavefronts of 64 threads, so the mask must be 64-bit. torch-scatter's released
+source hardcodes CUDA's `unsigned int` mask; ROCm 6.4 added a static_assert
+that rejects it. (ROCm 5.7 didn't assert, but failed differently — ambiguous
+`__shfl_up` overloads.)
+**Fix:** torch-scatter's **git main already fixes this** and the fix is
+UNRELEASED on PyPI:
+
+    #ifdef USE_ROCM
+      using warp_mask_t = unsigned long long;   // 64-lane wavefront
+    #else
+      using warp_mask_t = unsigned int;         // 32-lane warp
+    #endif
+
+So `pip install torch-scatter` is broken on ROCm while the repo is fine. Always
+install these PyG extensions from git on AMD. Expect the same class of bug in
+any CUDA kernel that hardcodes `0xffffffff` as a warp mask.
+
+## torch-sparse spmm SILENTLY COMPUTES WRONG NUMBERS on ROCm (do not ship)
+
+**Signature:** None. No error, no warning. It builds, imports, and returns
+plausible-looking numbers that are WRONG.
+
+    dense reference  : [[2, 2, 2], [7, 7, 7]]
+    torch_sparse CPU : [[2, 2, 2], [7, 7, 7]]   correct
+    torch_sparse GPU : [[2, 2, 2], [2, 2, 2]]   WRONG
+    random 64x64 spmm: max|GPU - dense| = 12.47
+
+**Cause:** The deeper half of the warp-width problem, and it is SEMANTIC, not a
+type error. Fixing the 32->64-bit mask type (see the warp-mask entry above) only
+silences the compiler. torch-sparse's `spmm` kernel is *algorithmically built
+around a 32-lane warp*: it has a warp cooperatively reduce one row of the sparse
+matrix via shuffles, looping over lanes. AMD wavefronts are **64** lanes, so the
+reduction spans the wrong thread set and drops contributions — row 1 above lost
+its second nonzero (3+4=7 became 2).
+
+**THE TRAP:** patch-until-it-compiles produces a working-looking install that
+corrupts the physics. The probe CANNOT catch this — energies and forces still
+come out, they are just wrong. Only a CPU-vs-GPU numerical comparison catches it.
+
+**Fix:** Do NOT ship torch-sparse on ROCm on the strength of a successful build.
+Either (a) confirm the model never calls `torch_sparse.spmm` (many MLIPs pull
+torch-sparse in as a transitive dep of PyG but only ever use torch-scatter), or
+(b) rewrite the spmm kernel for a 64-lane wavefront (`warpSize` is not 32 on
+AMD), or (c) force the CPU/fallback path for spmm.
+
+**ALWAYS numerically validate a source-built GPU extension against CPU.** Not
+"does it import", not "does the probe pass" — compare the numbers:
+
+    cpu = op(src, idx)
+    gpu = op(src.cuda(), idx.cuda()).cpu()
+    assert (cpu - gpu).abs().max() < 1e-4
+
+Verified on MI300X / torch 2.9.1+rocm6.4:
+  torch-scatter  CORRECT (scatter_add/mean/max, segment_csr; max err ~5e-6)
+  torch-cluster  CORRECT (radius_graph edge-identical to CPU)
+  torch-sparse   WRONG   (spmm)
+
+## gfx942-only extension: works on MI300X, dies on Frontier
+
+**Signature:** Extension builds and probes fine on the MI300X box, then on
+Frontier: `HSA_STATUS_ERROR_INVALID_ISA`, "invalid device function", or a
+segfault at first kernel launch.
+**Cause:** A source build targets only the build host's arch (gfx942) unless
+told otherwise. Official torch wheels are unaffected — they are fat binaries
+carrying gfx90a (verified: 23/23 fat libs in the mace env).
+**Fix:** `PYTORCH_ROCM_ARCH="gfx90a;gfx942"` before building, then gate on it —
+the probe CANNOT catch this, since the code runs fine on the build box:
+
+    python3 check_isa.py <env> --require gfx90a
+
+## CUDA torch wheel resolved on a ROCm box
+
+**Signature:** `torch.cuda.is_available()` returns False on a machine where
+`rocm-smi` shows the GPU; or import errors mentioning `libcudart.so` /
+`libnvrtc`.
+**Cause:** The config resolved torch from plain PyPI (a CUDA build) instead of
+the ROCm index.
+**Fix:** Add to the PEP 723 block: `[tool.uv.sources] torch = { index = "pytorch-rocm" }`
+plus `[[tool.uv.index]] name = "pytorch-rocm" url = "https://download.pytorch.org/whl/rocm6.4"
+explicit = true`. Note `--device cuda` is correct on ROCm — HIP devices are
+exposed under the `cuda` API; only the wheel source changes.
+
+## No ROCm wheels for torch-scatter / torch-sparse / torch-cluster
+
+**Signature:** `uv export` / install fails resolving `torch-scatter` against the
+rocm index, or only `+cuXXX` wheels are found on data.pyg.org.
+**Cause:** data.pyg.org publishes CUDA wheels only; there is no official ROCm
+build of the PyG C extensions.
+**Fix (in order):** (1) Try dropping torch-scatter/sparse entirely — PyG >= 2.3
+falls back to pure-torch scatter ops and many models work without them.
+(2) Source-build on the box with `PYTORCH_ROCM_ARCH="gfx90a;gfx942"` (both
+Frontier MI250X and droplet MI300X) and install with `--no-deps`.
+
+## gfx arch mismatch between droplet and Frontier
+
+**Signature:** Works on the MI300X droplet, but on MI250X:
+`HSA_STATUS_ERROR_INVALID_ISA`, "invalid device function", or instant
+segfault at first kernel launch.
+**Cause:** A source-built extension was compiled only for gfx942 (MI300X);
+Frontier's MI250X is gfx90a. Official torch ROCm wheels are multi-arch and
+unaffected — only locally-built extensions hit this.
+**Fix:** Rebuild with `PYTORCH_ROCM_ARCH="gfx90a;gfx942"`.
+
+## cuEquivariance / CUDA-only acceleration packages
+
+**Signature:** Install failure or import error for `cuequivariance*` on ROCm.
+**Cause:** NVIDIA-only package.
+**Fix:** Omit it. MACE and friends run on the pure e3nn/torch path (slower,
+but the configs never enabled acceleration anyway).
+
+## MIOpen cache writes at first inference
+
+**Signature:** First inference is slow or errors with MIOpen unable to write
+its cache in a read-only HOME.
+**Cause:** MIOpen (ROCm's cuDNN analog) writes kernel-tuning caches under
+`$HOME/.cache/miopen` — the ROCm analog of the CUDA_CACHE_PATH redirect
+rootstock already does.
+**Fix:** On the droplet the workshop's HOME redirect covers it. On Frontier,
+set `MIOPEN_USER_DB_PATH` / `MIOPEN_CACHE_DIR` to a writable per-user dir
+alongside rootstock's existing cache redirection.
+
+---
+
 ## How to read this file when porting a new MLIP
 
 1. Try the build / probe.

--- a/sample_model_configurations/amd_configs/chgnet.py
+++ b/sample_model_configurations/amd_configs/chgnet.py
@@ -1,0 +1,33 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "chgnet>=0.3.0",
+#     "ase>=3.22",
+#     "torch>=2.0",
+#     # torch's ROCm wheels depend on this; it lives only on the ROCm
+#     # index, so it must be a direct dep for [tool.uv.sources] to route it.
+#     "pytorch-triton-rocm",
+# ]
+#
+# [tool.uv.sources]
+# torch = { index = "pytorch-rocm" }
+# pytorch-triton-rocm = { index = "pytorch-rocm" }
+#
+# [[tool.uv.index]]
+# name = "pytorch-rocm"
+# url = "https://download.pytorch.org/whl/rocm6.4"
+# explicit = true
+# ///
+"""CHGNet env (ROCm) - pretrained charge-informed universal potentials on AMD GPUs."""
+
+CHECKPOINTS = {
+    "chgnet-default": "chgnet-default",
+}
+
+
+def setup(checkpoint: str, device: str = "cuda"):
+    from chgnet.model import CHGNet, CHGNetCalculator
+
+    model_name = CHECKPOINTS[checkpoint]
+    model = CHGNet.load() if model_name == "chgnet-default" else CHGNet.load(model_name)
+    return CHGNetCalculator(model=model, use_device=device)

--- a/sample_model_configurations/amd_configs/mace.py
+++ b/sample_model_configurations/amd_configs/mace.py
@@ -1,0 +1,47 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "mace-torch>=0.3.0",
+#     "ase>=3.22",
+#     "torch>=2.4.0,<2.10",
+#     # torch's ROCm wheels depend on this; it lives only on the ROCm
+#     # index, so it must be a direct dep for [tool.uv.sources] to route it.
+#     "pytorch-triton-rocm",
+# ]
+#
+# [tool.uv.sources]
+# torch = { index = "pytorch-rocm" }
+# pytorch-triton-rocm = { index = "pytorch-rocm" }
+#
+# [[tool.uv.index]]
+# name = "pytorch-rocm"
+# url = "https://download.pytorch.org/whl/rocm6.4"
+# explicit = true
+# ///
+"""MACE env (ROCm) - MACE-MP-0 and MACE-OFF23 on AMD GPUs.
+
+Identical to nvidia_configs/mace.py except torch resolves from the ROCm wheel
+index. PyTorch ROCm builds expose AMD GPUs as device="cuda", so setup() is
+unchanged. cuEquivariance acceleration is CUDA-only and is not used here  -
+MACE falls back to the pure e3nn/torch path.
+"""
+
+CHECKPOINTS = {
+    "mace-mp-0-small": "small",
+    "mace-mp-0-medium": "medium",
+    "mace-mp-0-large": "large",
+    "mace-off23-small": "off:small",
+    "mace-off23-medium": "off:medium",
+    "mace-off23-large": "off:large",
+}
+
+
+def setup(checkpoint: str, device: str = "cuda"):
+    arg = CHECKPOINTS[checkpoint]
+    if arg.startswith("off:"):
+        from mace.calculators import mace_off
+
+        return mace_off(model=arg[4:], device=device, default_dtype="float32")
+    from mace.calculators import mace_mp
+
+    return mace_mp(model=arg, device=device, default_dtype="float32")

--- a/sample_model_configurations/amd_configs/mattersim.py
+++ b/sample_model_configurations/amd_configs/mattersim.py
@@ -1,0 +1,32 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "mattersim>=1.1.0",
+#     "ase>=3.22",
+#     "torch>=2.0",
+#     # torch's ROCm wheels depend on this; it lives only on the ROCm
+#     # index, so it must be a direct dep for [tool.uv.sources] to route it.
+#     "pytorch-triton-rocm",
+# ]
+#
+# [tool.uv.sources]
+# torch = { index = "pytorch-rocm" }
+# pytorch-triton-rocm = { index = "pytorch-rocm" }
+#
+# [[tool.uv.index]]
+# name = "pytorch-rocm"
+# url = "https://download.pytorch.org/whl/rocm6.4"
+# explicit = true
+# ///
+"""MatterSim env (ROCm) - Microsoft's MatterSim universal potential on AMD GPUs."""
+
+CHECKPOINTS = {
+    "mattersim-v1-0-0-5m": "MatterSim-v1.0.0-5M",
+    "mattersim-v1-0-0-1m": "MatterSim-v1.0.0-1M",
+}
+
+
+def setup(checkpoint: str, device: str = "cuda"):
+    from mattersim.forcefield import MatterSimCalculator
+
+    return MatterSimCalculator(load_path=CHECKPOINTS[checkpoint], device=device)

--- a/sample_model_configurations/amd_configs/orb.py
+++ b/sample_model_configurations/amd_configs/orb.py
@@ -1,0 +1,80 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "orb-models>=0.4.0",
+#     "ase>=3.22",
+#     "torch>=2.0",
+#     # Not imported here - constrains orb-models' transitive dep (see
+#     # nvidia_configs/orb.py and Garden-AI/rootstock#67).
+#     "cached_path==1.8.10",
+#     # torch's ROCm wheels depend on this; it lives only on the ROCm
+#     # index, so it must be a direct dep for [tool.uv.sources] to route it.
+#     "pytorch-triton-rocm",
+# ]
+#
+# [tool.uv.sources]
+# torch = { index = "pytorch-rocm" }
+# pytorch-triton-rocm = { index = "pytorch-rocm" }
+#
+# [[tool.uv.index]]
+# name = "pytorch-rocm"
+# url = "https://download.pytorch.org/whl/rocm6.4"
+# explicit = true
+# ///
+"""Orb env (ROCm) - Orbital Materials' Orb universal potentials on AMD GPUs."""
+
+import os
+import shutil
+import urllib.request
+from pathlib import Path
+
+CHECKPOINTS = {
+    "orb-v2": "orb-v2",
+    "orb-d3-v2": "orb-d3-v2",
+    "orb-mptraj-only-v2": "orb-mptraj-only-v2",
+}
+
+
+def _default_weights_url(load_fn) -> str:
+    import inspect
+
+    default = inspect.signature(load_fn).parameters["weights_path"].default
+    if not isinstance(default, str) or not default.startswith(("http://", "https://")):
+        raise RuntimeError(
+            f"{load_fn.__name__} has no URL default for weights_path "
+            f"(got {default!r}); update this env file for the installed orb-models"
+        )
+    return default
+
+
+def _local_weights_path(url: str) -> Path:
+    cache = Path(os.environ.get("XDG_CACHE_HOME") or Path.home() / ".cache")
+    return cache / "orb" / os.path.basename(url)
+
+
+def _fetch(url: str, dest: Path) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_name(f"{dest.name}.tmp.{os.getpid()}")
+    try:
+        with urllib.request.urlopen(url) as resp, open(tmp, "wb") as out:
+            shutil.copyfileobj(resp, out)
+        os.replace(tmp, dest)
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def setup(checkpoint: str, device: str = "cuda"):
+    import torch
+    from orb_models.forcefield import pretrained
+    from orb_models.forcefield.calculator import ORBCalculator
+
+    fn_name = CHECKPOINTS[checkpoint].replace("-", "_")
+    load_fn = getattr(pretrained, fn_name)
+
+    url = _default_weights_url(load_fn)
+    weights = _local_weights_path(url)
+    if not weights.exists():
+        _fetch(url, weights)
+
+    orbff = load_fn(weights_path=str(weights), device=torch.device(device))
+    return ORBCalculator(orbff, device=torch.device(device))

--- a/sample_model_configurations/amd_configs/uma.py
+++ b/sample_model_configurations/amd_configs/uma.py
@@ -1,0 +1,39 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "fairchem-core>=2.20",
+#     "ase>=3.22",
+#     "torch>=2.4.0",
+#     # torch's ROCm wheels depend on this; it lives only on the ROCm
+#     # index, so it must be a direct dep for [tool.uv.sources] to route it.
+#     "pytorch-triton-rocm",
+# ]
+#
+# [tool.uv.sources]
+# torch = { index = "pytorch-rocm" }
+# pytorch-triton-rocm = { index = "pytorch-rocm" }
+#
+# [[tool.uv.index]]
+# name = "pytorch-rocm"
+# url = "https://download.pytorch.org/whl/rocm6.4"
+# explicit = true
+# ///
+"""UMA env (ROCm) - Meta's UMA foundation model via FAIRChem on AMD GPUs.
+
+fairchem-core v2 is a plain PyPI install (no torch-geometric/pyg-find-links),
+so the only ROCm change is the torch wheel index. Requires HF_TOKEN for the
+gated facebook/UMA checkpoints.
+"""
+
+CHECKPOINTS = {
+    "uma-s-1p1": "uma-s-1p1",
+    "uma-s-1p2": "uma-s-1p2",
+    "uma-m-1p1": "uma-m-1p1",
+}
+
+
+def setup(checkpoint: str, device: str = "cuda", task: str = "omat"):
+    from fairchem.core import FAIRChemCalculator, pretrained_mlip
+
+    predictor = pretrained_mlip.get_predict_unit(CHECKPOINTS[checkpoint], device=device)
+    return FAIRChemCalculator(predictor, task_name=task)

--- a/sample_model_configurations/amd_workshop/README.md
+++ b/sample_model_configurations/amd_workshop/README.md
@@ -1,0 +1,113 @@
+# AMD workshop - MLIP configs on ROCm, targeting Frontier
+
+The ROCm counterpart of `../modal_app.py`. Same philosophy - a workshop, not a
+validator: the artifact we ship is the config in `../amd_configs/`.
+
+**Why it exists.** Every cluster in the almanac is NVIDIA; ORNL's Frontier is
+AMD MI250X, and every config in `nvidia_configs/` hardcodes a CUDA wheel index.
+Modal has no AMD GPUs, so the Modal workshop cannot derive the ROCm equivalents.
+This workshop runs the same loop on a rented MI300X instead (developed on
+RunPod; any ROCm box works).
+
+**The MI300X is a surrogate, not the target.** Frontier is MI250X (`gfx90a`);
+the rentable AMD box is MI300X (`gfx942`). GPU code is compiled per-architecture,
+so that gap is real - it is the entire reason `check_isa.py` exists.
+
+## Layout
+
+| | |
+|---|---|
+| `workshop.py` | build a venv per config from its PEP 723 block, run `../_agent/probe.py` in it |
+| `check_isa.py` | **Frontier gate** - does the env actually contain `gfx90a` machine code? |
+| `check_numerics.py` | **correctness gate** - do source-built GPU ops match CPU? |
+| `bootstrap.sh` | one-time box setup (rocm-smi, uv, torch-on-ROCm smoke test) |
+
+## Modal -> AMD box
+
+| Modal | here |
+|---|---|
+| `modal.Image` + `uv_pip_install` per MLIP | one uv venv per config - the same path `rootstock install` uses on HPC |
+| `modal run app::probe_x` | `ssh` + `workshop.py probe`; stdout streams natively |
+| `modal.Volume` at `/cache` | a directory on the box's data volume, same HOME/HF_HOME redirection |
+| `modal.Secret("huggingface")` | `export HF_TOKEN=...` |
+| `gpu="A10G"` | the box *is* the GPU (192 GB - the A10G OOM failure modes vanish) |
+
+`_agent/probe.py` is unchanged: PyTorch's ROCm build exposes AMD GPUs through
+the `cuda` API, so `--device cuda` selects the AMD card, and every `setup()` in
+`amd_configs/` is byte-identical to its `nvidia_configs/` twin. **The entire
+port lives in the PEP 723 dependency block.**
+
+## Quickstart
+
+```bash
+scp -r sample_model_configurations root@<box>:/workspace/code/
+ssh root@<box>
+bash /workspace/code/sample_model_configurations/amd_workshop/bootstrap.sh
+
+export HF_TOKEN=hf_...                       # gated checkpoints (UMA)
+export WORKSHOP_ROOT=/workspace/rootstock-workshop
+export UV_CACHE_DIR=/workspace/uv-cache      # NOT the boot disk - see Storage
+cd /workspace/code/sample_model_configurations/amd_workshop
+
+python3 workshop.py probe ../amd_configs/mace.py --checkpoint mace-mp-0-medium
+python3 check_isa.py mace --require gfx90a
+```
+
+Iteration loop (same as the Modal workshop):
+
+1. Copy the closest `nvidia_configs/<name>.py` into `amd_configs/` and repoint
+   torch at the ROCm index via `[tool.uv.sources]` / `[[tool.uv.index]]`
+   (see `amd_configs/mace.py` - and note it must also declare
+   `pytorch-triton-rocm`, which exists on no other index).
+2. `workshop.py probe ../amd_configs/<name>.py --checkpoint <id>` - watch the
+   `STAGE:` markers.
+3. On failure, grep the error against `../_agent/failure_modes.md`; fix; re-run
+   (`--fresh` after dependency changes).
+4. On success: run `check_isa.py`, then commit the config plus any new
+   failure-mode entry.
+
+**Storage:** a ROCm torch env is **~17 GB** (the wheel alone is 4.2 GB - roughly
+double CUDA's, since it fat-binaries kernels for every gfx target). Five envs
+plus the shared wheel cache wants ~100 GB. Put `WORKSHOP_ROOT` and
+`UV_CACHE_DIR` on a data volume; a full boot disk surfaces as a baffling
+mid-install `No space left on device` on some unrelated package.
+
+## The Frontier gap (read this)
+
+Code built only for `gfx942` **imports fine, probes green, and then dies on
+Frontier** with `HSA_STATUS_ERROR_INVALID_ISA`. **The probe structurally cannot
+catch this** - it passes on the build box. So gate on it:
+
+```bash
+python3 check_isa.py <env> --require gfx90a
+```
+
+Verified here: official ROCm torch wheels are fat binaries and **do** carry
+`gfx90a` (23/23 fat libraries). So pure-wheel models are Frontier-safe for free.
+
+The gap only bites what you compile yourself - `torch-scatter`, `torch-sparse`,
+`torch-cluster`, for which **no ROCm wheels exist anywhere** (PyG publishes CUDA
+only). Build those with `PYTORCH_ROCM_ARCH="gfx90a;gfx942"` so one artifact
+serves both machines. You do **not** need an MI250X to compile for one.
+
+## A build that succeeds is not a build that is correct
+
+`torch-sparse` compiles on ROCm, imports, runs - and returns **wrong numbers**.
+Its `spmm` kernel is built around a 32-lane NVIDIA warp; AMD wavefronts are 64
+lanes, so its shuffle-based row reduction drops contributions:
+
+```
+dense reference  : [[2, 2, 2], [7, 7, 7]]
+torch_sparse GPU : [[2, 2, 2], [2, 2, 2]]     <-- no error raised
+```
+
+The probe passes. The physics is corrupt. So for any source-built extension:
+
+```bash
+python3 check_numerics.py <env>     # every source-built GPU op vs a CPU reference
+```
+
+Verified: `torch-scatter` and `torch-cluster` are numerically correct on ROCm;
+`torch-sparse`'s `spmm` is not.
+
+See `../_agent/failure_modes.md` for the full taxonomy.

--- a/sample_model_configurations/amd_workshop/bootstrap.sh
+++ b/sample_model_configurations/amd_workshop/bootstrap.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# One-time setup for a rented AMD (MI300X) box with ROCm preinstalled.
+# Developed on RunPod; any ROCm host works.
+#
+#   scp -r sample_model_configurations root@<box>:/workspace/code/
+#   ssh root@<box> 'bash /workspace/code/sample_model_configurations/amd_workshop/bootstrap.sh'
+#
+# Then export HF_TOKEN (gated checkpoints) and start probing:
+#   ssh root@<box>
+#   export HF_TOKEN=hf_...
+#   # Keep envs + wheel cache OFF the boot disk: a ROCm torch env is ~17 GB.
+#   export WORKSHOP_ROOT=/workspace/rootstock-workshop UV_CACHE_DIR=/workspace/uv-cache
+#   cd /workspace/code/sample_model_configurations/amd_workshop
+#   python3 workshop.py probe ../amd_configs/mace.py --checkpoint mace-mp-0-medium
+set -euo pipefail
+
+echo "== GPU check =="
+rocm-smi --showproductname || { echo "FATAL: rocm-smi failed - not a ROCm box?"; exit 1; }
+
+echo "== Installing uv =="
+command -v uv >/dev/null || curl -LsSf https://astral.sh/uv/install.sh | sh
+export PATH="$HOME/.local/bin:$PATH"
+uv --version
+
+echo "== torch-on-ROCm smoke test (throwaway env) =="
+uv run --python 3.11 --index https://download.pytorch.org/whl/rocm6.4 --with torch -- python - <<'EOF'
+import torch
+print("torch", torch.__version__, "| ROCm/HIP:", torch.version.hip)
+assert torch.cuda.is_available(), "torch.cuda.is_available() is False - ROCm torch can't see the GPU"
+print("device:", torch.cuda.get_device_name(0))
+x = torch.randn(1024, 1024, device="cuda")
+print("matmul OK, sum =", (x @ x).sum().item())
+EOF
+
+echo "== Bootstrap OK =="

--- a/sample_model_configurations/amd_workshop/check_isa.py
+++ b/sample_model_configurations/amd_workshop/check_isa.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""
+Frontier-compatibility gate for a ROCm environment.
+
+GPU code is compiled per-architecture. This box is gfx942 (MI300X); Frontier is
+gfx90a (MI250X). A binary built only for gfx942 imports fine, passes the probe
+here, and then dies on Frontier with HSA_STATUS_ERROR_INVALID_ISA / "invalid
+device function" - the probe structurally CANNOT catch that. This can: it reads
+the GPU code objects actually embedded in the env's binaries.
+
+    python3 check_isa.py <env> [--require gfx90a]
+
+Two kinds of artifact, which must be judged differently:
+
+  * fat libraries (libtorch_hip.so, librocblas.so) embed code for MANY arches.
+    Each one must itself contain the required arch.
+  * per-arch kernel objects (rocblas/library/Kernels.so-000-gfx942.hsaco,
+    TensileLibrary_..._gfx90a.co) are single-arch BY DESIGN - the arch is in the
+    filename. Demanding gfx90a inside `...-gfx1100.hsaco` is nonsense. What
+    matters is whether the *family* ships a gfx90a member alongside its gfx942
+    one.
+
+Exit 1 if a fat library or a kernel family lacks the required arch.
+
+Verified against torch 2.9.1+rocm6.4: official ROCm wheels are fat binaries and
+DO carry gfx90a. The real risk is source-built extensions (torch-scatter,
+torch-sparse), which compile only for the build host's arch unless you set
+    PYTORCH_ROCM_ARCH="gfx90a;gfx942"
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+WORKSHOP_ROOT = Path(os.environ.get("WORKSHOP_ROOT", Path.home() / "rootstock-workshop"))
+
+# gfx digit counts differ: gfx90a is 2 digits + letter, gfx942/gfx908 are 3,
+# gfx1100 is 4. Requiring 3 digits silently never matches gfx90a - the one arch
+# we care about. No capture group: findall must yield the full "gfx90a" token.
+GFX = re.compile(rb"gfx\d{2,4}[a-z]?\b")
+
+# A per-arch kernel object names its arch in the filename, e.g.
+#   Kernels.so-000-gfx90a-xnack+.hsaco
+#   TensileLibrary_..._CU104_gfx942.co
+PER_ARCH_FILE = re.compile(r"[-_](gfx\d{2,4}[a-z]?)(-xnack[+-])?\.(hsaco|co|dat)$")
+
+BINARY_SUFFIXES = (".so", ".hsaco", ".co", ".a")
+
+
+def arches(path: Path) -> set[str]:
+    """GPU architectures whose code objects are embedded in a binary."""
+    try:
+        blob = path.read_bytes()
+    except OSError:
+        return set()
+    return {m.decode() for m in GFX.findall(blob)}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("env", help="env name under $WORKSHOP_ROOT/envs")
+    ap.add_argument("--require", default="gfx90a", help="arch Frontier needs")
+    ap.add_argument("-v", "--verbose", action="store_true")
+    args = ap.parse_args()
+
+    root = WORKSHOP_ROOT / "envs" / args.env
+    if not root.exists():
+        print(f"no such env: {root}")
+        return 2
+    need = args.require
+
+    fat_ok, fat_missing = [], []
+    # family key -> arches shipped by that family (dir + kernel-object stem)
+    families: dict[str, set[str]] = defaultdict(set)
+
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or not path.name.endswith(BINARY_SUFFIXES):
+            if ".so." not in path.name:
+                continue
+
+        m = PER_ARCH_FILE.search(path.name)
+        if m:
+            # Single-arch by design: group into a family, judge the family later.
+            stem = PER_ARCH_FILE.sub("", path.name)
+            families[f"{path.parent.relative_to(root)}/{stem}"].add(m.group(1))
+            continue
+
+        found = arches(path)
+        if not found:
+            continue  # CPU-only binary, irrelevant
+        rel = path.relative_to(root)
+        (fat_ok if need in found else fat_missing).append((rel, found))
+
+    if args.verbose:
+        for rel, found in fat_ok:
+            print(f"OK   {rel}  [{' '.join(sorted(found))}]")
+
+    for rel, found in fat_missing:
+        print(f"FAT-LIB MISSING {need}: {rel}  has [{' '.join(sorted(found))}]")
+
+    # Kernel families are INFORMATIONAL, not a gate. Verified against
+    # torch 2.9.1+rocm6.4: 635 of 914 families have no gfx90a member, and they
+    # are overwhelmingly FP8 (B8B8/F8) GEMM variants plus all of hipsparselt.
+    # That is not a packaging defect - MI250X has no FP8 units and no structured
+    # -sparsity engine, so AMD correctly ships no gfx90a kernels for them. Gating
+    # on this would fail every environment forever. What actually decides whether
+    # torch loads and runs on Frontier is the fat libraries.
+    fam_missing = {k: v for k, v in families.items() if need not in v}
+    fp8_ish = sum(1 for k in fam_missing if re.search(r"B8|F8|XF32", k))
+    sparse = sum(1 for k in fam_missing if "hipsparselt" in k)
+
+    print(
+        f"fat libraries : {len(fat_ok)} carry {need}, {len(fat_missing)} do not  <-- the gate\n"
+        f"kernel families: {len(families) - len(fam_missing)} carry {need}, "
+        f"{len(fam_missing)} do not (informational)\n"
+        f"  of those, {fp8_ish} are FP8/XF32 variants and {sparse} are hipsparselt  - \n"
+        f"  datatypes/engines MI250X physically lacks, so their absence is expected."
+    )
+
+    if fat_missing:
+        print(
+            f"\nFAIL: the fat libraries above lack {need} and would hit\n"
+            f"HSA_STATUS_ERROR_INVALID_ISA on Frontier. If these are source-built\n"
+            f'extensions (torch-scatter/torch-sparse), rebuild with\n'
+            f'PYTORCH_ROCM_ARCH="gfx90a;gfx942".'
+        )
+        return 1
+    print(f"\nPASS: every fat GPU library in '{args.env}' carries {need} - Frontier-compatible.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sample_model_configurations/amd_workshop/check_numerics.py
+++ b/sample_model_configurations/amd_workshop/check_numerics.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Numerical gate for source-built GPU extensions on ROCm.
+
+WHY THIS EXISTS: on ROCm, torch-sparse's spmm compiles cleanly, imports fine,
+runs without error - and returns WRONG NUMBERS. Its kernel is built around a
+32-lane NVIDIA warp; an AMD wavefront is 64 lanes, so its shuffle-based row
+reduction spans the wrong threads and drops contributions:
+
+    dense reference  : [[2, 2, 2], [7, 7, 7]]
+    torch_sparse GPU : [[2, 2, 2], [2, 2, 2]]      <-- no error raised
+
+The probe cannot catch this. The model still produces energies and forces; they
+are simply wrong. A build that succeeds is NOT evidence of a correct build  -
+only comparing GPU output against CPU is.
+
+    python3 check_numerics.py <env>
+
+Exit 1 if any GPU op disagrees with its CPU reference.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+WORKSHOP_ROOT = Path(os.environ.get("WORKSHOP_ROOT", Path.home() / "rootstock-workshop"))
+TOL = 1e-4
+
+# Run inside the target env's interpreter, not ours.
+PROGRAM = r'''
+import sys
+import torch
+
+fails, checked = [], []
+
+def cmp(name, cpu, gpu):
+    err = (cpu - gpu.cpu()).abs().max().item()
+    ok = err < %(tol)g
+    checked.append((name, err, ok))
+    if not ok:
+        fails.append(name)
+
+torch.manual_seed(0)
+
+try:
+    import torch_scatter
+    src, idx = torch.randn(20000, 128), torch.randint(0, 999, (20000,))
+    for nm, fn in [
+        ("torch_scatter.scatter_add",  torch_scatter.scatter_add),
+        ("torch_scatter.scatter_mean", torch_scatter.scatter_mean),
+    ]:
+        cmp(nm, fn(src, idx, dim=0, dim_size=999),
+                fn(src.cuda(), idx.cuda(), dim=0, dim_size=999))
+    ptr = torch.tensor([0, 100, 350, 700, 1000])
+    s = torch.randn(1000, 32)
+    cmp("torch_scatter.segment_csr",
+        torch_scatter.segment_csr(s, ptr, reduce="sum"),
+        torch_scatter.segment_csr(s.cuda(), ptr.cuda(), reduce="sum"))
+except ImportError:
+    pass
+
+try:
+    # The known-bad one. spmm is where the 64-lane wavefront breaks the kernel.
+    from torch_sparse import SparseTensor
+    D = (torch.rand(64, 64) > 0.7).float() * torch.rand(64, 64)
+    r, c = D.nonzero(as_tuple=True)
+    v, B = D[r, c], torch.randn(64, 8)
+    cmp("torch_sparse.spmm",
+        D @ B,
+        SparseTensor(row=r.cuda(), col=c.cuda(), value=v.cuda(),
+                     sparse_sizes=(64, 64)) @ B.cuda())
+except ImportError:
+    pass
+
+try:
+    import torch_cluster
+    pos = torch.randn(500, 3)
+    a = set(map(tuple, torch_cluster.radius_graph(pos, r=0.5).t().tolist()))
+    b = set(map(tuple, torch_cluster.radius_graph(pos.cuda(), r=0.5).cpu().t().tolist()))
+    checked.append(("torch_cluster.radius_graph", 0.0 if a == b else 1.0, a == b))
+    if a != b:
+        fails.append("torch_cluster.radius_graph")
+except ImportError:
+    pass
+
+for nm, err, ok in checked:
+    print("  %%-30s max|GPU-CPU| = %%.2e  %%s" %% (nm, err, "OK" if ok else "*** WRONG ***"))
+
+if not checked:
+    print("  (no source-built GPU extensions found in this env - nothing to check)")
+elif fails:
+    print("\nFAIL: %%d op(s) disagree with CPU: %%s" %% (len(fails), ", ".join(fails)))
+    print("The build SUCCEEDED and the numbers are WRONG. Do not ship this env.")
+    sys.exit(1)
+else:
+    print("\nPASS: every source-built GPU op matches its CPU reference.")
+''' % {"tol": TOL}
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(__doc__)
+        return 2
+    python = WORKSHOP_ROOT / "envs" / sys.argv[1] / "bin" / "python"
+    if not python.exists():
+        print(f"no such env: {python}")
+        return 2
+    print(f"numerical gate: {sys.argv[1]} (tol={TOL})")
+    # cwd matters: running from a package's source checkout shadows the
+    # installed module and yields a bogus ImportError.
+    return subprocess.run([str(python), "-c", PROGRAM], cwd="/").returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sample_model_configurations/amd_workshop/workshop.py
+++ b/sample_model_configurations/amd_workshop/workshop.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+AMD workshop for crafting MLIP configurations on ROCm, targeting Frontier.
+
+The ROCm counterpart of ../modal_app.py. Same philosophy: this is a workshop,
+not a validator - the artifact we ship is the config file in ../amd_configs/.
+But instead of Modal images we build one uv venv per config on the box (the
+same thing `rootstock install` does on HPC), and instead of `modal run` we
+just run ../_agent/probe.py in that venv. STAGE markers stream to stdout, so
+running this over ssh gives the same realtime observability as Modal did.
+
+A green probe is necessary but NOT sufficient for Frontier. Also run:
+    check_isa.py <env> --require gfx90a   # is Frontier's arch even in the binary?
+    check_numerics.py <env>               # do source-built GPU ops match CPU?
+
+Runs ON the AMD box (stdlib only, needs python3 >= 3.8 and uv on PATH):
+
+    python3 workshop.py probe ../amd_configs/mace.py
+    python3 workshop.py probe ../amd_configs/mace.py --checkpoint mace-off23-medium --system molecule
+    python3 workshop.py probe ../amd_configs/uma.py --fresh   # rebuild the venv
+    python3 workshop.py list
+
+Environment resolution honors the config's full PEP 723 metadata, including
+[tool.uv.index] blocks (this is how the ROCm torch index is selected):
+`uv export --script` resolves the script's deps to a lockfile, which is then
+installed into a plain venv. Iteration is fast because uv's wheel cache plays
+the role Modal image layers did.
+
+Weight caches live under WORKSHOP_ROOT/cache with the same env redirection
+modal_app.py used (HOME, XDG_CACHE_HOME, HF_HOME, ...), mirroring what
+rootstock does on HPC. Set HF_TOKEN in your shell for gated checkpoints.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+PROBE = HERE.parent / "_agent" / "probe.py"
+
+WORKSHOP_ROOT = Path(os.environ.get("WORKSHOP_ROOT", Path.home() / "rootstock-workshop"))
+ENVS = WORKSHOP_ROOT / "envs"
+CACHE = WORKSHOP_ROOT / "cache"
+PROBE_TIMEOUT = int(os.environ.get("PROBE_TIMEOUT", "900"))
+
+CACHE_ENV = {
+    "HOME": str(CACHE / "home"),
+    "XDG_CACHE_HOME": str(CACHE),
+    "HF_HOME": str(CACHE / "huggingface"),
+    "HF_HUB_CACHE": str(CACHE / "huggingface" / "hub"),
+    "HF_XET_CACHE": str(CACHE / "huggingface" / "xet"),
+}
+
+
+def sh(cmd: list[str], **kw) -> subprocess.CompletedProcess:
+    print(f"RUN: {' '.join(str(c) for c in cmd)}", flush=True)
+    return subprocess.run([str(c) for c in cmd], **kw)
+
+
+def requires_python(config: Path) -> str | None:
+    """Pull requires-python out of the PEP 723 block, e.g. '>=3.11' -> '3.11'."""
+    m = re.search(r'^#\s*requires-python\s*=\s*"[>=~]*(\d+\.\d+)', config.read_text(), re.M)
+    return m.group(1) if m else None
+
+
+def index_urls(config: Path) -> list[str]:
+    """Index URLs declared in the config's [[tool.uv.index]] blocks.
+
+    `uv export --script` reads these from the PEP 723 metadata, but the
+    resulting lockfile only carries pinned versions - `uv pip install -r` would
+    then look for e.g. pytorch-triton-rocm (ROCm-index-only) on PyPI and fail.
+    So the same indexes are handed to the install step explicitly.
+    """
+    return re.findall(r'^#\s*url\s*=\s*"([^"]+)"', config.read_text(), re.M)
+
+
+def build_env(config: Path, fresh: bool) -> Path:
+    """Create (or reuse) a venv for the config from its PEP 723 metadata."""
+    name = config.stem
+    venv = ENVS / name
+    lock = ENVS / f"{name}.lock.txt"
+    python = venv / "bin" / "python"
+
+    if fresh and venv.exists():
+        sh(["rm", "-rf", str(venv)])
+
+    # Resolve script deps honoring [tool.uv.index] etc. Re-export every time  -
+    # it's cheap and catches config edits; the install below is a no-op when
+    # nothing changed.
+    r = sh(["uv", "export", "--script", config, "--no-hashes", "-o", lock])
+    if r.returncode != 0:
+        raise SystemExit(f"uv export failed for {config}")
+
+    if not python.exists():
+        cmd = ["uv", "venv", venv]
+        py = requires_python(config)
+        if py:
+            cmd += ["--python", py]
+        if sh(cmd).returncode != 0:
+            raise SystemExit(f"uv venv failed for {name}")
+
+    cmd = ["uv", "pip", "install", "--python", python, "-r", lock]
+    for url in index_urls(config):
+        cmd += ["--index", url]
+    if index_urls(config):
+        # The lock pins exact versions (already resolved under the config's
+        # `explicit` index rules), but by default uv takes each package from the
+        # *first* index that carries it at all - so a package the ROCm index
+        # happens to mirror at an older version (filelock, sympy, ...) fails to
+        # match the pin. Searching all indexes is safe against a pinned lock.
+        cmd += ["--index-strategy", "unsafe-best-match"]
+    r = sh(cmd)
+    if r.returncode != 0:
+        raise SystemExit(f"uv pip install failed for {name} - grep _agent/failure_modes.md")
+    return python
+
+
+def cmd_probe(args) -> int:
+    config = Path(args.config).resolve()
+    if not config.exists():
+        raise SystemExit(f"no such config: {config}")
+    ENVS.mkdir(parents=True, exist_ok=True)
+    for p in CACHE_ENV.values():
+        os.makedirs(p, exist_ok=True)
+
+    python = build_env(config, fresh=args.fresh)
+
+    cmd = [python, PROBE, "--config", config, "--system", args.system, "--device", args.device]
+    if args.checkpoint:
+        cmd += ["--checkpoint", args.checkpoint]
+    env = {**os.environ, **CACHE_ENV}
+    print(f"PROBE_CMD: {' '.join(str(c) for c in cmd)}", flush=True)
+    try:
+        return sh(cmd, env=env, timeout=PROBE_TIMEOUT).returncode
+    except subprocess.TimeoutExpired:
+        print(f"PROBE: TIMEOUT after {PROBE_TIMEOUT}s - last STAGE marker names the hung stage")
+        return 124
+
+
+def cmd_list(_args) -> int:
+    if not ENVS.exists():
+        print("(no envs built yet)")
+        return 0
+    for d in sorted(ENVS.iterdir()):
+        if (d / "bin" / "python").exists():
+            print(d.name)
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    pr = sub.add_parser("probe", help="build/reuse the config's venv and run one probe")
+    pr.add_argument("config", help="path to an amd_configs/<name>.py file")
+    pr.add_argument("--checkpoint", default="", help="canonical checkpoint id (empty = setup default)")
+    pr.add_argument("--system", default="crystal", choices=["molecule", "crystal", "slab_co"])
+    pr.add_argument("--device", default="cuda", help="'cuda' also selects AMD GPUs under ROCm torch")
+    pr.add_argument("--fresh", action="store_true", help="delete and rebuild the venv first")
+    pr.set_defaults(fn=cmd_probe)
+
+    ls = sub.add_parser("list", help="list built envs")
+    ls.set_defaults(fn=cmd_list)
+
+    args = p.parse_args()
+    return args.fn(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Every cluster in the almanac is NVIDIA. Frontier is AMD MI250X, and every config in `nvidia_configs/` hardcodes a CUDA wheel index. Modal has no AMD GPUs, so the Modal workshop cannot derive the ROCm equivalents. This ports the loop to a rented MI300X and ships what it produced.

## amd_configs/

Five ROCm environment specs, each probe-verified on an MI300X (real energy and forces on an 8-atom Cu crystal) and gated for Frontier's gfx90a:

| model | checkpoint | energy | probe | gfx90a gate |
|---|---|---|---|---|
| mace | mace-mp-0-medium | -32.645 eV | OK | PASS |
| chgnet | chgnet-default | -32.649 eV | OK | PASS |
| mattersim | mattersim-v1-0-0-5m | -32.757 eV | OK | PASS |
| orb | orb-v2 | -32.710 eV | OK | PASS |
| uma | uma-s-1p1 | -29.979 eV | OK | PASS |

Four independently-trained networks landing within 0.11 eV of each other on the same crystal is the sanity check that ROCm numerics are not quietly wrong.

**Every `setup()` is byte-identical to its `nvidia_configs/` twin.** The entire port lives in the PEP 723 dependency block. PyTorch's ROCm build exposes AMD GPUs through the `cuda` API, so no model code changes and `_agent/probe.py` is untouched.

## amd_workshop/

The ROCm counterpart of `modal_app.py`: one uv venv per config (the same path `rootstock install` uses on HPC) instead of Modal images, ssh instead of `modal run`. Plus two gates the probe cannot replace.

**`check_isa.py` (Frontier gate).** GPU code is compiled per-architecture. A build carrying only gfx942 (MI300X) imports fine, probes green, and then dies on Frontier with `HSA_STATUS_ERROR_INVALID_ISA`. The probe structurally cannot catch this, since it passes on the build box. Verified: official ROCm torch wheels are fat binaries and do carry gfx90a (23 of 23 fat libraries), so pure-wheel models are Frontier-safe for free.

**`check_numerics.py` (correctness gate).** A build that succeeds is not a build that is correct. `torch-sparse` compiles on ROCm, imports, runs without error, and returns wrong numbers:

```
dense reference  : [[2, 2, 2], [7, 7, 7]]
torch_sparse GPU : [[2, 2, 2], [2, 2, 2]]     <-- no error raised
```

Its `spmm` kernel is built around a 32-lane NVIDIA warp; AMD wavefronts are 64 lanes, so its shuffle-based row reduction drops contributions. The probe passes and the physics is corrupt. This gate compares every source-built GPU op against a CPU reference.

## _agent/failure_modes.md

New ROCm section. The load-bearing entries:

- **`pytorch-triton-rocm` is published only on the ROCm index, never on PyPI.** ROCm torch depends on it, so a naive CUDA-to-ROCm config cannot even resolve. This failure cannot occur on NVIDIA (the CUDA equivalent is on PyPI), so it is invisible from the NVIDIA side. Fix: declare it as a direct dependency AND map it in `[tool.uv.sources]`. A sources entry alone does nothing, since uv only routes packages that appear in `dependencies`.

- **The obvious fix for that is a trap.** Relaxing index isolation (dropping `explicit = true`) so the resolver finds it does work, while silently resolving `torchmetrics` to 1.0.3 instead of 1.9.0, because the ROCm index mirrors a stale slice of PyPI and uv takes each package from the first index that carries it. The result is a working environment quietly running different library code, which is the worst case for reproducible science. Keep `explicit = true` and declare the missing package. When a package is missing, add the package; never widen the search.

- **Same failure, one layer down.** `--index-strategy unsafe-best-match` with an unpinned torch installs a CUDA build (2.13.0+cu130) onto an AMD box, and `torch.cuda.is_available()` returns False. It is safe only against a pinned lockfile, which is how `workshop.py` uses it.

- Plus: lockfile installs need the config's indexes passed through, and a ROCm torch env is roughly 17 GB (the wheel alone is 4.2 GB, about double CUDA's), which has real filesystem implications on a cluster.

## What this does not prove

Nothing has executed on an MI250X. This validates dependency resolution and the API layer on ROCm, and confirms Frontier's machine code is present in the shipped binaries. It does not prove that code runs there. Someone with a Frontier allocation should `rootstock install` these and confirm.

Also untested: the `molecule` and `slab_co` probe systems (only `crystal` was run), and Rootstock's own i-PI worker path, which the workshop deliberately bypasses just as `modal_app.py` does.

## Follow-up, not in this PR

The PyG-extension tier (fairchem OC20 models, TensorNet, TorchMD-Net) needs `torch-scatter` / `torch-sparse` / `torch-cluster`, for which no ROCm wheels exist anywhere. Progress so far, for a later PR:

- Source-building works. The recipe is a ROCm toolchain matching the torch wheel's ROCm version, installing from git rather than PyPI, and `PYTORCH_ROCM_ARCH="gfx90a;gfx942"`. The resulting `.so` carries both architectures, so one artifact serves Frontier and the MI300X. You do not need an MI250X to compile for one.
- `torch-scatter` and `torch-cluster` build dual-arch and are numerically correct.
- `torch-sparse`'s `spmm` is not (see above). Notably fairchem never imports `torch_sparse`, so that tier may be less blocked than it appears.

## Open questions for maintainers

- Directory layout: `amd_configs/` mirrors `nvidia_configs/`, but you may prefer `configs/{amd,nvidia}/`.
- `check_isa.py` is arguably not workshop-specific. It is a Frontier-readiness check that could live alongside `rootstock install` on the cluster itself.
