### PR TITLE
Add new LAMMPS integration style

### DIFF
--- a/docs/lammps.md
+++ b/docs/lammps.md
@@ -1,13 +1,18 @@
 # LAMMPS integration
 
 !!! warning "Experimental"
-    LAMMPS support is experimental and far less tested than the ASE path. For most work, use [`RootstockCalculator`](api.md) from Python. If you try the LAMMPS fix and hit issues, reach out.
+    LAMMPS support is experimental and far less tested than the ASE path. For most work, use [`RootstockCalculator`](api.md) from Python. If you try the LAMMPS styles and hit issues, reach out.
 
-Rootstock includes a native LAMMPS `fix` that spawns a worker subprocess, giving a LAMMPS run access to a Rootstock-managed MLIP for molecular dynamics. The fix handles worker lifecycle, socket communication, and cleanup. Virial information is passed through, so barostats (`npt`, `nph`) work, and the MLIP energy is available as `f_mlip` in thermo output.
+Rootstock ships two LAMMPS styles, sharing one worker protocol. Both spawn a worker subprocess that runs the MLIP in its pre-built environment and exchange positions/forces over a Unix socket each timestep:
 
-## Building the fix
+- **`pair_style rootstock`** — the MLIP as a genuine pair style. It contributes to thermo `pe`, `compute pair`, and the pressure natively, and composes with `pair_style hybrid/scaled`. Tools that assume the potential is a pair style (e.g., calphy) require this form. **Use this when the MLIP is the only potential.**
+- **`fix rootstock`** — *adds* MLIP forces on top of whatever pair style is defined. Use this to combine an MLIP with another potential; energy is exposed as the fix scalar `f_<id>`.
 
-The fix ships as two files (`fix_rootstock.h`, `fix_rootstock.cpp`) with no dependencies beyond the C++ standard library and POSIX sockets. Copy them into your LAMMPS `src/` directory and rebuild:
+Both require `units metal` and a single MPI rank (the worker sees all atoms and computes its own neighborhoods; runs on more than one rank are rejected at startup).
+
+## Building the styles
+
+The styles ship as six files (`rootstock_ipi.{h,cpp}`, `fix_rootstock.{h,cpp}`, `pair_rootstock.{h,cpp}`) with no dependencies beyond the C++ standard library and POSIX sockets. Copy them into your LAMMPS `src/` directory and rebuild:
 
 ```bash
 ./lammps/install.sh /path/to/lammps/src
@@ -16,13 +21,44 @@ cmake ../cmake [your usual flags]
 make -j 4
 ```
 
-Rootstock must be installed and on `PATH` so the fix can call `rootstock resolve` and `rootstock serve`:
+Rootstock must be installed and on `PATH` so the styles can call `rootstock resolve` and `rootstock serve`:
 
 ```bash
 pip install rootstock
 ```
 
-## Fix syntax
+## pair_style rootstock
+
+```lammps
+pair_style rootstock cluster <name> checkpoint <ckpt> \
+    [device <dev>] [timeout <sec>] [cutoff <r>]
+pair_coeff * * <e1> <e2> ...
+```
+
+| Keyword | Required | Default | Description |
+|---------|----------|---------|-------------|
+| `cluster` | yes | — | Cluster name (e.g., `della`) |
+| `checkpoint` | yes | — | Canonical checkpoint id (e.g., `mace-mp-0-medium`) |
+| `device` | no | `cuda` | `cuda` or `cpu` |
+| `timeout` | no | `120` | Seconds to wait for worker startup |
+| `cutoff` | no | `1.0` | Neighbor/comm bookkeeping only; the worker builds its own neighborhoods |
+
+The element symbols on `pair_coeff` map atom types in order (type 1 = first element, and so on).
+
+A minimal input fragment:
+
+```lammps
+units metal
+
+pair_style rootstock cluster della checkpoint mace-mp-0-medium device cuda
+pair_coeff * * Cu
+
+thermo_style custom step temp pe press
+```
+
+The MLIP energy appears in `pe` directly — no placeholder pair style, no `f_<id>` bookkeeping. Per-atom energy and stress (`compute pe/atom`, `compute stress/atom`) are **not** provided; the worker reports global quantities only.
+
+## fix rootstock
 
 ```lammps
 fix <id> <group> rootstock cluster <name> checkpoint <ckpt> \
@@ -37,9 +73,7 @@ fix <id> <group> rootstock cluster <name> checkpoint <ckpt> \
 | `timeout` | no | `120` | Seconds to wait for worker startup |
 | `elements` | yes | — | Element symbols mapping atom types (must be last) |
 
-`checkpoint` takes the same canonical id as [`RootstockCalculator`](api.md) and the CLI. Run `rootstock list --root <root>` to see what is registered on a cluster.
-
-A minimal input fragment:
+A minimal input fragment (standalone use, with a placeholder pair style):
 
 ```lammps
 units metal
@@ -51,10 +85,12 @@ fix mlip all rootstock cluster della checkpoint mace-mp-0-medium device cuda ele
 thermo_style custom step temp pe f_mlip press
 ```
 
+- **Forces are added** (`+=`) to existing forces — that is the point of the fix form; don't combine with a real pair style unless you intend to sum potentials.
+- **Energy** is exposed as `f_<id>` (`variable e equal f_mlip` to capture it). `fix_modify <id> energy yes` folds it into `pe`.
+- **Ordering matters with force-rescaling fixes** (e.g. `fix ti/spring`): define `fix rootstock` first, so its forces are present in the array when the rescaling fix runs.
+
 ## Notes
 
-- **Requires `units metal`.** The fix checks this at startup.
-- **Use `pair_style zero`.** The fix provides all interatomic forces, so a placeholder pair style is needed.
-- **Single-node only.** The worker sees all atoms and computes its own neighborhoods. MPI-parallel runs are not supported.
-- **Element order matters.** `elements` must be last; symbols map to atom types in order (type 1 = first element, and so on).
-- **Energy** is exposed as `f_mlip` (`variable e equal f_mlip` to capture it). **Barostats** work because the virial is passed through.
+- `checkpoint` takes the same canonical id as [`RootstockCalculator`](api.md) and the CLI. Run `rootstock list --root <root>` to see what is registered on a cluster.
+- **Barostats** (`npt`, `nph`) work with both styles: the virial is passed through from the worker.
+- **Single-node only.** MPI-parallel runs are rejected; launch with `mpirun -np 1` on MPI builds.

--- a/lammps/README.md
+++ b/lammps/README.md
@@ -1,11 +1,20 @@
-# fix rootstock — LAMMPS integration
+# rootstock LAMMPS styles
 
-A LAMMPS fix that communicates with a rootstock MLIP worker over Unix sockets
-using the i-PI protocol.
+Two LAMMPS styles that communicate with a rootstock MLIP worker over Unix
+sockets using the i-PI protocol:
+
+- **`pair_style rootstock`** — the MLIP as a genuine pair style. Energy in
+  thermo `pe`, works with `compute pair` and `pair_style hybrid/scaled`.
+  Use this when the MLIP is the only potential, and for pair-style-assuming
+  drivers (calphy).
+- **`fix rootstock`** — adds MLIP forces on top of an existing pair style.
+  Use this to combine potentials. Energy via the fix scalar `f_<id>`.
+
+Both share one protocol implementation (`rootstock_ipi.{h,cpp}`).
 
 ## Install
 
-Copy the fix source files into your LAMMPS source tree:
+Copy the source files into your LAMMPS source tree:
 
 ```bash
 ./install.sh /path/to/lammps/src
