### PR TITLE
Document the in-place env_source.py hotfix as a supported procedure

### DIFF
--- a/docs/cluster-setup.md
+++ b/docs/cluster-setup.md
@@ -291,6 +291,23 @@ rootstock manifest push
 
 Rebuilding an env invalidates prior verifications (the venv changed; weights in `cache/` are unaffected). `rootstock status` will show those checkpoints as **stale** until you re-run `add` or `smoke-test`.
 
+### Hotfixing `setup()` without a rebuild
+
+`envs/<name>/env_source.py` is re-read at runtime on both sides of the socket: every worker spawn imports `setup()` from it, and every client resolution AST-parses its `CHECKPOINTS` table. Nothing caches it across runs — which means a maintainer can fix a bug in `setup()` (or adjust a `CHECKPOINTS` entry) by **editing that file in place on the shared filesystem, with no rebuild**. The next worker spawn picks it up. This is the one cheap lever into already-built envs, and it is a supported procedure:
+
+1. **Edit a copy, then move it into place** (an in-progress edit with a syntax error breaks every new worker spawn on the cluster):
+   ```bash
+   cp {root}/envs/mace/env_source.py /tmp/env_source.py
+   $EDITOR /tmp/env_source.py
+   # umask 002 so the result stays world-readable
+   mv /tmp/env_source.py {root}/envs/mace/env_source.py
+   ```
+2. **Apply the same edit to the registered source** `{root}/environments/mace.py` — that file is what rebuilds build from, so skipping this step means the next `install --force` silently reverts your hotfix.
+3. **Verify and refresh the manifest**: `rootstock smoke-test --env mace` (or `rootstock add <id>`) exercises the fixed `setup()` and pushes an updated manifest. Until this runs, the manifest's `source_hash` for the env is stale — it still hashes the pre-hotfix source.
+4. **Contribute the fix back** to the sample env file in the repo so the next cluster doesn't need the same hotfix.
+
+**What a hotfix can and cannot reach.** In-place edits can change anything `setup()` does (model loading logic, upstream URLs/paths, `CHECKPOINTS` values, new optional kwargs) — but they cannot change the env's **dependencies** (the venv is already built; dependency changes need `install --force`) and cannot fix **worker/protocol code** (that's the rootstock pinned inside the venv; only a rebuild replaces it).
+
 ## Troubleshooting
 
 ### Environment build fails

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -207,6 +207,8 @@ The same model rarely drops onto every cluster unchanged. Driver and CUDA versio
 
 When an entire hardware class needs a different dependency stack (a non-NVIDIA GPU, say), that belongs in its own sample folder alongside `nvidia_configs/`, rather than as a one-off edit to an existing file.
 
+A `setup()`-only fix to an env that is already deployed does not require a rebuild at all — see [Hotfixing `setup()` without a rebuild](cluster-setup.md#hotfixing-setup-without-a-rebuild).
+
 ## Testing your environment
 
 ```bash


### PR DESCRIPTION
## Summary

Seventh checklist item of #78 — docs only. `envs/<name>/env_source.py` is re-read at runtime on both sides of the socket: the client AST-parses `CHECKPOINTS` from it on every resolution, and the generated wrapper does `from env_source import setup` at every worker spawn. So a maintainer can fix a deployed env's `setup()` in place on the shared filesystem with **no rebuild** — the one cheap worker-adjacent lever we have, previously undocumented folklore.

New section in `docs/cluster-setup.md` (under *Updating environments*) covering:
- the edit-a-copy-then-`mv` procedure — an in-progress edit with a syntax error breaks every new worker spawn on the cluster — plus the `umask 002` caveat
- mirroring the edit into `environments/<name>.py`, since that's what rebuilds build from; skipping it means the next `install --force` silently reverts the hotfix
- running `smoke-test`/`add` afterwards, which both verifies the fix and refreshes the manifest — whose `source_hash` for the env is stale until that refresh (the refresh re-hashes from the env's copy, so no code change needed)
- scope boundaries: anything `setup()` does is reachable; dependencies (frozen venv) and worker/protocol code (pinned rootstock) are not — those need a rebuild

Plus a cross-reference from `docs/environments.md`'s cluster-specific-edits section.

## Test plan
Docs-only; verified the two runtime-reread claims against the code (`parse_checkpoints_dict` walks `envs/*/env_source.py`; `WRAPPER_TEMPLATE` imports `setup` from `env_source`) and that `_refresh_manifest_environments` re-hashes `source_hash` from the env's copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)