### PR TITLE
LAMMPS: migrate fix to canonical checkpoint id, fix broken serve invocation

### DIFF
--- a/docs/lammps.md
+++ b/docs/lammps.md
@@ -5,9 +5,6 @@
 
 Rootstock includes a native LAMMPS `fix` that spawns a worker subprocess, giving a LAMMPS run access to a Rootstock-managed MLIP for molecular dynamics. The fix handles worker lifecycle, socket communication, and cleanup. Virial information is passed through, so barostats (`npt`, `nph`) work, and the MLIP energy is available as `f_mlip` in thermo output.
 
-!!! note "Fix keyword interface predates the v0.8 API"
-    The fix has not yet been updated to the v0.8 canonical-checkpoint-id API used by the Python interface and CLI. It still takes separate `model` and `checkpoint` keywords, matching the current `lammps/fix_rootstock.cpp` source. The interface is expected to change to a single canonical checkpoint id. The syntax below is what the fix accepts today.
-
 ## Building the fix
 
 The fix ships as two files (`fix_rootstock.h`, `fix_rootstock.cpp`) with no dependencies beyond the C++ standard library and POSIX sockets. Copy them into your LAMMPS `src/` directory and rebuild:
@@ -28,18 +25,19 @@ pip install rootstock
 ## Fix syntax
 
 ```lammps
-fix <id> <group> rootstock cluster <name> model <model> \
-    checkpoint <ckpt> device <dev> [timeout <sec>] elements <e1> <e2> ...
+fix <id> <group> rootstock cluster <name> checkpoint <ckpt> \
+    device <dev> [timeout <sec>] elements <e1> <e2> ...
 ```
 
 | Keyword | Required | Default | Description |
 |---------|----------|---------|-------------|
 | `cluster` | yes | — | Cluster name (e.g., `della`) |
-| `model` | yes | — | MLIP family (e.g., `mace`) |
-| `checkpoint` | no | `default` | Model weights within that family (e.g., `medium`) |
+| `checkpoint` | yes | — | Canonical checkpoint id (e.g., `mace-mp-0-medium`) |
 | `device` | no | `cuda` | `cuda` or `cpu` |
 | `timeout` | no | `120` | Seconds to wait for worker startup |
 | `elements` | yes | — | Element symbols mapping atom types (must be last) |
+
+`checkpoint` takes the same canonical id as [`RootstockCalculator`](api.md) and the CLI. Run `rootstock list --root <root>` to see what is registered on a cluster.
 
 A minimal input fragment:
 
@@ -48,7 +46,7 @@ units metal
 pair_style zero 6.0
 pair_coeff * *
 
-fix mlip all rootstock cluster della model mace checkpoint medium device cuda elements Cu
+fix mlip all rootstock cluster della checkpoint mace-mp-0-medium device cuda elements Cu
 
 thermo_style custom step temp pe f_mlip press
 ```

--- a/lammps/README.md
+++ b/lammps/README.md
@@ -32,27 +32,21 @@ You should see `rootstock` listed under fix styles.
 
 ## Usage
 
-### 1. Start the rootstock worker
-
-In a separate terminal (or as a background job):
-
-```bash
-rootstock serve mace --root /scratch/gpfs/SHARED/rootstock \
-    --socket /tmp/rootstock_test.sock \
-    --model medium \
-    --device cuda
-```
-
-### 2. Run LAMMPS
+The fix spawns the worker itself via `rootstock serve`, so there is no separate
+worker to start. `rootstock` must be installed and on `PATH`.
 
 ```
 units           metal
 atom_style      atomic
 boundary        p p p
 
+pair_style      zero 6.0
+pair_coeff      * *
+
 read_data       structure.data
 
-fix             mlip all rootstock /tmp/rootstock_test.sock elements Cu
+fix             mlip all rootstock cluster della checkpoint mace-mp-0-medium \
+                device cuda elements Cu
 
 # Energy is available via f_mlip
 thermo_style    custom step temp pe f_mlip