@@ -25,34 +34,42 @@ make -j$(nproc)
 ## Verify
 
 ```bash
-./lmp -h | grep rootstock
+./lmp -h | grep -i rootstock
 ```
 
-You should see `rootstock` listed under fix styles.
+You should see `rootstock` listed under both pair styles and fix styles.
 
 ## Usage
 
-The fix spawns the worker itself via `rootstock serve`, so there is no separate
-worker to start. `rootstock` must be installed and on `PATH`.
+Both styles spawn the worker themselves via `rootstock serve`, so there is no
+separate worker to start. `rootstock` must be installed and on `PATH`.
+
+### pair_style (recommended standalone form)
 
 ```
 units           metal
 atom_style      atomic
 boundary        p p p
 
-pair_style      zero 6.0
-pair_coeff      * *
-
 read_data       structure.data
 
-fix             mlip all rootstock cluster della checkpoint mace-mp-0-medium \
-                device cuda elements Cu
+pair_style      rootstock cluster della checkpoint mace-mp-0-medium device cuda
+pair_coeff      * * Cu
 
-# Energy is available via f_mlip
-thermo_style    custom step temp pe f_mlip
+thermo_style    custom step temp pe press
 thermo          10
 
 run             100
+```
+
+### fix (combine with another potential)
+
+```
+pair_style      eam/alloy
+pair_coeff      * * Cu.eam.alloy Cu
+
+fix             mlip all rootstock cluster della checkpoint mace-mp-0-medium \
+                device cuda elements Cu
 ```
 
 `checkpoint` is a canonical checkpoint id, the same one used by
@@ -61,10 +78,14 @@ built on that cluster (`rootstock install`).
 
 ### Notes
 
-- The fix waits up to `timeout` seconds (default 120) for the worker it spawned
-  to connect back.
-- The `elements` keyword maps LAMMPS atom types to element symbols in order
-  (type 1 = first element, type 2 = second, etc.) and must come last.
-- Forces are added to existing forces (`+=`), so do not use another pair style
-  unless you intend to combine potentials.
-- Requires `units metal` (eV, Angstrom, ps).
+- Both styles wait up to `timeout` seconds (default 120) for the worker they
+  spawned to connect back.
+- Element symbols map LAMMPS atom types in order (type 1 = first element,
+  type 2 = second, etc.) — via `pair_coeff * *` for the pair style, via the
+  trailing `elements` keyword for the fix.
+- Fix forces are added to existing forces (`+=`). With force-rescaling fixes
+  (e.g. `fix ti/spring`), define `fix rootstock` first.
+- Requires `units metal` (eV, Angstrom, ps) and a single MPI rank
+  (`mpirun -np 1` on MPI builds); multi-rank runs are rejected at startup.
+- The pair style reports global energy/virial only — no per-atom energy or
+  stress.

--- a/lammps/install.sh
+++ b/lammps/install.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Install fix_rootstock into a LAMMPS source tree.
+# Install the rootstock styles (fix rootstock, pair_style rootstock) into a
+# LAMMPS source tree.
 #
 # Usage:
 #   ./install.sh /path/to/lammps/src
@@ -23,8 +24,12 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-cp "$SCRIPT_DIR/fix_rootstock.h"   "$LAMMPS_SRC/"
-cp "$SCRIPT_DIR/fix_rootstock.cpp" "$LAMMPS_SRC/"
+cp "$SCRIPT_DIR/rootstock_ipi.h"    "$LAMMPS_SRC/"
+cp "$SCRIPT_DIR/rootstock_ipi.cpp"  "$LAMMPS_SRC/"
+cp "$SCRIPT_DIR/fix_rootstock.h"    "$LAMMPS_SRC/"
+cp "$SCRIPT_DIR/fix_rootstock.cpp"  "$LAMMPS_SRC/"
+cp "$SCRIPT_DIR/pair_rootstock.h"   "$LAMMPS_SRC/"
+cp "$SCRIPT_DIR/pair_rootstock.cpp" "$LAMMPS_SRC/"
 
-echo "Installed fix_rootstock into $LAMMPS_SRC"
-echo "Rebuild LAMMPS to pick up the new fix."
+echo "Installed fix rootstock and pair_style rootstock into $LAMMPS_SRC"
+echo "Rebuild LAMMPS to pick up the new styles."

--- a/lammps/pair_rootstock.cpp
+++ b/lammps/pair_rootstock.cpp
@@ -12,42 +12,58 @@
 ------------------------------------------------------------------------- */
 
 /* ----------------------------------------------------------------------
-   fix rootstock - MLIP forces added via i-PI protocol over Unix sockets
+   pair_style rootstock - MLIP as a genuine pair style via i-PI sockets
 
    Usage:
-     fix <id> <group> rootstock cluster <name> checkpoint <ckpt> \
-         device <dev> elements <e1> <e2> ...
+     pair_style rootstock cluster <name> checkpoint <ckpt> \
+                [device <dev>] [timeout <sec>] [cutoff <r>]
+     pair_coeff * * <e1> <e2> ...
 
    The worker is auto-spawned via `rootstock serve`. Protocol lives in
-   RootstockIPI (rootstock_ipi.cpp), shared with pair_style rootstock.
+   RootstockIPI (rootstock_ipi.cpp), shared with fix rootstock.
 ------------------------------------------------------------------------- */
 
-#include "fix_rootstock.h"
+#include "pair_rootstock.h"
 
 #include "atom.h"
 #include "comm.h"
 #include "domain.h"
 #include "error.h"
+#include "memory.h"
+#include "neighbor.h"
 #include "update.h"
 
 #include <cstdlib>
+#include <cstring>
 
 using namespace LAMMPS_NS;
 
 // ---------------------------------------------------------------------------
