### PR TITLE
Vendor the rootstock wheel into {root}/wheels/ at install time

### DIFF
--- a/docs/cluster-setup.md
+++ b/docs/cluster-setup.md
@@ -261,6 +261,8 @@ After setup, the Rootstock root directory will look like this:
 │   │   ├── env_source.py
 │   │   └── env_source.py.lock   # what this build was resolved from
 │   └── ...
+├── wheels/                 # Vendored rootstock wheels (rebuilds install from here,
+│                           # so they don't depend on PyPI still serving the release)
 ├── home/                   # Redirected HOME for not-well-behaved libraries
 │   ├── .cache/fairchem/
 │   └── .matgl/

--- a/rootstock/commands/install.py
+++ b/rootstock/commands/install.py
@@ -38,6 +38,67 @@ def _rootstock_install_spec() -> str:
     return f"rootstock@git+{ROOTSTOCK_GITHUB_URL}@{commit_hash}"
 
 
+def _vendor_rootstock_wheel(root: Path) -> Path | None:
+    """Archive this release's wheel in {root}/wheels/ and return its path.
+
+    Rebuilding an env reinstalls the pinned rootstock, which normally depends
+    on PyPI still serving that exact release, un-yanked, years later. Keeping
+    the wheel inside the install root removes that dependency: rebuilds
+    install rootstock from the vendored file, and the wheel doubles as a
+    bootstrap source if the release ever disappears upstream.
+
+    Returns None (with a warning) when vendoring isn't possible: dev builds
+    have no published wheel (they pin a git sha instead), and a download or
+    checksum failure must not fail the install — it just falls back to the
+    index. The download is verified against PyPI's published sha256.
+    """
+    import hashlib
+    import json as json_module
+    import urllib.error
+    import urllib.request
+
+    from rootstock import __version__
+
+    if "dev" in __version__:
+        return None
+
+    wheels_dir = root / "wheels"
+    existing = sorted(wheels_dir.glob(f"rootstock-{__version__}-*.whl"))
+    if existing:
+        return existing[0]
+
+    try:
+        url = f"https://pypi.org/pypi/rootstock/{__version__}/json"
+        with urllib.request.urlopen(url, timeout=30) as resp:
+            release = json_module.load(resp)
+        wheel_meta = next(
+            entry for entry in release["urls"] if entry["packagetype"] == "bdist_wheel"
+        )
+        with urllib.request.urlopen(wheel_meta["url"], timeout=60) as resp:
+            wheel_bytes = resp.read()
+
+        digest = hashlib.sha256(wheel_bytes).hexdigest()
+        if digest != wheel_meta["digests"]["sha256"]:
+            raise ValueError(
+                f"sha256 mismatch for {wheel_meta['filename']}: "
+                f"got {digest}, PyPI says {wheel_meta['digests']['sha256']}"
+            )
+
+        wheels_dir.mkdir(parents=True, exist_ok=True)
+        wheel_path = wheels_dir / wheel_meta["filename"]
+        tmp_path = wheel_path.with_suffix(".whl.partial")
+        tmp_path.write_bytes(wheel_bytes)
+        tmp_path.rename(wheel_path)
+        return wheel_path
+    except (urllib.error.URLError, OSError, ValueError, KeyError, StopIteration) as exc:
+        print(
+            f"  Warning: could not vendor the rootstock wheel into {wheels_dir} "
+            f"({exc}); this build will install rootstock from the index instead.",
+            file=sys.stderr,
+        )
+        return None
+
+
 def extract_minimum_python_version(requires_python: str) -> str:
     """
     Extract minimum Python version from a requires-python specifier.
@@ -394,10 +455,17 @@ def _build_and_swap(
             )
             return 1
 
-    # Install rootstock
+    # Install rootstock. Prefer the wheel vendored into {root}/wheels/ (this
+    # release's own artifact, archived so rebuilds don't depend on PyPI still
+    # serving it); fall back to the pinned index/git spec.
     print("4. Installing rootstock...")
-    rootstock_spec = _rootstock_install_spec()
-    print(f"  Installing: {rootstock_spec}")
+    vendored_wheel = _vendor_rootstock_wheel(root)
+    if vendored_wheel is not None:
+        rootstock_spec = str(vendored_wheel)
+        print(f"  Installing vendored wheel: {vendored_wheel}")
+    else:
+        rootstock_spec = _rootstock_install_spec()
+        print(f"  Installing: {rootstock_spec}")
 
     result = subprocess.run(
         ["uv", "pip", "install", "--python", str(env_python), rootstock_spec],

--- a/tests/commands/test_install_spec.py
+++ b/tests/commands/test_install_spec.py
@@ -113,6 +113,11 @@ def test_install_command_passes_helper_spec_as_final_arg(tmp_path, monkeypatch, 
 
     monkeypatch.setattr("rootstock.commands.install.subprocess.run", fake_run)
     monkeypatch.setattr("rootstock.commands.install.shutil.copy", lambda *a, **k: None)
+    # No vendored wheel available: force the index-spec fallback (also keeps
+    # the test off the network).
+    monkeypatch.setattr(
+        "rootstock.commands.install._vendor_rootstock_wheel", lambda root: None
+    )
     monkeypatch.setattr(
         "rootstock.commands.install._precompile_environment", lambda *a, **k: None
     )
@@ -194,6 +199,11 @@ def test_dependencies_installed_via_uv_sync_script(tmp_path, monkeypatch, capsys
     monkeypatch.setattr("rootstock.commands.install.shutil.copy", lambda *a, **k: None)
     monkeypatch.setattr(
         "rootstock.commands.install._precompile_environment", lambda *a, **k: None
+    )
+    # No vendored wheel available: force the index-spec fallback (also keeps
+    # the test off the network).
+    monkeypatch.setattr(
+        "rootstock.commands.install._vendor_rootstock_wheel", lambda root: None
     )
     monkeypatch.setattr(
         "rootstock.commands.manifest.update_and_push_manifest",

--- a/tests/commands/test_vendor_wheel.py
+++ b/tests/commands/test_vendor_wheel.py
@@ -1,0 +1,175 @@
+"""Vendoring the rootstock wheel into {root}/wheels/.
+
+Rebuilds reinstall the pinned rootstock; without a vendored copy they depend
+on PyPI serving that exact release, un-yanked, for the lifetime of the
+install. All network access is faked; the sha256 comes from the fake PyPI
+metadata just like the real API.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+from rootstock.commands.install import _vendor_rootstock_wheel
+
+WHEEL_BYTES = b"not-really-a-wheel-but-bytes-are-bytes"
+VERSION = "9.9.9"
+FILENAME = f"rootstock-{VERSION}-py3-none-any.whl"
+
+
+class _FakeResponse(io.BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+
+def _fake_urlopen_factory(calls, wheel_bytes=WHEEL_BYTES, advertised_sha=None):
+    sha = advertised_sha or hashlib.sha256(wheel_bytes).hexdigest()
+    metadata = {
+        "urls": [
+            {
+                "packagetype": "sdist",
+                "filename": f"rootstock-{VERSION}.tar.gz",
+                "url": "https://files.example/sdist",
+                "digests": {"sha256": "irrelevant"},
+            },
+            {
+                "packagetype": "bdist_wheel",
+                "filename": FILENAME,
+                "url": "https://files.example/wheel",
+                "digests": {"sha256": sha},
+            },
+        ]
+    }
+
+    def fake_urlopen(url, timeout=None):
+        calls.append(url)
+        if url.endswith("/json"):
+            return _FakeResponse(json.dumps(metadata).encode())
+        return _FakeResponse(wheel_bytes)
+
+    return fake_urlopen
+
+
+@pytest.fixture
+def release_version(monkeypatch):
+    monkeypatch.setattr("rootstock.__version__", VERSION)
+
+
+def test_vendors_wheel_from_pypi(tmp_path, monkeypatch, release_version):
+    calls: list[str] = []
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen_factory(calls))
+
+    wheel = _vendor_rootstock_wheel(tmp_path)
+
+    assert wheel == tmp_path / "wheels" / FILENAME
+    assert wheel.read_bytes() == WHEEL_BYTES
+    assert calls == [
+        f"https://pypi.org/pypi/rootstock/{VERSION}/json",
+        "https://files.example/wheel",
+    ]
+
+
+def test_already_vendored_wheel_is_reused_offline(tmp_path, monkeypatch, release_version):
+    calls: list[str] = []
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen_factory(calls))
+    wheels = tmp_path / "wheels"
+    wheels.mkdir()
+    (wheels / FILENAME).write_bytes(WHEEL_BYTES)
+
+    wheel = _vendor_rootstock_wheel(tmp_path)
+
+    assert wheel == wheels / FILENAME
+    assert calls == []  # a rebuild must not need the network for this
+
+
+def test_dev_builds_are_not_vendored(tmp_path, monkeypatch):
+    monkeypatch.setattr("rootstock.__version__", "9.9.9.dev0+abc1234")
+    calls: list[str] = []
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen_factory(calls))
+
+    assert _vendor_rootstock_wheel(tmp_path) is None
+    assert calls == []
+
+
+def test_sha_mismatch_rejects_wheel(tmp_path, monkeypatch, release_version, capsys):
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        _fake_urlopen_factory(calls, advertised_sha="0" * 64),
+    )
+
+    assert _vendor_rootstock_wheel(tmp_path) is None
+    assert "sha256 mismatch" in capsys.readouterr().err
+    assert not list((tmp_path / "wheels").glob("*.whl")) if (tmp_path / "wheels").exists() else True
+
+
+def test_network_failure_falls_back_with_warning(tmp_path, monkeypatch, release_version, capsys):
+    def failing_urlopen(url, timeout=None):
+        raise urllib.error.URLError("no route to pypi")
+
+    monkeypatch.setattr("urllib.request.urlopen", failing_urlopen)
+
+    assert _vendor_rootstock_wheel(tmp_path) is None
+    assert "could not vendor" in capsys.readouterr().err
+
+
+def test_install_step_prefers_vendored_wheel(tmp_path, monkeypatch, release_version, capsys):
+    """The env's rootstock comes from the vendored file, not the index."""
+    from unittest.mock import MagicMock
+
+    calls: list[str] = []
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen_factory(calls))
+
+    env_dir = tmp_path / "environments"
+    env_dir.mkdir()
+    env_source = env_dir / "noop.py"
+    env_source.write_text(
+        "# /// script\n"
+        '# requires-python = ">=3.10"\n'
+        "# dependencies = []\n"
+        "# ///\n"
+        "CHECKPOINTS = {}\n"
+        'def setup(checkpoint: str, device: str = "cuda"):\n'
+        "    return None\n"
+    )
+
+    captured: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append(list(cmd))
+        if cmd[:2] == ["uv", "venv"]:
+            Path(cmd[2]).mkdir(parents=True, exist_ok=True)
+        result = MagicMock()
+        result.returncode = 0
+        result.stderr = ""
+        result.stdout = ""
+        return result
+
+    monkeypatch.setattr("rootstock.commands.install.subprocess.run", fake_run)
+    monkeypatch.setattr("rootstock.commands.install.shutil.copy", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "rootstock.commands.install._precompile_environment", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        "rootstock.commands.manifest.update_and_push_manifest", lambda *a, **k: None
+    )
+
+    from rootstock.commands.install import _install_single_environment
+
+    rc = _install_single_environment(
+        root=tmp_path, source=str(env_source), force=False, verbose=False
+    )
+
+    assert rc == 0
+    wheel_path = str(tmp_path / "wheels" / FILENAME)
+    pip_installs = [c for c in captured if c[:3] == ["uv", "pip", "install"]]
+    assert pip_installs and pip_installs[0][-1] == wheel_path


