### PR TITLE
Document Academy integration in run-agents

### DIFF
--- a/docs/run-agents.md
+++ b/docs/run-agents.md
@@ -1,6 +1,6 @@
 # Run — with agents
 
-Beyond writing Python yourself, you can let a coding agent drive Rootstock for you. Rootstock ships an [agent skill](https://github.com/Garden-AI/rootstock/blob/main/skill/skill.md) that teaches an agent to discover what is deployed on a cluster and to call `RootstockCalculator` correctly.
+"Agent" means two different things here, and Rootstock works with both. A **coding agent** writes Rootstock code for you, and Rootstock ships a [skill](https://github.com/Garden-AI/rootstock/blob/main/skill/skill.md) that teaches one to discover what's deployed on a cluster and call `RootstockCalculator` correctly. An **autonomous agent**, built with a framework like [Academy](https://github.com/academy-agents/academy), holds a `RootstockCalculator` as its own state and serves MLIP calls to whatever else is running. The skill comes first, Academy after it.
 
 ## What the skill does
 
@@ -20,3 +20,104 @@ The full skill lives in the Rootstock repo at [`skill/skill.md`](https://github.
 - Read each env's `setup()` signature for the kwargs it accepts.
 
 Getting Python code onto a compute node (job submission, file staging, credentials) is out of scope for the skill itself — see the "Getting code onto a cluster" section there for the common paths.
+
+## Academy
+
+[Academy](https://github.com/academy-agents/academy) is Globus Labs' middleware for stateful agents on distributed and federated infrastructure. An agent is a class with `@action` methods peers can call and `@loop` methods that run on their own; a manager places agents on remote resources through executors, and they talk through an exchange.
+
+Rootstock fits Academy more cleanly than it fits most tools, and the reason is lifecycle. Academy agents persist, and they have real startup and shutdown hooks. Build the calculator in `agent_on_startup()`, keep it as agent state, close it in `agent_on_shutdown()`. The worker spins up once when the agent lands on the node, stays hot across every action it serves, and dies when the agent does. This is the same shape Academy's own [HPC guide](https://docs.academy-agents.org/stable/guides/hpc/) uses for a Parsl DFK.
+
+```bash
+pip install academy-py
+```
+
+An agent that serves MLIP evaluations:
+
+```python
+from academy.agent import Agent, action
+from ase import Atoms
+
+from rootstock import RootstockCalculator
+
+
+class MLIPAgent(Agent):
+    def __init__(self, checkpoint: str, cluster: str, device: str = "cuda") -> None:
+        super().__init__()
+        self.checkpoint = checkpoint
+        self.cluster = cluster
+        self.device = device
+        self.calc: RootstockCalculator | None = None
+
+    async def agent_on_startup(self) -> None:
+        # One worker, started once the agent is running on the compute node.
+        self.calc = RootstockCalculator(
+            checkpoint=self.checkpoint,
+            cluster=self.cluster,
+            device=self.device,
+        )
+
+    async def agent_on_shutdown(self) -> None:
+        if self.calc is not None:
+            self.calc.close()
+            self.calc = None
+
+    @action
+    async def potential_energy(self, atoms: Atoms) -> float:
+        atoms.calc = self.calc
+        return atoms.get_potential_energy()
+
+    @action
+    async def forces(self, atoms: Atoms) -> list[list[float]]:
+        atoms.calc = self.calc
+        return atoms.get_forces().tolist()
+```
+
+Launch it and call it by handle. `kwargs` are forwarded to the agent's `__init__` on the worker:
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+
+from academy.exchange import LocalExchangeFactory
+from academy.manager import Manager
+
+async with await Manager.from_exchange_factory(
+    factory=LocalExchangeFactory(),
+    executors=ThreadPoolExecutor(),
+) as manager:
+    mlip = await manager.launch(
+        MLIPAgent,
+        kwargs={"checkpoint": "mace-mp-0-medium", "cluster": "sophia"},
+    )
+
+    energy = await mlip.potential_energy(atoms)
+
+    await manager.shutdown(mlip, blocking=True)
+```
+
+### Onto a cluster
+
+The local exchange and thread pool above keep everything in-process, which is fine for development but misses the point. To put the agent on a compute node, swap in a Globus Compute executor and the hosted exchange. Rootstock and Academy are both Globus Labs projects, so this is the well-trodden path:
+
+```python
+from academy.exchange.cloud.client import HttpExchangeFactory
+from academy.manager import Manager
+from globus_compute_sdk import Executor as GCExecutor
+
+async with await Manager.from_exchange_factory(
+    factory=HttpExchangeFactory(
+        "https://exchange.academy-agents.org",
+        auth_method="globus",
+    ),
+    executors=GCExecutor(endpoint_id),
+) as manager:
+    mlip = await manager.launch(
+        MLIPAgent,
+        kwargs={"checkpoint": "mace-mp-0-medium", "cluster": "sophia"},
+    )
+```
+
+The agent now runs where the GPU and the Rootstock install are, and the Rootstock env resolves locally on that node. See Academy's [Building HPC Agents](https://docs.academy-agents.org/stable/guides/hpc/) guide for endpoint setup.
+
+**What the agent's environment needs.** Rootstock, ASE, Academy, and whatever the agent itself does. Not `torch`, not `mace-torch`, not any model dependency. Those live in the isolated env on the other side of the i-PI socket, which is the whole reason to reach for Rootstock here rather than importing the model into the agent.
+
+Pass `cluster=` for a registered cluster, or `root="/path/to/rootstock"` for a local install (not both). `device` defaults to `cpu` in `RootstockCalculator`; set `cuda` on GPU nodes. The target environment must already be built with `rootstock install`.


### PR DESCRIPTION
Adds an Academy section to `run-agents.md`, framed around agent-driven workflows
on HPC as discussed.

## The angle

Academy agents are stateful and have real lifecycle hooks, which makes
`RootstockCalculator` fit them better than it fits most tools. Build the calculator
in `agent_on_startup()`, hold it as agent state, close it in `agent_on_shutdown()`.
The worker starts once when the agent lands on the node, stays hot across every
action it serves, and dies with the agent. No cold start per call, no leaked worker.

Worth noting this is Academy's own documented pattern, not one I invented: their
HPC guide uses the same startup/shutdown hooks to manage a Parsl DFK. Rootstock's
calculator drops into the same slot.

## Structure of the section

Three parts:

1. What Academy is, and why the lifecycle hooks matter for Rootstock specifically.
2. A worked `MLIPAgent` that serves `potential_energy` and `forces` as actions,
   launched through a local exchange and thread pool.
3. An "onto a cluster" subsection swapping in a Globus Compute executor and the
   hosted exchange, which is what actually puts the agent on a compute node next to
   the Rootstock install. Both are Globus Labs projects, so that's the natural path.

The closing note makes the payoff explicit: the agent's environment needs Rootstock,
ASE, and Academy. It does not need torch, `mace-torch`, or any model dependency.
That's the reason to reach for Rootstock here instead of importing the model into
the agent directly.

## One editorial change

I reworked the page's opening paragraph. It previously used "agent" to mean "coding
agent", which collides with what Academy means by the word, and leaving it would have
made the page read as confused about its own subject. The new intro distinguishes the
two senses and orders them (skill first, Academy second). Happy to revert if you'd
rather not touch the existing copy.

## Verification

I checked the API against Academy's source rather than working from memory:
`Manager.launch()` takes `args` / `kwargs` that are forwarded to the agent's
`__init__` on the worker, and `agent_on_startup` / `agent_on_shutdown` are real hooks
on `Agent`. The Globus Compute snippet mirrors the one in their HPC guide.

**Not verified:** I have not run any of it. No Globus Compute endpoint, no built
Rootstock env on my machine. The samples are API-correct but untested. If someone has
an endpoint handy, a sanity run before this ships would be worth it.