### PR TITLE
Re-land #97: manifest state semantics never reached main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Rootstock is a proof-of-concept for running MLIP (Machine Learning Interatomic Potential) calculators in isolated pre-built Python environments, communicating via the i-PI protocol over Unix sockets.
 
-**Current version: v0.8** - Manifest schema v3; canonical-checkpoint-id API.
+**Current version: v0.8** - Manifest schema v4 (older schemas migrate in place on load); canonical-checkpoint-id API.
 
 ## Commands
 

--- a/rootstock/commands/add.py
+++ b/rootstock/commands/add.py
@@ -132,25 +132,26 @@ def _ensure_manifest_entry(
 
     env = manifest.environments.get(env_name)
     if env is None:
-        # The env directory must exist for the operation to make sense, but if
-        # the manifest hasn't been refreshed yet we'll synthesize a minimal
-        # entry. update_and_push_manifest() will fill in the rest on save.
+        # The manifest hasn't been refreshed since this env was built. Refresh
+        # from disk rather than synthesizing a placeholder — a fabricated
+        # built_at=now would fake freshness into the verified_at > built_at
+        # staleness comparison, and an empty source_hash would record nothing.
         env_dir = root / "envs" / env_name
         if not (env_dir / "bin" / "python").exists():
             raise RuntimeError(
                 f"environment '{env_name}' is not built at {env_dir}.\n"
                 f"Run: rootstock install <path-to-{env_name}.py> --root {root}"
             )
-        env = EnvironmentInfo(
-            status="ready",
-            built_at=now_iso(),
-            source_hash="",
-            source="",
-            python_requires=">=3.11",
-            dependencies={},
-            checkpoints={},
-        )
-        manifest.environments[env_name] = env
+        from .manifest import _refresh_manifest_environments
+
+        manifest = _refresh_manifest_environments(manifest, root)
+        env = manifest.environments.get(env_name)
+        if env is None:
+            raise RuntimeError(
+                f"environment '{env_name}' is built at {env_dir} but has no "
+                f"env_source.py — rebuild it: rootstock install {env_name} "
+                f"--root {root} --force"
+            )
 
     if checkpoint not in env.checkpoints:
         env.checkpoints[checkpoint] = CheckpointInfo()

--- a/rootstock/commands/install.py
+++ b/rootstock/commands/install.py
@@ -310,8 +310,10 @@ def _install_single_environment(
 
     print(f"\nBuilt environment: {env_target}")
 
-    # Update manifest (quiet=True to avoid cluttering build output)
-    update_and_push_manifest(root, quiet=False, push=not no_push)
+    # Update manifest (quiet=True to avoid cluttering build output).
+    # built_env stamps this env's built_at to now — the one moment the true
+    # build time is known.
+    update_and_push_manifest(root, quiet=False, push=not no_push, built_env=env_name)
 
     return 0
 

--- a/rootstock/commands/manifest.py
+++ b/rootstock/commands/manifest.py
@@ -12,6 +12,7 @@ from ..config import load_config
 from ..manifest import (
     EnvironmentInfo,
     Manifest,
+    built_at_estimate,
     compute_source_hash,
     create_manifest,
     get_installed_versions,
@@ -28,6 +29,7 @@ def update_and_push_manifest(
     cluster: str | None = None,
     quiet: bool = False,
     push: bool = True,
+    built_env: str | None = None,
 ) -> bool:
     """
     Update manifest with current state and optionally push to backend.
@@ -39,6 +41,8 @@ def update_and_push_manifest(
         cluster: Cluster name (optional, will try to detect)
         quiet: Suppress output
         push: Whether to push to backend (default True)
+        built_env: Env name that was (re)built by the calling command, if any;
+            its built_at is stamped to now
 
     Returns:
         True if push succeeded or was skipped (no API key), False on error
@@ -70,7 +74,7 @@ def update_and_push_manifest(
         manifest = create_manifest(root, cluster, config)
 
     # Refresh environment info from current state
-    manifest = _refresh_manifest_environments(manifest, root)
+    manifest = _refresh_manifest_environments(manifest, root, built_env=built_env)
 
     # Save locally
     save_manifest(manifest, root)
@@ -104,11 +108,19 @@ def update_and_push_manifest(
     return True  # Not maintainer or no API key = skip push (not an error)
 
 
-def _refresh_manifest_environments(manifest: Manifest, root: Path) -> Manifest:
+def _refresh_manifest_environments(
+    manifest: Manifest, root: Path, built_env: str | None = None
+) -> Manifest:
     """
     Update manifest with current environment state.
 
     Scans built environments and updates their info in the manifest.
+
+    built_at semantics: `built_env` (the env the calling command just built)
+    is stamped now; envs already in the manifest keep their recorded time; an
+    env the manifest has never seen gets the env directory's mtime as a
+    best-effort estimate — never `now`, which would fake freshness into the
+    `verified_at > built_at` staleness comparison.
     """
     from .. import __version__
     from ..environment import list_built_environments
@@ -145,9 +157,15 @@ def _refresh_manifest_environments(manifest: Manifest, root: Path) -> Manifest:
         existing_env = manifest.environments.get(env_name)
         checkpoints = existing_env.checkpoints if existing_env else {}
 
+        if env_name == built_env:
+            built_at = now_iso()
+        elif existing_env:
+            built_at = existing_env.built_at
+        else:
+            built_at = built_at_estimate(env_path)
+
         manifest.environments[env_name] = EnvironmentInfo(
-            status="ready",
-            built_at=existing_env.built_at if existing_env else now_iso(),
+            built_at=built_at,
             source_hash=source_hash,
             source=source_content,
             python_requires=python_requires,
@@ -197,7 +215,6 @@ def cmd_manifest_show(args) -> int:
         print(f"  Environments ({len(manifest.environments)}):")
         for name, env in manifest.environments.items():
             print(f"    {name}:")
-            print(f"      Status:       {env.status}")
             print(f"      Built at:     {env.built_at}")
             print(f"      Source hash:  {env.source_hash[:20]}...")
             print(f"      Dependencies: {len(env.dependencies)} packages")

--- a/rootstock/commands/smoke_test.py
+++ b/rootstock/commands/smoke_test.py
@@ -28,8 +28,6 @@ def _select(
     for env_name, env in manifest.environments.items():
         if env_filter is not None and env_name != env_filter:
             continue
-        if env.status != "ready":
-            continue
         for ckpt_name, ckpt in env.checkpoints.items():
             if checkpoint_filter is not None and ckpt_name != checkpoint_filter:
                 continue

--- a/rootstock/manifest.py
+++ b/rootstock/manifest.py
@@ -24,7 +24,7 @@ from pathlib import Path
 
 from .config import UserConfig
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 
 def _migrate_v1_to_v2(data: dict) -> tuple[dict, str | None]:
@@ -70,12 +70,26 @@ def _migrate_v2_to_v3(data: dict) -> tuple[dict, str | None]:
     return data, note
 
 
+def _migrate_v3_to_v4(data: dict) -> tuple[dict, str | None]:
+    """v4 dropped EnvironmentInfo.status and .error_message.
+
+    Nothing ever wrote a status other than "ready" or set an error message,
+    so removing the keys loses no information.
+    """
+    for env in data.get("environments", {}).values():
+        env.pop("status", None)
+        env.pop("error_message", None)
+    data["schema_version"] = 4
+    return data, None
+
+
 # One entry per historical schema version, upgrading one step. A schema bump
 # without a migration here strands every deployed manifest of that vintage —
 # add the migration in the same change as the bump.
 MIGRATIONS = {
     1: _migrate_v1_to_v2,
     2: _migrate_v2_to_v3,
+    3: _migrate_v3_to_v4,
 }
 
 
@@ -174,20 +188,22 @@ class CheckpointInfo:
 
 @dataclass
 class EnvironmentInfo:
-    """Metadata for a single built environment."""
+    """Metadata for a single built environment.
 
-    status: str  # "ready", "building", "error"
+    An entry exists iff the env is built on disk — there is no status field.
+    A failed build leaves no env directory, so the manifest never has anything
+    to say about it.
+    """
+
     built_at: str  # ISO 8601 timestamp
     source_hash: str  # "sha256:abc123..."
     source: str  # Full source code of the environment file
     python_requires: str  # ">=3.11"
     dependencies: dict[str, str]  # {"mace-torch": "0.3.6"}
     checkpoints: dict[str, CheckpointInfo] = field(default_factory=dict)
-    error_message: str | None = None
 
     def to_dict(self) -> dict:
-        d = {
-            "status": self.status,
+        return {
             "built_at": self.built_at,
             "source_hash": self.source_hash,
             "source": self.source,
@@ -195,9 +211,6 @@ class EnvironmentInfo:
             "dependencies": self.dependencies,
             "checkpoints": {name: ckpt.to_dict() for name, ckpt in self.checkpoints.items()},
         }
-        if self.error_message:
-            d["error_message"] = self.error_message
-        return d
 
     @classmethod
     def from_dict(cls, data: dict) -> EnvironmentInfo:
@@ -207,14 +220,12 @@ class EnvironmentInfo:
             for name, ckpt_data in checkpoints_data.items()
         }
         return cls(
-            status=data["status"],
             built_at=data["built_at"],
             source_hash=data["source_hash"],
             source=data.get("source", ""),
             python_requires=data["python_requires"],
             dependencies=data["dependencies"],
             checkpoints=checkpoints,
-            error_message=data.get("error_message"),
         )
 
 
@@ -288,12 +299,6 @@ class Manifest:
         if not self.maintainer.email:
             return False, "Missing maintainer email"
 
-        # Validate environment status values
-        valid_statuses = {"ready", "building", "error"}
-        for env_name, env_info in self.environments.items():
-            if env_info.status not in valid_statuses:
-                return False, f"Invalid status '{env_info.status}' for {env_name}"
-
         return True, "OK"
 
 
@@ -346,7 +351,7 @@ def get_installed_versions(
 
             if result.returncode == 0:
                 packages_data = json.loads(result.stdout)
-        except (subprocess.TimeoutExpired, json.JSONDecodeError, KeyError):
+        except (subprocess.TimeoutExpired, json.JSONDecodeError, KeyError, OSError):
             pass
 
     # Fallback to python -m pip list
@@ -361,7 +366,7 @@ def get_installed_versions(
 
             if result.returncode == 0:
                 packages_data = json.loads(result.stdout)
-        except (subprocess.TimeoutExpired, json.JSONDecodeError, KeyError):
+        except (subprocess.TimeoutExpired, json.JSONDecodeError, KeyError, OSError):
             pass
 
     if not packages_data:
@@ -401,6 +406,19 @@ def detect_python_version(root: Path) -> str:
 def now_iso() -> str:
     """Return current UTC time as ISO 8601 string."""
     return datetime.now(timezone.utc).isoformat()
+
+
+def built_at_estimate(env_path: Path) -> str:
+    """Best-effort build time for an env the manifest doesn't know about.
+
+    The env directory's mtime is set when the build wrote its last top-level
+    entry, so it approximates the true build time. Only ``install`` knows the
+    exact moment; everything else discovering an already-built env must not
+    fabricate ``built_at=now``, which would poison the
+    ``verified_at > built_at`` staleness comparison.
+    """
+    ts = env_path.stat().st_mtime
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
 
 
 def load_manifest(root: Path) -> Manifest | None:

--- a/tests/cli/test_smoke_test.py
+++ b/tests/cli/test_smoke_test.py
@@ -32,7 +32,6 @@ def populated_root(tmp_path: Path, monkeypatch) -> Path:
     manifest = create_manifest(root, "test", cfg)
 
     manifest.environments["mace"] = EnvironmentInfo(
-        status="ready",
         built_at="2026-01-01T00:00:00Z",
         source_hash="sha256:abc",
         source="",
@@ -45,7 +44,6 @@ def populated_root(tmp_path: Path, monkeypatch) -> Path:
         },
     )
     manifest.environments["uma"] = EnvironmentInfo(
-        status="ready",
         built_at="2026-01-01T00:00:00Z",
         source_hash="sha256:def",
         source="",

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -17,7 +17,6 @@ from rootstock.manifest import (
 
 def _env_with_checkpoints(built_at: str, **checkpoints) -> EnvironmentInfo:
     return EnvironmentInfo(
-        status="ready",
         built_at=built_at,
         source_hash="sha256:abc",
         source="",

--- a/tests/manifest/test_built_at.py
+++ b/tests/manifest/test_built_at.py
@@ -1,0 +1,126 @@
+"""built_at semantics: stamped by install, preserved on refresh, estimated
+from disk for envs the manifest has never seen.
+
+`verified_at > built_at` is the staleness comparison behind `rootstock
+status` and smoke-test reporting; a fabricated built_at silently breaks it
+in both directions.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from rootstock.commands.add import _ensure_manifest_entry
+from rootstock.commands.manifest import _refresh_manifest_environments
+from rootstock.manifest import (
+    SCHEMA_VERSION,
+    Maintainer,
+    Manifest,
+    built_at_estimate,
+)
+
+ENV_SOURCE = (
+    "# /// script\n"
+    '# requires-python = ">=3.10"\n'
+    '# dependencies = ["six>=1.0"]\n'
+    "# ///\n"
+    "CHECKPOINTS = {}\n"
+)
+
+BUILD_TIME = 1735689600  # 2025-01-01T00:00:00Z
+
+
+@pytest.fixture(autouse=True)
+def _no_version_probe(monkeypatch):
+    """Version probing shells out to the env's python; not under test here."""
+    monkeypatch.setattr(
+        "rootstock.commands.manifest.get_installed_versions", lambda *a, **k: {}
+    )
+
+
+def _make_built_env(root: Path, name: str = "mace") -> Path:
+    env_dir = root / "envs" / name
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+    (env_dir / "env_source.py").write_text(ENV_SOURCE)
+    os.utime(env_dir, (BUILD_TIME, BUILD_TIME))
+    return env_dir
+
+
+def _manifest(root: Path, environments=None) -> Manifest:
+    return Manifest(
+        schema_version=SCHEMA_VERSION,
+        cluster="test",
+        root=str(root),
+        maintainer=Maintainer(name="a", email="a@b.c"),
+        rootstock_version="0.0.0",
+        python_version="3.10",
+        last_updated="2026-01-01T00:00:00Z",
+        environments=environments or {},
+    )
+
+
+# --- _refresh_manifest_environments ------------------------------------------
+
+
+def test_refresh_stamps_built_env_to_now(tmp_path):
+    _make_built_env(tmp_path)
+    manifest = _refresh_manifest_environments(_manifest(tmp_path), tmp_path)
+    old = manifest.environments["mace"].built_at
+
+    manifest = _refresh_manifest_environments(manifest, tmp_path, built_env="mace")
+
+    assert manifest.environments["mace"].built_at > old
+
+
+def test_refresh_preserves_built_at_for_known_env(tmp_path):
+    _make_built_env(tmp_path)
+    manifest = _refresh_manifest_environments(_manifest(tmp_path), tmp_path)
+    recorded = manifest.environments["mace"].built_at
+
+    manifest = _refresh_manifest_environments(manifest, tmp_path)
+
+    assert manifest.environments["mace"].built_at == recorded
+
+
+def test_refresh_estimates_built_at_from_dir_mtime_for_unknown_env(tmp_path):
+    env_dir = _make_built_env(tmp_path)
+
+    manifest = _refresh_manifest_environments(_manifest(tmp_path), tmp_path)
+
+    built_at = manifest.environments["mace"].built_at
+    assert built_at == built_at_estimate(env_dir)
+    assert built_at.startswith("2025-01-01")  # dir mtime, not now
+
+
+# --- rootstock add: no more placeholder entries -------------------------------
+
+
+def test_add_backfills_real_env_info_from_disk(tmp_path):
+    """When the manifest lags a built env, add refreshes from disk instead of
+    synthesizing a placeholder with source_hash='' and built_at=now."""
+    env_dir = _make_built_env(tmp_path)
+
+    manifest, env, _ = _ensure_manifest_entry(tmp_path, "test", "mace", "some-ckpt")
+
+    assert env.source_hash.startswith("sha256:")
+    assert env.source == ENV_SOURCE
+    assert env.built_at == built_at_estimate(env_dir)
+    assert "some-ckpt" in env.checkpoints
+
+
+def test_add_errors_on_unbuilt_env(tmp_path):
+    with pytest.raises(RuntimeError, match="not built"):
+        _ensure_manifest_entry(tmp_path, "test", "mace", "some-ckpt")
+
+
+def test_add_errors_on_env_missing_source(tmp_path):
+    env_dir = tmp_path / "envs" / "mace"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+
+    with pytest.raises(RuntimeError, match="no env_source.py"):
+        _ensure_manifest_entry(tmp_path, "test", "mace", "some-ckpt")

--- a/tests/manifest/test_manifest.py
+++ b/tests/manifest/test_manifest.py
@@ -16,7 +16,6 @@ from rootstock.manifest import (
 
 def _make_env(built_at: str = "2026-01-01T00:00:00Z", **ckpts: CheckpointInfo) -> EnvironmentInfo:
     return EnvironmentInfo(
-        status="ready",
         built_at=built_at,
         source_hash="sha256:abc",
         source="",
@@ -40,7 +39,7 @@ def _make_manifest(envs: dict[str, EnvironmentInfo] | None = None) -> Manifest:
 
 
 def test_schema_version_constant():
-    assert SCHEMA_VERSION == 3
+    assert SCHEMA_VERSION == 4
 
 
 def test_checkpoint_info_round_trip():

--- a/tests/manifest/test_migrations.py
+++ b/tests/manifest/test_migrations.py
@@ -72,7 +72,10 @@ def test_v2_environments_survive_checkpoints_dropped():
 
 def test_v2_without_checkpoints_migrates_quietly():
     _, notes = migrate_manifest_data(_base(2, {"mace": _v2_env()}))
-    assert notes == ["migrated manifest schema v2 -> v3"]
+    assert notes == [
+        "migrated manifest schema v2 -> v3",
+        "migrated manifest schema v3 -> v4",
+    ]
 
 
 def test_v2_loads_via_from_dict():
@@ -81,7 +84,28 @@ def test_v2_loads_via_from_dict():
     assert "mace" in manifest.environments
 
 
-# --- v1 -> v3 (full chain) --------------------------------------------------
+# --- v3 -> v4 -------------------------------------------------------------
+
+
+def test_v3_drops_dead_status_fields():
+    """v4 removed EnvironmentInfo.status/error_message (nothing ever wrote
+    values other than the defaults)."""
+    env = _v2_env({"mace-mp-0-medium": {"fetched_at": "2026-01-02T00:00:00Z"}})
+    env["error_message"] = None
+    data = _base(3, {"mace": env})
+
+    migrated, notes = migrate_manifest_data(data)
+
+    assert migrated["schema_version"] == SCHEMA_VERSION
+    assert "status" not in migrated["environments"]["mace"]
+    assert "error_message" not in migrated["environments"]["mace"]
+    # v3 checkpoint ids are already canonical — they survive
+    assert "mace-mp-0-medium" in migrated["environments"]["mace"]["checkpoints"]
+    assert notes == ["migrated manifest schema v3 -> v4"]
+    assert "mace" in Manifest.from_dict(migrated).environments
+
+
+# --- v1 -> v4 (full chain) --------------------------------------------------
 
 
 def test_v1_chain_migrates_to_current():
@@ -92,7 +116,7 @@ def test_v1_chain_migrates_to_current():
     assert migrated["schema_version"] == SCHEMA_VERSION
     # v1->v2 mints empty CheckpointInfo dicts; v2->v3 then drops them
     assert migrated["environments"]["mace"]["checkpoints"] == {}
-    assert len(notes) == 2
+    assert len(notes) == 3
     assert Manifest.from_dict(migrated).environments["mace"].source_hash == "sha256:abc"
 
 


### PR DESCRIPTION
## Summary

#97 was stacked on `manifest-schema-migrations`, and because that branch wasn't deleted when #96 was squash-merged, GitHub never retargeted #97 to `main` — so merging #97 merged it **into the base branch**, and main never received it. This cherry-picks #97's squash commit onto main.

Content is exactly what was already reviewed and approved in #97 (built_at stamping via `built_env`, add refreshing from disk instead of placeholders, dir-mtime estimates, schema v4 dropping `status`/`error_message`). One conflict resolved: #104 had bumped `python_requires` inside the placeholder block that #97 deletes — the deletion wins.

After this merges, the `manifest-schema-migrations` branch can be deleted.

## Test plan
- `uv run pytest tests/` — 237 passed on the cherry-picked branch, including #97's `tests/manifest/test_built_at.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)