@@ -61,12 +55,16 @@ thermo          10
 run             100
 ```
 
+`checkpoint` is a canonical checkpoint id, the same one used by
+`RootstockCalculator` and the CLI. The environment providing it must already be
+built on that cluster (`rootstock install`).
+
 ### Notes
 
-- The worker must be started **before** LAMMPS runs (the fix waits up to 60 seconds
-  for a connection).
+- The fix waits up to `timeout` seconds (default 120) for the worker it spawned
+  to connect back.
 - The `elements` keyword maps LAMMPS atom types to element symbols in order
-  (type 1 = first element, type 2 = second, etc.).
+  (type 1 = first element, type 2 = second, etc.) and must come last.
 - Forces are added to existing forces (`+=`), so do not use another pair style
   unless you intend to combine potentials.
 - Requires `units metal` (eV, Angstrom, ps).

--- a/lammps/fix_rootstock.cpp
+++ b/lammps/fix_rootstock.cpp
@@ -15,8 +15,8 @@
    fix rootstock - MLIP calculator via i-PI protocol over Unix sockets
 
    Usage:
-     fix <id> <group> rootstock cluster <name> model <model> \
-         checkpoint <ckpt> device <dev> elements <e1> <e2> ...
+     fix <id> <group> rootstock cluster <name> checkpoint <ckpt> \
+         device <dev> elements <e1> <e2> ...
 
    The worker is auto-spawned via `rootstock serve`.
 ------------------------------------------------------------------------- */
@@ -75,12 +75,12 @@ int FixRootstock::element_to_z(const std::string &symbol) {
 
 // ---------------------------------------------------------------------------
 // Constructor — parse keyword arguments
-//   fix <id> <group> rootstock cluster <name> model <model> checkpoint <ckpt>
+//   fix <id> <group> rootstock cluster <name> checkpoint <ckpt>
 //       device <dev> timeout <sec> elements <e1> <e2> ...
 // ---------------------------------------------------------------------------
 FixRootstock::FixRootstock(LAMMPS *lmp, int narg, char **arg)
     : Fix(lmp, narg, arg), server_fd_(-1), client_fd_(-1), worker_pid_(-1),
-      energy_(0.0), device_("cuda"), checkpoint_("default"), timeout_(120) {
+      energy_(0.0), device_("cuda"), timeout_(120) {
 
   if (narg < 4)
     error->all(FLERR, "fix rootstock: not enough arguments");
@@ -94,8 +94,6 @@ FixRootstock::FixRootstock(LAMMPS *lmp, int narg, char **arg)
 
     if (key == "cluster" && iarg + 1 < narg) {
       cluster_name_ = arg[++iarg];
-    } else if (key == "model" && iarg + 1 < narg) {
-      model_ = arg[++iarg];
     } else if (key == "checkpoint" && iarg + 1 < narg) {
       checkpoint_ = arg[++iarg];
     } else if (key == "device" && iarg + 1 < narg) {
@@ -115,8 +113,9 @@ FixRootstock::FixRootstock(LAMMPS *lmp, int narg, char **arg)
   // Validate required keywords
   if (cluster_name_.empty())
     error->all(FLERR, "fix rootstock: 'cluster' keyword is required");
-  if (model_.empty())
-    error->all(FLERR, "fix rootstock: 'model' keyword is required");
+  if (checkpoint_.empty())
+    error->all(FLERR, "fix rootstock: 'checkpoint' keyword is required "
+                      "(canonical id, e.g. 'mace-mp-0-medium')");
   if (!found_elements)
     error->all(FLERR, "fix rootstock: 'elements' keyword is required");
 
@@ -236,9 +235,9 @@ pid_t FixRootstock::spawn_worker(const std::string &root) {
 
   if (pid == 0) {
     // Child: exec rootstock serve
-    execlp("rootstock", "rootstock", "serve", model_.c_str(), "--root",
-           root.c_str(), "--socket", socket_path_.c_str(), "--checkpoint",
-           checkpoint_.c_str(), "--device", device_.c_str(), nullptr);
+    execlp("rootstock", "rootstock", "serve", checkpoint_.c_str(), "--root",
+           root.c_str(), "--socket", socket_path_.c_str(), "--device",
+           device_.c_str(), nullptr);
     // If exec fails, exit immediately
     _exit(127);
   }
@@ -301,9 +300,9 @@ void FixRootstock::init() {
   if (sel <= 0)
     error->all(FLERR,
                "fix rootstock: no worker connected within {} seconds. "
-               "Worker may have failed to start — check that the '{}' "
-               "environment is built.",
-               timeout_, model_);
+               "Worker may have failed to start. Check that an environment "
+               "providing checkpoint '{}' is built on this cluster.",
+               timeout_, checkpoint_);
 
   client_fd_ = ::accept(server_fd_, nullptr, nullptr);
   if (client_fd_ < 0)

--- a/lammps/fix_rootstock.h
+++ b/lammps/fix_rootstock.h
@@ -19,8 +19,11 @@
    The worker is auto-spawned via `rootstock serve`.
 
    Usage:
-     fix <id> <group> rootstock cluster <name> model <model> \
-         checkpoint <ckpt> device <dev> elements <e1> <e2> ...
+     fix <id> <group> rootstock cluster <name> checkpoint <ckpt> \
+         device <dev> elements <e1> <e2> ...
+
+   `checkpoint` is a canonical checkpoint id (e.g. 'mace-mp-0-medium'), the
+   same id used by RootstockCalculator and the `rootstock` CLI.
 ------------------------------------------------------------------------- */
 
 #ifdef FIX_CLASS
@@ -53,7 +56,6 @@ public:
 private:
   // User-facing keywords
   std::string cluster_name_;
-  std::string model_;
   std::string checkpoint_;
   std::string device_;
   int timeout_;


### PR DESCRIPTION
Moves the LAMMPS fix onto the v0.8 canonical-checkpoint-id API, per your note.

## Not stale but broken

The fix execs:

    rootstock serve <model> --root R --socket S --checkpoint <ckpt> --device D

The CLI takes:

    rootstock serve <checkpoint> --root R --socket S --device D [--kwarg K=V]

There is no `--checkpoint` flag anymore. argparse rejects it, `rootstock serve`
exits nonzero, the forked child dies, and the fix sits waiting on a socket that
nothing ever connects to. So the LAMMPS path currently doesn't work against any
recent rootstock, it just fails as a timeout rather than a clear error. Worth
knowing since the docs presented it as merely outdated.

## What changed

`fix_rootstock.h` / `.cpp`: dropped the `model` keyword and `model_` member.
`checkpoint` is now required and takes a canonical id. `spawn_worker` passes it
as the positional arg, which is what `serve` actually wants. The startup-timeout
error message also interpolated `model_`, so it now names the checkpoint instead,
which matters because that's the exact error a user hits from this bug.

`resolve_cluster()` needed no change. `rootstock resolve --cluster X --json` still
emits a `root` key and the existing string parse still matches.

`docs/lammps.md`: dropped the "predates the v0.8 API" note (that's what this fixes),
updated the syntax block and keyword table.

`lammps/README.md`: this was a generation behind even the fix. It documented a
manually-started worker (`rootstock serve mace --model medium`, a flag that doesn't
exist) and a positional-socket fix invocation (`fix mlip all rootstock /tmp/x.sock`)
that the fix has never implemented in this form. Replaced with the real interface.
It was also missing `pair_style zero`, which `docs/lammps.md` says is required.

## Not tested

I have no LAMMPS build and no rootstock env locally, so I have not confirmed this
end to end. The change is mechanical and I've checked the new argv against the
`serve` parser in `rootstock/cli.py` line by line, but that's argument-shape
verification, not a run. Needs someone with a built LAMMPS and an installed env to
confirm forces come back and the worker exits.

## Follow-up worth considering

Nothing pins the contract between the fix and the `serve` CLI, which is how this
broke silently. A test asserting that `serve` accepts the exact argv the fix emits
would make the next change to that CLI fail loudly instead of at someone's runtime.
Didn't fold it in here because the parser is built inside `main()` and would need
extracting first, which felt like scope creep for this PR. Happy to do it separately.