-// Constructor — parse keyword arguments
-//   fix <id> <group> rootstock cluster <name> checkpoint <ckpt>
-//       device <dev> timeout <sec> elements <e1> <e2> ...
+// Constructor / destructor
 // ---------------------------------------------------------------------------
-FixRootstock::FixRootstock(LAMMPS *lmp, int narg, char **arg)
-    : Fix(lmp, narg, arg), client_(lmp->error), energy_(0.0) {
+PairRootstock::PairRootstock(LAMMPS *lmp)
+    : Pair(lmp), client_(lmp->error), cut_comm_(1.0) {
+  single_enable = 0;      // no pairwise decomposition exists
+  restartinfo = 0;        // nothing to write to restart files
+  one_coeff = 1;          // single pair_coeff * * line
+  manybody_flag = 1;
+  no_virial_fdotr_compute = 1;    // virial comes whole from the worker
+}
 
-  if (narg < 4) error->all(FLERR, "fix rootstock: not enough arguments");
+PairRootstock::~PairRootstock() {
+  if (allocated) {
+    memory->destroy(setflag);
+    memory->destroy(cutsq);
+  }
+}
 
-  // Parse keyword arguments starting from arg[3]
-  int iarg = 3;
-  bool found_elements = false;
-
+// ---------------------------------------------------------------------------
+// settings — parse pair_style arguments
+//   pair_style rootstock cluster <name> checkpoint <ckpt>
+//              [device <dev>] [timeout <sec>] [cutoff <r>]
+// ---------------------------------------------------------------------------
+void PairRootstock::settings(int narg, char **arg) {
+  int iarg = 0;
   while (iarg < narg) {
     std::string key = arg[iarg];
 
@@ -59,61 +75,69 @@ FixRootstock::FixRootstock(LAMMPS *lmp, int narg, char **arg)
       client_.device = arg[++iarg];
     } else if (key == "timeout" && iarg + 1 < narg) {
       client_.timeout = std::atoi(arg[++iarg]);
-    } else if (key == "elements") {
-      found_elements = true;
-      iarg++;
-      break;
+    } else if (key == "cutoff" && iarg + 1 < narg) {
+      cut_comm_ = std::atof(arg[++iarg]);
+      if (cut_comm_ <= 0.0)
+        error->all(FLERR, "pair_style rootstock: cutoff must be positive");
     } else {
-      error->all(FLERR, "fix rootstock: unknown keyword '{}'", key);
+      error->all(FLERR, "pair_style rootstock: unknown keyword '{}'", key);
     }
     iarg++;
   }
 
-  // Validate required keywords
   if (client_.cluster.empty())
-    error->all(FLERR, "fix rootstock: 'cluster' keyword is required");
+    error->all(FLERR, "pair_style rootstock: 'cluster' keyword is required");
   if (client_.checkpoint.empty())
-    error->all(FLERR, "fix rootstock: 'checkpoint' keyword is required "
-                      "(canonical id, e.g. 'mace-mp-0-medium')");
-  if (!found_elements)
-    error->all(FLERR, "fix rootstock: 'elements' keyword is required");
-
-  // Parse element list (remaining args after 'elements')
-  int ntypes = atom->ntypes;
-  int nelem = narg - iarg;
-  if (nelem != ntypes)
     error->all(FLERR,
-               "fix rootstock: {} elements given but {} atom types defined",
-               nelem, ntypes);
-
-  elements_.resize(ntypes);
-  for (int i = 0; i < ntypes; i++) {
-    std::string sym = arg[iarg + i];
-    if (RootstockIPI::element_to_z(sym) < 0)
-      error->all(FLERR, "fix rootstock: unknown element '{}'", sym);
-    elements_[i] = sym;
-  }
-
-  // Enable thermo output: energy via compute_scalar()
-  scalar_flag = 1;
-  global_freq = 1;
-  energy_global_flag = 1;
-  extscalar = 1;
-
-  // Enable virial contribution for NPT
-  virial_global_flag = 1;
-  thermo_virial = 1;
+               "pair_style rootstock: 'checkpoint' keyword is required "
+               "(canonical id, e.g. 'mace-mp-0-medium')");
 }
 
 // ---------------------------------------------------------------------------
-// setmask — we operate in post_force
+// coeff — parse pair_coeff * * <e1> <e2> ...
 // ---------------------------------------------------------------------------
-int FixRootstock::setmask() { return FixConst::POST_FORCE; }
+void PairRootstock::coeff(int narg, char **arg) {
+  if (!allocated) allocate();
+
+  int ntypes = atom->ntypes;
+  if (narg != 2 + ntypes)
+    error->all(FLERR,
+               "pair_coeff rootstock: expected '* * <{} element symbols>', "
+               "got {} arguments",
+               ntypes, narg);
+  if (std::strcmp(arg[0], "*") != 0 || std::strcmp(arg[1], "*") != 0)
+    error->all(FLERR, "pair_coeff rootstock: only '* *' is supported");
+
+  elements_.resize(ntypes);
+  for (int i = 0; i < ntypes; i++) {
+    std::string sym = arg[2 + i];
+    if (RootstockIPI::element_to_z(sym) < 0)
+      error->all(FLERR, "pair_coeff rootstock: unknown element '{}'", sym);
+    elements_[i] = sym;
+  }
+
+  for (int i = 1; i <= ntypes; i++)
+    for (int j = i; j <= ntypes; j++) setflag[i][j] = 1;
+}
+
+// ---------------------------------------------------------------------------
+// allocate — standard Pair arrays
+// ---------------------------------------------------------------------------
+void PairRootstock::allocate() {
+  allocated = 1;
+  int n = atom->ntypes + 1;
+
+  memory->create(setflag, n, n, "pair:setflag");
+  for (int i = 1; i < n; i++)
+    for (int j = i; j < n; j++) setflag[i][j] = 0;
+
+  memory->create(cutsq, n, n, "pair:cutsq");
+}
 
 // ---------------------------------------------------------------------------
 // refresh_atomic_numbers — rebuild the type -> Z mapping for local atoms
 // ---------------------------------------------------------------------------
