### PR TITLE
Version the on-disk layout with {root}/layout.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ Main Process                          Worker Process (subprocess)
 
 ```
 {root}/
+├── layout.json             # on-disk layout version (clients refuse newer layouts)
 ├── .python/                # uv-managed Python interpreters (portable)
 │   └── cpython-3.10.19-linux-x86_64-gnu/
 ├── environments/           # Environment SOURCE files (*.py with PEP 723 + CHECKPOINTS)

--- a/docs/cluster-setup.md
+++ b/docs/cluster-setup.md
@@ -246,6 +246,7 @@ After setup, the Rootstock root directory will look like this:
 
 ```
 {root}/
+├── layout.json             # on-disk layout version (future clients check this)
 ├── .python/                # uv-managed Python interpreters
 ├── environments/           # Environment source files (*.py with PEP 723 metadata)
 │   ├── mace.py

--- a/rootstock/calculator.py
+++ b/rootstock/calculator.py
@@ -15,6 +15,7 @@ from ase.stress import full_3x3_to_voigt_6_stress
 
 from .clusters import get_cluster
 from .environment import find_env_for_checkpoint
+from .layout import ensure_layout_compatible
 from .server import RootstockServer
 
 
@@ -123,6 +124,11 @@ class RootstockCalculator(Calculator):
             self.cache_root = Path(cache_root) if cache_root is not None else self.root
         else:
             raise ValueError("Must specify either 'cluster' or 'root'")
+
+        # A root laid out by a newer rootstock may not be readable by this
+        # client's conventions — fail with "upgrade rootstock", not a
+        # misleading resolution error.
+        ensure_layout_compatible(self.root)
 
         # Resolve env name from the canonical checkpoint id by walking the
         # installed envs at self.root. Raises CheckpointNotFoundError with a

--- a/rootstock/commands/init.py
+++ b/rootstock/commands/init.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from ..clusters import CLUSTER_REGISTRY, get_cluster_for_root
 from ..config import DEFAULT_CONFIG_FILE, load_config, save_config
+from ..layout import write_layout_marker
 from ..manifest import create_manifest, save_manifest
 from .common import ROOTSTOCK_ROOT_ENV
 from .manifest import _refresh_manifest_environments
@@ -143,6 +144,12 @@ def cmd_init(args) -> int:
                     print(f"  Skipped (no permission): {dir_path}")
             else:
                 print(f"  Exists:  {dir_path}")
+
+        try:
+            write_layout_marker(root)
+            print(f"  Created: {root / 'layout.json'}")
+        except PermissionError:
+            print(f"  Skipped (no permission): {root / 'layout.json'}")
 
     # Initialize manifest if we have a cluster
     if cluster and not args.skip_manifest:

--- a/rootstock/commands/install.py
+++ b/rootstock/commands/install.py
@@ -9,6 +9,7 @@ import sys
 import tempfile
 from pathlib import Path
 
+from ..layout import ensure_layout_compatible, write_layout_marker
 from .common import get_root_or_exit, resolve_cache_root
 
 ROOTSTOCK_GITHUB_URL = "https://github.com/Garden-AI/rootstock.git"
@@ -417,6 +418,13 @@ def cmd_install(args) -> int:
     source = args.source
     source_path = Path(source)
 
