### PR TITLE
Fix env-var-knobs test broken by socket_name removal

### DIFF
--- a/tests/worker/test_env_var_knobs.py
+++ b/tests/worker/test_env_var_knobs.py
@@ -118,7 +118,7 @@ def test_connect_uses_config_values(monkeypatch):
     recorder = _ConnectRecorder()
     monkeypatch.setattr(worker_module, "connect_unix_socket", recorder)
 
-    worker = MLIPWorker(socket_name="test", calculator=None)
+    worker = MLIPWorker(calculator=None, socket_path="test")
     with pytest.raises(SystemExit):
         worker._connect()
 


### PR DESCRIPTION
## Summary
Main is red: [#85](https://github.com/Garden-AI/rootstock/pull/85) added `test_connect_uses_config_values` against the pre-[#88](https://github.com/Garden-AI/rootstock/pull/88) `MLIPWorker` signature, and #88 (merged after) removed the dead `socket_name` parameter. The one-line test fix planned for #88's rebase never landed. This passes `socket_path` instead.

## Test plan
- `uv run pytest tests/` — full suite green (was 1 failure on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)