-void FixRootstock::refresh_atomic_numbers() {
+void PairRootstock::refresh_atomic_numbers() {
   int nlocal = atom->nlocal;
   int *type = atom->type;
   numbers_.resize(nlocal);
@@ -123,22 +147,29 @@ void FixRootstock::refresh_atomic_numbers() {
 }
 
 // ---------------------------------------------------------------------------
-// init — start the worker on first call
+// init_style — validate, request a (nominal) neighbor list, start worker
 // ---------------------------------------------------------------------------
-void FixRootstock::init() {
-  // Validate units
+void PairRootstock::init_style() {
   if (std::string(update->unit_style) != "metal")
-    error->all(FLERR, "fix rootstock requires 'units metal'");
+    error->all(FLERR, "pair_style rootstock requires 'units metal'");
 
   // The worker sees all atoms and computes its own neighborhoods; there is
   // no force decomposition across ranks.
   if (comm->nprocs > 1)
     error->all(FLERR,
-               "fix rootstock requires a single MPI rank (run with "
+               "pair_style rootstock requires a single MPI rank (run with "
                "'mpirun -np 1')");
 
+  if (elements_.empty())
+    error->all(FLERR,
+               "pair_style rootstock: pair_coeff * * <elements> is required");
+
+  // The list is never read — the worker builds its own neighborhoods — but
+  // LAMMPS's neighbor machinery expects every pair style to hold one.
+  neighbor->add_request(this);
+
   // Only do socket/worker setup on first call.
-  // LAMMPS calls init() at the start of every `run` command.
+  // LAMMPS calls init_style() at the start of every `run` command.
   if (client_.running()) return;
 
   // Warn about atom types with zero atoms
@@ -149,23 +180,25 @@ void FixRootstock::init() {
     for (int i = 0; i < nlocal; i++)
       if (type[i] == t) count++;
     if (count == 0)
-      error->warning(FLERR, "fix rootstock: atom type {} ({}) has no atoms", t,
-                     elements_[t - 1]);
+      error->warning(FLERR, "pair_style rootstock: atom type {} ({}) has no atoms",
+                     t, elements_[t - 1]);
   }
 
   refresh_atomic_numbers();
-  client_.start("fix rootstock", std::string(id));
+  client_.start("pair_style rootstock", "pair");
 }
 
 // ---------------------------------------------------------------------------
-// setup — delegate to post_force (LAMMPS calls this for initial forces)
+// init_one — nominal cutoff for neighbor/comm bookkeeping only
 // ---------------------------------------------------------------------------
-void FixRootstock::setup(int vflag) { post_force(vflag); }
+double PairRootstock::init_one(int /* i */, int /* j */) { return cut_comm_; }
 
 // ---------------------------------------------------------------------------
-// post_force — every timestep: send positions, receive forces
+// compute — every timestep: send positions, receive energy/forces/virial
 // ---------------------------------------------------------------------------
-void FixRootstock::post_force(int /* vflag */) {
+void PairRootstock::compute(int eflag, int vflag) {
+  ev_init(eflag, vflag);
+
   int nlocal = atom->nlocal;
 
   // Refresh every call: atom sorting reorders local atoms without changing
@@ -186,8 +219,9 @@ void FixRootstock::post_force(int /* vflag */) {
     pos_[3 * i + 2] = x[i][2];
   }
 
+  double energy;
   double v6[6];
-  client_.exchange(cell, pos_.data(), nlocal, energy_, frc_.data(), v6);
+  client_.exchange(cell, pos_.data(), nlocal, energy, frc_.data(), v6);
 
   double **f = atom->f;
   for (int i = 0; i < nlocal; i++) {
@@ -196,10 +230,7 @@ void FixRootstock::post_force(int /* vflag */) {
     f[i][2] += frc_[3 * i + 2];
   }
 
-  for (int k = 0; k < 6; k++) virial[k] = v6[k];
+  if (eflag_global) eng_vdwl += energy;
+  if (vflag_global)
+    for (int k = 0; k < 6; k++) virial[k] += v6[k];
 }
-
-// ---------------------------------------------------------------------------
-// compute_scalar — return cached energy for thermo output
-// ---------------------------------------------------------------------------
-double FixRootstock::compute_scalar() { return energy_; }

--- a/lammps/pair_rootstock.h
+++ b/lammps/pair_rootstock.h
@@ -12,35 +12,44 @@
 ------------------------------------------------------------------------- */
 
 /* ----------------------------------------------------------------------
-   fix rootstock - MLIP forces added via i-PI protocol over Unix sockets
+   pair_style rootstock - MLIP as a genuine pair style via i-PI sockets
 
    Communicates with a rootstock worker process that runs an MLIP model
    (MACE, CHGNet, UMA, TensorNet, etc.) in an isolated Python environment.
    The worker is auto-spawned via `rootstock serve`.
 
-   Forces are ADDED to existing forces, so the MLIP can be combined with
-   a real pair style. When the MLIP is the only potential, prefer
-   pair_style rootstock: it contributes to thermo `pe` and `compute pair`
-   natively and composes with pair_style hybrid/scaled.
+   As a pair style, the MLIP participates natively in thermo `pe`,
+   `compute pair`, pressure, and pair_style hybrid/scaled — which is what
+   pair-style-assuming drivers (e.g. calphy) require. This is the
+   recommended integration when the MLIP is the only potential; use
+   fix rootstock to ADD MLIP forces on top of another potential.
 
    Usage:
-     fix <id> <group> rootstock cluster <name> checkpoint <ckpt> \
-         device <dev> elements <e1> <e2> ...
+     pair_style rootstock cluster <name> checkpoint <ckpt> \
+                [device <dev>] [timeout <sec>] [cutoff <r>]
+     pair_coeff * * <e1> <e2> ...
 
    `checkpoint` is a canonical checkpoint id (e.g. 'mace-mp-0-medium'), the
-   same id used by RootstockCalculator and the `rootstock` CLI.
+   same id used by RootstockCalculator and the `rootstock` CLI. The
+   elements on pair_coeff map atom types in order (type 1 = e1, ...).
+
+   `cutoff` only sizes LAMMPS's neighbor/communication bookkeeping — the
+   worker computes its own neighborhoods from the full cell. Default 1.0.
+
+   Per-atom energy and per-atom stress (compute pe/atom, stress/atom) are
+   not provided; the worker reports global quantities only.
 ------------------------------------------------------------------------- */
 
-#ifdef FIX_CLASS
+#ifdef PAIR_CLASS
 // clang-format off
-FixStyle(rootstock, FixRootstock)
+PairStyle(rootstock, PairRootstock)
 // clang-format on
 #else
 
-#ifndef LMP_FIX_ROOTSTOCK_H
-#define LMP_FIX_ROOTSTOCK_H
+#ifndef LMP_PAIR_ROOTSTOCK_H
+#define LMP_PAIR_ROOTSTOCK_H
 
-#include "fix.h"
+#include "pair.h"
 #include "rootstock_ipi.h"
 
 #include <string>
@@ -48,28 +57,28 @@ FixStyle(rootstock, FixRootstock)
 
 namespace LAMMPS_NS {
 
-class FixRootstock : public Fix {
+class PairRootstock : public Pair {
  public:
-  FixRootstock(class LAMMPS *, int, char **);
+  PairRootstock(class LAMMPS *);
+  ~PairRootstock() override;
 
-  int setmask() override;
-  void init() override;
-  void post_force(int) override;
-  void setup(int) override;
-  double compute_scalar() override;
+  void compute(int, int) override;
+  void settings(int, char **) override;
+  void coeff(int, char **) override;
+  void init_style() override;
+  double init_one(int, int) override;
 
  private:
   RootstockIPI client_;
   std::vector<std::string> elements_;    // per atom type, 0-indexed
-
-  // Cached energy for thermo output
-  double energy_;
+  double cut_comm_;
 
   // Per-call scratch buffers
   std::vector<int> numbers_;
   std::vector<double> pos_;
   std::vector<double> frc_;
 
+  void allocate();
   void refresh_atomic_numbers();
 };
 

--- a/lammps/rootstock_ipi.cpp
+++ b/lammps/rootstock_ipi.cpp
@@ -1,0 +1,446 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#include "rootstock_ipi.h"
+
+#include "error.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <sstream>
+
+#include <signal.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+using namespace LAMMPS_NS;
+
+// ---------------------------------------------------------------------------
+// Unit conversions — must match rootstock/protocol.py exactly
+// ---------------------------------------------------------------------------
+static constexpr double BOHR_TO_ANGSTROM = 0.52917721067;
+static constexpr double HARTREE_TO_EV = 27.211386245988;
+static constexpr double ANGSTROM_TO_BOHR = 1.0 / BOHR_TO_ANGSTROM;
+
+// ---------------------------------------------------------------------------
+// Periodic table: element symbol -> atomic number (1-indexed)
+// ---------------------------------------------------------------------------
+static const char *ELEMENT_SYMBOLS[] = {
+    "",   "H",  "He", "Li", "Be", "B",  "C",  "N",  "O",  "F",  "Ne", "Na",
+    "Mg", "Al", "Si", "P",  "S",  "Cl", "Ar", "K",  "Ca", "Sc", "Ti", "V",
+    "Cr", "Mn", "Fe", "Co", "Ni", "Cu", "Zn", "Ga", "Ge", "As", "Se", "Br",
+    "Kr", "Rb", "Sr", "Y",  "Zr", "Nb", "Mo", "Tc", "Ru", "Rh", "Pd", "Ag",
+    "Cd", "In", "Sn", "Sb", "Te", "I",  "Xe", "Cs", "Ba", "La", "Ce", "Pr",
+    "Nd", "Pm", "Sm", "Eu", "Gd", "Tb", "Dy", "Ho", "Er", "Tm", "Yb", "Lu",
+    "Hf", "Ta", "W",  "Re", "Os", "Ir", "Pt", "Au", "Hg", "Tl", "Pb", "Bi",
+    "Po", "At", "Rn", "Fr", "Ra", "Ac", "Th", "Pa", "U",  "Np", "Pu", "Am",
+    "Cm", "Bk", "Cf", "Es", "Fm", "Md", "No", "Lr", "Rf", "Db", "Sg", "Bh",
+    "Hs", "Mt", "Ds", "Rg", "Cn", "Nh", "Fl", "Mc", "Lv", "Ts", "Og"};
+static constexpr int NUM_ELEMENTS = 118;
+
+int RootstockIPI::element_to_z(const std::string &symbol) {
+  for (int i = 1; i <= NUM_ELEMENTS; i++) {
+    if (symbol == ELEMENT_SYMBOLS[i]) return i;
+  }
+  return -1;
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+RootstockIPI::RootstockIPI(Error *error) : error_(error) {}
+
+RootstockIPI::~RootstockIPI() {
+  // Best-effort EXIT message
+  if (client_fd_ >= 0) {
+    char buf[12];
+    std::memset(buf, ' ', 12);
+    std::memcpy(buf, "EXIT", 4);
+    ::send(client_fd_, buf, 12, MSG_NOSIGNAL);
+    ::close(client_fd_);
+  }
+  if (server_fd_ >= 0) ::close(server_fd_);
+
+  // Clean up worker process
+  if (worker_pid_ > 0) {
+    ::kill(worker_pid_, SIGTERM);
+    int status;
+    // Give worker up to 5 seconds to exit
+    for (int i = 0; i < 50; i++) {
+      if (::waitpid(worker_pid_, &status, WNOHANG) != 0) break;
+      usleep(100000);    // 100ms
+    }
+    // Force kill if still alive
+    if (::waitpid(worker_pid_, &status, WNOHANG) == 0) {
+      ::kill(worker_pid_, SIGKILL);
+      ::waitpid(worker_pid_, &status, 0);
+    }
+  }
+
+  // Clean up socket file
+  if (!socket_path_.empty()) ::unlink(socket_path_.c_str());
+}
+
+void RootstockIPI::set_atomic_numbers(std::vector<int> numbers) {
+  atomic_numbers_ = std::move(numbers);
+}
+
+// ---------------------------------------------------------------------------
+// resolve_cluster — call `rootstock resolve --cluster <name> --json`
+// ---------------------------------------------------------------------------
+std::string RootstockIPI::resolve_cluster() {
+  std::string cmd = "rootstock resolve --cluster " + cluster + " --json";
+  FILE *pipe = popen(cmd.c_str(), "r");
+  if (!pipe)
+    error_->all(FLERR,
+                "{}: failed to run 'rootstock resolve'. "
+                "Is rootstock installed? (pip install rootstock)",
+                style_);
+
+  char buffer[1024];
+  std::string output;
+  while (fgets(buffer, sizeof(buffer), pipe)) output += buffer;
+
+  int status = pclose(pipe);
+  if (status != 0)
+    error_->all(FLERR,
+                "{}: 'rootstock resolve --cluster {}' failed. Unknown cluster?",
+                style_, cluster);
+
+  // Parse "root" from JSON output: {"root": "/path/...", "cluster": "..."}
+  // Simple string search — no JSON library needed for this minimal format
+  std::string key = "\"root\": \"";
+  auto pos = output.find(key);
+  if (pos == std::string::npos)
+    error_->all(FLERR, "{}: failed to parse 'rootstock resolve' output", style_);
+
+  pos += key.size();
+  auto end = output.find('"', pos);
+  if (end == std::string::npos)
+    error_->all(FLERR, "{}: failed to parse 'rootstock resolve' output", style_);
+
+  return output.substr(pos, end - pos);
+}
+
+// ---------------------------------------------------------------------------
+// spawn_worker — fork + execlp rootstock serve
+// ---------------------------------------------------------------------------
+pid_t RootstockIPI::spawn_worker(const std::string &root) {
+  pid_t pid = fork();
+  if (pid < 0) error_->all(FLERR, "{}: fork() failed", style_);
+
+  if (pid == 0) {
+    // Child: exec rootstock serve
+    execlp("rootstock", "rootstock", "serve", checkpoint.c_str(), "--root",
+           root.c_str(), "--socket", socket_path_.c_str(), "--device",
+           device.c_str(), nullptr);
+    // If exec fails, exit immediately
+    _exit(127);
+  }
+  return pid;    // Parent: return child PID
+}
+
+// ---------------------------------------------------------------------------
+// start — resolve cluster, create socket, spawn worker, accept, handshake
+// ---------------------------------------------------------------------------
+void RootstockIPI::start(const std::string &style, const std::string &tag) {
+  style_ = style;
+  if (running()) return;
+
+  if (cluster.empty())
+    error_->all(FLERR, "{}: 'cluster' keyword is required", style_);
+  if (checkpoint.empty())
+    error_->all(FLERR,
+                "{}: 'checkpoint' keyword is required "
+                "(canonical id, e.g. 'mace-mp-0-medium')",
+                style_);
+  if (atomic_numbers_.empty())
+    error_->all(FLERR, "{}: atomic numbers not set before start", style_);
+
+  // Resolve cluster root directory
+  std::string root = resolve_cluster();
+
+  // Generate unique socket path
+  socket_path_ =
+      "/tmp/rootstock_" + std::to_string(getpid()) + "_" + tag + ".sock";
+
+  // Create Unix domain socket
+  server_fd_ = ::socket(AF_UNIX, SOCK_STREAM, 0);
+  if (server_fd_ < 0) error_->all(FLERR, "{}: socket() failed", style_);
+
+  struct sockaddr_un addr;
+  std::memset(&addr, 0, sizeof(addr));
+  addr.sun_family = AF_UNIX;
+  if (socket_path_.size() >= sizeof(addr.sun_path))
+    error_->all(FLERR, "{}: socket path too long", style_);
+  std::strncpy(addr.sun_path, socket_path_.c_str(), sizeof(addr.sun_path) - 1);
+
+  // Remove stale socket file
+  ::unlink(socket_path_.c_str());
+
+  if (::bind(server_fd_, (struct sockaddr *) &addr, sizeof(addr)) < 0)
+    error_->all(FLERR, "{}: bind() failed on {}", style_, socket_path_);
+
+  if (::listen(server_fd_, 1) < 0)
+    error_->all(FLERR, "{}: listen() failed", style_);
+
+  // Spawn the worker
+  worker_pid_ = spawn_worker(root);
+
+  // Accept connection with configurable timeout
+  fd_set fds;
+  FD_ZERO(&fds);
+  FD_SET(server_fd_, &fds);
+  struct timeval tv;
+  tv.tv_sec = timeout;
+  tv.tv_usec = 0;
+
+  int sel = ::select(server_fd_ + 1, &fds, nullptr, nullptr, &tv);
+  if (sel <= 0)
+    error_->all(FLERR,
+                "{}: no worker connected within {} seconds. "
+                "Worker may have failed to start. Check that an environment "
+                "providing checkpoint '{}' is built on this cluster.",
+                style_, timeout, checkpoint);
+
+  client_fd_ = ::accept(server_fd_, nullptr, nullptr);
+  if (client_fd_ < 0) error_->all(FLERR, "{}: accept() failed", style_);
+
+  // INIT handshake: STATUS -> NEEDINIT -> INIT -> STATUS -> READY
+  sendmsg("STATUS");
+  std::string status = recvmsg();
+  if (status != "NEEDINIT")
+    error_->all(FLERR, "{}: expected NEEDINIT, got {}", style_, status);
+
+  send_init();
+
+  sendmsg("STATUS");
+  status = recvmsg();
+  if (status != "READY")
+    error_->all(FLERR, "{}: expected READY after INIT, got {}", style_, status);
+}
+
+// ---------------------------------------------------------------------------
+// exchange — one force cycle: positions out, energy/forces/virial back
+// ---------------------------------------------------------------------------
+void RootstockIPI::exchange(const double cell[3][3], const double *x,
+                            int natoms, double &energy, double *forces,
+                            double virial6[6]) {
+  if ((int) atomic_numbers_.size() != natoms)
+    error_->all(FLERR, "{}: {} atomic numbers set but {} atoms", style_,
+                atomic_numbers_.size(), natoms);
+
+  // STATUS -> check state
+  sendmsg("STATUS");
+  std::string status = recvmsg();
+
+  // Worker returns to NEEDINIT after each FORCEREADY, so re-send INIT
+  if (status == "NEEDINIT") {
+    send_init();
+    sendmsg("STATUS");
+    status = recvmsg();
+  }
+
+  if (status != "READY")
+    error_->all(FLERR, "{}: expected READY, got {}", style_, status);
+
+  // Send positions
+  send_posdata(cell, x, natoms);
+
+  // STATUS -> HAVEDATA
+  sendmsg("STATUS");
+  status = recvmsg();
+  if (status != "HAVEDATA")
+    error_->all(FLERR, "{}: expected HAVEDATA, got {}", style_, status);
+
+  // GETFORCE -> FORCEREADY
+  sendmsg("GETFORCE");
+  recv_forceready(natoms, energy, forces, virial6);
+}
+
+// ---------------------------------------------------------------------------
+// send_init — send INIT message with JSON species data
+// ---------------------------------------------------------------------------
+void RootstockIPI::send_init() {
+  // Build JSON: {"numbers": [29, 29, ...], "pbc": [true, true, true]}
+  std::ostringstream json;
+  json << "{\"numbers\": [";
+  for (size_t i = 0; i < atomic_numbers_.size(); i++) {
+    if (i > 0) json << ", ";
+    json << atomic_numbers_[i];
+  }
+  json << "], \"pbc\": [true, true, true]}";
+  std::string init_str = json.str();
+
+  sendmsg("INIT");
+
+  // bead index (int32)
+  int32_t bead = 0;
+  sendall(&bead, sizeof(bead));
+
+  // init string length (int32) + bytes
+  int32_t nbytes = (int32_t) init_str.size();
+  sendall(&nbytes, sizeof(nbytes));
+  sendall(init_str.data(), init_str.size());
+}
+
+// ---------------------------------------------------------------------------
+// send_posdata — send cell + positions in atomic units
+// ---------------------------------------------------------------------------
+void RootstockIPI::send_posdata(const double cell[3][3], const double *x,
+                                int natoms) {
+  sendmsg("POSDATA");
+
+  // LAMMPS box: lower-triangular cell
+  //   [[lx,  0,  0],
+  //    [xy, ly,  0],
+  //    [xz, yz, lz]]
+  double lx = cell[0][0];
+  double ly = cell[1][1];
+  double lz = cell[2][2];
+  double xy = cell[1][0];
+  double xz = cell[2][0];
+  double yz = cell[2][1];
+
+  // Transpose and convert to Bohr for i-PI column-major convention
+  double cell_t[3][3];
+  for (int i = 0; i < 3; i++)
+    for (int j = 0; j < 3; j++) cell_t[i][j] = cell[j][i] * ANGSTROM_TO_BOHR;
+
+  // Inverse of lower-triangular 3x3
+  double inv_lx = 1.0 / lx;
+  double inv_ly = 1.0 / ly;
+  double inv_lz = 1.0 / lz;
+
+  double icell[3][3] = {{inv_lx, 0.0, 0.0},
+                        {-xy * inv_lx * inv_ly, inv_ly, 0.0},
+                        {(xy * yz - ly * xz) * inv_lx * inv_ly * inv_lz,
+                         -yz * inv_ly * inv_lz, inv_lz}};
+
+  // Transpose and convert to match protocol.py:
+  //   icell_bohr = np.linalg.pinv(cell).T / ANGSTROM_TO_BOHR
+  // The worker receives but discards icell (recv_posdata ignores it).
+  double icell_t[3][3];
+  for (int i = 0; i < 3; i++)
+    for (int j = 0; j < 3; j++) icell_t[i][j] = icell[j][i] / ANGSTROM_TO_BOHR;
+
+  sendall(cell_t, sizeof(cell_t));
+  sendall(icell_t, sizeof(icell_t));
+
+  // Number of atoms
+  int32_t n32 = natoms;
+  sendall(&n32, sizeof(n32));
+
+  // Positions in Bohr
+  std::vector<double> pos(natoms * 3);
+  for (int i = 0; i < 3 * natoms; i++) pos[i] = x[i] * ANGSTROM_TO_BOHR;
+  sendall(pos.data(), pos.size() * sizeof(double));
+}
+
+// ---------------------------------------------------------------------------
+// recv_forceready — receive energy, forces, virial from worker
+// ---------------------------------------------------------------------------
+void RootstockIPI::recv_forceready(int natoms, double &energy, double *forces,
+                                   double virial6[6]) {
+  std::string msg = recvmsg();
+  if (msg != "FORCEREADY")
+    error_->all(FLERR, "{}: expected FORCEREADY, got {}", style_, msg);
+
+  // Energy in Hartree
+  double energy_hartree;
+  recvall(&energy_hartree, sizeof(energy_hartree));
+  energy = energy_hartree * HARTREE_TO_EV;
+
+  // Number of atoms
+  int32_t natoms_recv;
+  recvall(&natoms_recv, sizeof(natoms_recv));
+  if (natoms_recv != natoms)
+    error_->all(FLERR, "{}: natoms mismatch ({} vs {})", style_, natoms_recv,
+                natoms);
+
+  // Forces in Hartree/Bohr -> eV/Angstrom
+  std::vector<double> forces_au(natoms * 3);
+  recvall(forces_au.data(), forces_au.size() * sizeof(double));
+
+  double force_conv = HARTREE_TO_EV / BOHR_TO_ANGSTROM;
+  for (int i = 0; i < 3 * natoms; i++) forces[i] = forces_au[i] * force_conv;
+
+  // Virial: 3x3 transposed in Hartree -> Voigt in eV.
+  // i-PI sends column-major 3x3 (virial.T), so after receiving as row-major
+  // we have the transpose. For a symmetric tensor, indices are interchangeable.
+  double virial_au[9];
+  recvall(virial_au, sizeof(virial_au));
+
+  // Convert Hartree -> eV, store in LAMMPS Voigt order: xx, yy, zz, xy, xz, yz
+  // (the order Pair::ev_tally and compute pressure use).
+  virial6[0] = virial_au[0] * HARTREE_TO_EV;    // xx
+  virial6[1] = virial_au[4] * HARTREE_TO_EV;    // yy
+  virial6[2] = virial_au[8] * HARTREE_TO_EV;    // zz
+  virial6[3] = virial_au[1] * HARTREE_TO_EV;    // xy
+  virial6[4] = virial_au[2] * HARTREE_TO_EV;    // xz
+  virial6[5] = virial_au[5] * HARTREE_TO_EV;    // yz
+
+  // Extra bytes
+  int32_t nextra;
+  recvall(&nextra, sizeof(nextra));
+  if (nextra > 0) {
+    std::vector<char> extra(nextra);
+    recvall(extra.data(), nextra);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Socket I/O helpers
+// ---------------------------------------------------------------------------
+void RootstockIPI::sendall(const void *buf, size_t len) {
+  const char *p = (const char *) buf;
+  size_t sent = 0;
+  while (sent < len) {
+    ssize_t n = ::send(client_fd_, p + sent, len - sent, 0);
+    if (n <= 0) error_->all(FLERR, "{}: send failed", style_);
+    sent += (size_t) n;
+  }
+}
+
+void RootstockIPI::recvall(void *buf, size_t len) {
+  char *p = (char *) buf;
+  size_t received = 0;
+  while (received < len) {
+    ssize_t n = ::recv(client_fd_, p + received, len - received, 0);
+    if (n <= 0)
+      error_->all(FLERR, "{}: recv failed (connection closed?)", style_);
+    received += (size_t) n;
+  }
+}
+
+void RootstockIPI::sendmsg(const char *msg) {
+  char buf[12];
+  std::memset(buf, ' ', 12);
+  size_t msglen = std::strlen(msg);
+  if (msglen > 12) msglen = 12;
+  std::memcpy(buf, msg, msglen);
+  sendall(buf, 12);
+}
+
+std::string RootstockIPI::recvmsg() {
+  char buf[12];
+  recvall(buf, 12);
+  // Trim trailing spaces
+  int end = 11;
+  while (end >= 0 && buf[end] == ' ') end--;
+  return std::string(buf, end + 1);
+}

--- a/lammps/rootstock_ipi.h
+++ b/lammps/rootstock_ipi.h
@@ -1,0 +1,95 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://www.lammps.org/
+   LAMMPS development team: developers@lammps.org
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   RootstockIPI - shared i-PI dialect client for the rootstock styles
+
+   Owns the worker subprocess and Unix socket, and speaks the rootstock
+   i-PI dialect (JSON INIT payload, re-sent every force cycle). The wire
+   format is a frozen contract with rootstock/protocol.py; both
+   fix rootstock and pair_style rootstock delegate to this class so the
+   protocol has exactly one implementation on the LAMMPS side.
+
+   Not a LAMMPS style itself — no FixStyle/PairStyle registration.
+------------------------------------------------------------------------- */
+
+#ifndef LMP_ROOTSTOCK_IPI_H
+#define LMP_ROOTSTOCK_IPI_H
+
+#include <string>
+#include <sys/types.h>
+#include <vector>
+
+namespace LAMMPS_NS {
+
+class Error;
+
+class RootstockIPI {
+ public:
+  explicit RootstockIPI(Error *error);
+  ~RootstockIPI();
+
+  // User-facing configuration; set before start().
+  std::string cluster;
+  std::string checkpoint;
+  std::string device = "cuda";
+  int timeout = 120;
+
+  bool running() const { return client_fd_ >= 0; }
+
+  // Species (atomic numbers) sent with every (re-)INIT. Callers must
+  // refresh this before each exchange(): LAMMPS re-sorts atoms without
+  // changing nlocal, so a mapping captured once goes stale silently.
+  void set_atomic_numbers(std::vector<int> numbers);
+
+  // Resolve the cluster root, bind the socket, spawn `rootstock serve`,
+  // accept the worker connection, and complete the INIT handshake.
+  // `style` prefixes error messages (e.g. "pair_style rootstock");
+  // `tag` disambiguates the socket path within this process.
+  void start(const std::string &style, const std::string &tag);
+
+  // One force evaluation. `cell` is the row-major lower-triangular LAMMPS
+  // box in Angstrom; `x` is 3*natoms positions in Angstrom. Outputs:
+  // energy in eV, forces in eV/Angstrom (3*natoms, overwritten), virial
+  // in eV in LAMMPS Voigt order (xx, yy, zz, xy, xz, yz).
+  void exchange(const double cell[3][3], const double *x, int natoms,
+                double &energy, double *forces, double virial6[6]);
+
+  static int element_to_z(const std::string &symbol);
+
+ private:
+  Error *error_;
+  std::string style_ = "rootstock";
+  std::string socket_path_;
+  int server_fd_ = -1;
+  int client_fd_ = -1;
+  pid_t worker_pid_ = -1;
+  std::vector<int> atomic_numbers_;
+
+  std::string resolve_cluster();
+  pid_t spawn_worker(const std::string &root);
+
+  void sendall(const void *buf, size_t len);
+  void recvall(void *buf, size_t len);
+  void sendmsg(const char *msg);
+  std::string recvmsg();
+
+  void send_init();
+  void send_posdata(const double cell[3][3], const double *x, int natoms);
+  void recv_forceready(int natoms, double &energy, double *forces,
+                       double virial6[6]);
+};
+
+}    // namespace LAMMPS_NS
+
+#endif

--- a/sample_model_configurations/nvidia_configs/allegro.py
+++ b/sample_model_configurations/nvidia_configs/allegro.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.11"
 # dependencies = [
 #     "nequip-allegro @ git+https://github.com/mir-group/allegro.git",
 #     "nequip>=0.6.0",

--- a/sample_model_configurations/nvidia_configs/ani.py
+++ b/sample_model_configurations/nvidia_configs/ani.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.11"
 # dependencies = [
 #     "torchani>=2.2",
 #     "ase>=3.22",

--- a/sample_model_configurations/nvidia_configs/chgnet.py
+++ b/sample_model_configurations/nvidia_configs/chgnet.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.11"
 # dependencies = [
 #     "chgnet>=0.3.0",
 #     "ase>=3.22",

--- a/sample_model_configurations/nvidia_configs/m3gnet.py
+++ b/sample_model_configurations/nvidia_configs/m3gnet.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.11"
 # dependencies = [
 #     "chgnet>=0.4.0",
 #     "ase>=3.22",

--- a/sample_model_configurations/nvidia_configs/mace.py
+++ b/sample_model_configurations/nvidia_configs/mace.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.11"
 # dependencies = [
 #     "mace-torch>=0.3.0",
 #     "ase>=3.22",

--- a/sample_model_configurations/nvidia_configs/mace_off23.py
+++ b/sample_model_configurations/nvidia_configs/mace_off23.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.11"
 # dependencies = [
 #     "mace-torch>=0.3.0",
 #     "ase>=3.22",

--- a/sample_model_configurations/nvidia_configs/mace_polar.py
+++ b/sample_model_configurations/nvidia_configs/mace_polar.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.11"
 # dependencies = [
 #     "ase>=3.22",
 #     "torch>=2.4.0,<2.10",

--- a/sample_model_configurations/nvidia_configs/mattersim.py
+++ b/sample_model_configurations/nvidia_configs/mattersim.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.11"
 # dependencies = [
 #     "mattersim>=1.1.0",
 #     "ase>=3.22",

--- a/sample_model_configurations/nvidia_configs/nequip.py
+++ b/sample_model_configurations/nvidia_configs/nequip.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.11"
 # dependencies = [
 #     "nequip>=0.6.0",
 #     "ase>=3.22",

--- a/sample_model_configurations/nvidia_configs/orb.py
+++ b/sample_model_configurations/nvidia_configs/orb.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.11"
 # dependencies = [
 #     "orb-models>=0.4.0",
 #     "ase>=3.22",

--- a/sample_model_configurations/nvidia_configs/sevennet.py
+++ b/sample_model_configurations/nvidia_configs/sevennet.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.11"
 # dependencies = [
 #     "sevenn>=0.10.0",
 #     "ase>=3.22",

--- a/sample_model_configurations/nvidia_configs/tensornet.py
+++ b/sample_model_configurations/nvidia_configs/tensornet.py
@@ -5,7 +5,10 @@
 #     "ase>=3.22",
 #     "huggingface_hub",
 #     "matgl",
-#     "nvalchemi-toolkit-ops",
+#     # 0.4+ needs torch>=2.8 at runtime (custom-op registration uses string
+#     # annotations infer_schema can't parse on older torch) but only declares
+#     # the constraint on its extras, so the resolver won't catch it.
+#     "nvalchemi-toolkit-ops<0.4",
 #     "pymatgen",
 #     "monty",
 #     "ruamel.yaml",

--- a/sample_model_configurations/nvidia_configs/torchmdnet.py
+++ b/sample_model_configurations/nvidia_configs/torchmdnet.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.11"
 # dependencies = [
 #     "torchmd-net",
 #     "ase>=3.22",


### PR DESCRIPTION
I got a refreshed install working on Della, and made these tweaks along the way:
- I needed to bump the min Python version of some configs to work with the new 3.11 minimum in the Rootstock library.
- I added a new "pair style" to the LAMMPS integration. Calphy can integrate with this. It _could not_ integrate with the old fix