+    # Never write into a root laid out by a newer rootstock.
+    try:
+        ensure_layout_compatible(root)
+    except RuntimeError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
     # Check uv is available
     if not check_uv_available():
         print(
@@ -429,6 +437,9 @@ def cmd_install(args) -> int:
     # Surface permission problems before the (slow) build starts.
     if not getattr(args, "no_perm_check", False):
         _warn_on_permissions(root)
+
+    # Stamp (or backfill, for pre-marker installs) the layout version.
+    write_layout_marker(root)
 
     # DIRECTORY MODE: install all *.py files
     if source_path.is_dir():

--- a/rootstock/layout.py
+++ b/rootstock/layout.py
@@ -1,0 +1,100 @@
+"""On-disk layout versioning for a rootstock install root.
+
+The directory layout under ``{root}`` — ``environments/`` source files,
+``envs/<name>/`` venvs with ``env_source.py`` inside, ``.python/``
+interpreters, ``cache/``, ``home/`` — is an implicit contract that every
+future client must be able to read for as long as installs live on cluster
+filesystems. ``{root}/layout.json`` makes that contract explicit: a client
+that meets a layout newer than it understands can say so and stop, instead
+of misreading the tree by accident.
+
+Rules for future changes:
+- Additive changes (new files/dirs old clients ignore) do NOT bump
+  LAYOUT_VERSION.
+- Changes that move or reshape anything an old client reads DO bump it,
+  and must come with reader code for the old layout (mirroring the manifest
+  schema-migration policy).
+
+A root without a marker is a legacy (pre-marker) install of layout 1;
+maintainers' state-changing commands backfill the marker.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+LAYOUT_VERSION = 1
+MARKER_NAME = "layout.json"
+
+
+def read_layout_version(root: Path) -> int | None:
+    """Return the root's recorded layout version, or None if unrecorded.
+
+    None means either an empty/new root or a legacy install from before the
+    marker existed — both are layout 1 in practice. A corrupt marker also
+    reads as None: a broken metadata file must not brick an otherwise
+    working install.
+    """
+    marker = Path(root) / MARKER_NAME
+    try:
+        version = json.loads(marker.read_text()).get("layout_version")
+    except (OSError, json.JSONDecodeError, AttributeError):
+        return None
+    return version if isinstance(version, int) else None
+
+
+def ensure_layout_compatible(root: Path) -> None:
+    """Raise RuntimeError if the root's layout is newer than this client.
+
+    Read-only; safe for non-maintainer users on shared installs.
+    """
+    version = read_layout_version(root)
+    if version is not None and version > LAYOUT_VERSION:
+        raise RuntimeError(
+            f"install at {root} uses on-disk layout version {version}, but "
+            f"this rootstock only understands up to {LAYOUT_VERSION}. It was "
+            f"written by a newer rootstock — upgrade this client "
+            f"(`pip install -U rootstock`)."
+        )
+
+
+def write_layout_marker(root: Path) -> None:
+    """Record the current layout version in {root}/layout.json.
+
+    Called from maintainer commands that write the root anyway (install,
+    init). No-op when the recorded version is already current, so repeated
+    installs don't churn the file. Atomic write, mode honoring the process
+    umask — same recipe as save_manifest.
+    """
+    from . import __version__
+    from .manifest import now_iso
+
+    root = Path(root)
+    if read_layout_version(root) == LAYOUT_VERSION:
+        return
+
+    data = {
+        "layout_version": LAYOUT_VERSION,
+        "written_by": f"rootstock {__version__}",
+        "written_at": now_iso(),
+    }
+
+    root.mkdir(parents=True, exist_ok=True)
+    fd, temp_path = tempfile.mkstemp(dir=root, suffix=".json")
+    try:
+        with open(fd, "w") as f:
+            json.dump(data, f, indent=2)
+            f.write("\n")
+        umask_value = os.umask(0)
+        os.umask(umask_value)
+        os.chmod(temp_path, 0o666 & ~umask_value)
+        Path(temp_path).rename(root / MARKER_NAME)
+    except Exception:
+        try:
+            Path(temp_path).unlink()
+        except OSError:
+            pass
+        raise

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,0 +1,76 @@
+"""On-disk layout versioning ({root}/layout.json).
+
+The layout is a forever contract: 1.0-era roots will outlive many client
+versions. The marker lets a future client refuse a layout it doesn't
+understand instead of misreading the tree.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from rootstock.layout import (
+    LAYOUT_VERSION,
+    ensure_layout_compatible,
+    read_layout_version,
+    write_layout_marker,
+)
+
+
+def test_write_then_read_round_trip(tmp_path: Path):
+    write_layout_marker(tmp_path)
+    assert read_layout_version(tmp_path) == LAYOUT_VERSION
+
+
+def test_marker_records_provenance(tmp_path: Path):
+    write_layout_marker(tmp_path)
+    data = json.loads((tmp_path / "layout.json").read_text())
+    assert data["layout_version"] == LAYOUT_VERSION
+    assert data["written_by"].startswith("rootstock ")
+    assert data["written_at"]
+
+
+def test_missing_marker_reads_as_none(tmp_path: Path):
+    """Legacy (pre-marker) installs have no layout.json; that's layout 1,
+    not an error."""
+    assert read_layout_version(tmp_path) is None
+    ensure_layout_compatible(tmp_path)  # must not raise
+
+
+def test_corrupt_marker_reads_as_none(tmp_path: Path):
+    (tmp_path / "layout.json").write_text("{not json")
+    assert read_layout_version(tmp_path) is None
+    ensure_layout_compatible(tmp_path)  # a broken metadata file can't brick the root
+
+
+def test_current_layout_is_compatible(tmp_path: Path):
+    write_layout_marker(tmp_path)
+    ensure_layout_compatible(tmp_path)  # must not raise
+
+
+def test_newer_layout_tells_user_to_upgrade(tmp_path: Path):
+    (tmp_path / "layout.json").write_text(
+        json.dumps({"layout_version": LAYOUT_VERSION + 1})
+    )
+    with pytest.raises(RuntimeError, match="upgrade this client"):
+        ensure_layout_compatible(tmp_path)
+
+
+def test_rewrite_is_a_noop_when_current(tmp_path: Path):
+    """Repeated installs must not churn the marker (its written_at is the
+    first-stamp time, and shared-fs writes aren't free)."""
+    write_layout_marker(tmp_path)
+    before = (tmp_path / "layout.json").read_text()
+
+    write_layout_marker(tmp_path)
+
+    assert (tmp_path / "layout.json").read_text() == before
+
+
+def test_stale_marker_is_upgraded(tmp_path: Path):
+    (tmp_path / "layout.json").write_text(json.dumps({"layout_version": 0}))
+    write_layout_marker(tmp_path)
+    assert read_layout_version(tmp_path) == LAYOUT_VERSION


### PR DESCRIPTION
## Summary

Fourth checklist item of #78. The on-disk layout (`environments/`, `envs/<name>/env_source.py`, `.python/`, `cache/`, `home/`) is a contract every future client must read forever, but nothing recorded which layout a root uses — a future client reshaping the tree would leave old roots readable only by accident.

**Marker:** `install` and `init` write `{root}/layout.json` — `layout_version: 1` plus provenance (writing rootstock version, timestamp). Atomic write honoring the umask, same recipe as the manifest. A root without the marker is a legacy install of layout 1; the next `install` backfills it silently, so all live roots get stamped as maintainers touch them.

**Enforcement, both directions:**
- `rootstock install` refuses to write into a root whose layout is newer than the client understands.
- `RootstockCalculator` checks at construction, so a user on an old client gets *"layout version N … upgrade this client"* instead of a misleading checkpoint-resolution error.
- Missing or corrupt marker never blocks anything — a broken metadata file must not brick a working install.

**Policy** (documented in `rootstock/layout.py`): additive layout changes don't bump the version; changes that move or reshape anything an old client reads do, and must ship reader code for the old layout — mirroring the manifest-migration policy from #96.

Chose a standalone `layout.json` over reusing the manifest deliberately: the manifest describes install *state* and can be absent or corrupt (`load_manifest` returns `None`), while the layout contract must be readable unconditionally, including by non-Python tooling.

## Test plan
- `tests/test_layout.py`: round-trip, provenance, legacy-None, corrupt-marker tolerance, newer-version refusal, idempotent rewrite, stale-marker upgrade
- E2E: a root stamped `layout_version: 99` → `rootstock install` exits with the upgrade error and `RootstockCalculator` raises it; deleting the marker → next real install backfills a well-formed v1 marker
- `uv run pytest tests/`: 226 passed (deselecting the pre-existing failure fixed in #94)

🤖 Generated with [Claude Code](https://claude.com/claude-code)