### PR DESCRIPTION
## Summary

Fifth checklist item of #78 — with this, every item on the issue has an open PR.

Env rebuilds reinstall the pinned rootstock (`rootstock==X` from PyPI, or a git sha for dev builds), so the rebuild path — our only fix channel for worker-side problems — silently depends on PyPI/GitHub serving that exact release, un-yanked, for the lifetime of the install (years, per the issue's cost model).

**Mechanism:** when installing a tagged release, `install` downloads that release's wheel from PyPI — verified against the published sha256 — into `{root}/wheels/`, and installs the env's rootstock **from the vendored file**. What's archived is exactly what's deployed, and subsequent (re)builds find the wheel already present and never touch the index for rootstock (verified: second call makes zero network requests).

**Failure semantics:** vendoring is insurance, so it can't be load-bearing for the build — download failures, yanked releases, and checksum mismatches warn and fall back to the plain index spec. Dev builds skip vendoring entirely (they pin a git sha; there's no published wheel for a dev state).

**Bonus:** the vendored wheel doubles as a client bootstrap if the release ever disappears upstream — `pip install {root}/wheels/rootstock-X-*.whl` from the shared root.

Deliberately scoped to the rootstock wheel itself: the env's *dependency* stack is covered by the lockfile work in #95, and full dependency-wheel archival would balloon the root by gigabytes per env for insurance the uv cache (also inside `{root}`) mostly provides.

## Test plan
- `tests/commands/test_vendor_wheel.py` (network faked): downloads and stores the wheel, offline reuse without network calls, dev-build skip, sha-mismatch rejection, network-failure fallback with warning, and the install step passing the vendored path to `uv pip install`
- E2E against real PyPI: vendored the actual `rootstock-0.9.7` wheel (sha verified, valid zip containing `rootstock/worker.py`), second call reused it offline
- `uv run pytest tests/`: 224 passed (deselecting the pre-existing failure fixed in #94)

🤖 Generated with [Claude Code](https://claude.com/claude-code)