### PR TITLE
One source of truth for install state: the InstallState reader

### DIFF
--- a/rootstock/commands/manifest.py
+++ b/rootstock/commands/manifest.py
@@ -13,7 +13,6 @@ from ..manifest import (
     EnvironmentInfo,
     Manifest,
     built_at_estimate,
-    compute_source_hash,
     create_manifest,
     get_installed_versions,
     load_manifest,
@@ -114,7 +113,9 @@ def _refresh_manifest_environments(
     """
     Update manifest with current environment state.
 
-    Scans built environments and updates their info in the manifest.
+    Reads the installation through the InstallState reader: the filesystem
+    decides which envs the manifest records, and records for envs no longer
+    on disk are dropped.
 
     built_at semantics: `built_env` (the env the calling command just built)
     is stamped now; envs already in the manifest keep their recorded time; an
@@ -123,61 +124,61 @@ def _refresh_manifest_environments(
     `verified_at > built_at` staleness comparison.
     """
     from .. import __version__
-    from ..environment import list_built_environments
+    from ..install_state import read_install_state
 
     # Update rootstock version
     manifest.rootstock_version = __version__
 
-    # Get current built environments
-    built = list_built_environments(root)
+    state = read_install_state(root, manifest=manifest)
 
-    for env_name, env_path in built:
-        # Check if env_source.py exists
-        source_file = env_path / "env_source.py"
-        if not source_file.exists():
+    for env_name, env in state.envs.items():
+        if env.source_file is None:
+            # Built but missing env_source.py — nothing derivable to record;
+            # keep whatever record already exists.
             continue
 
-        # Get source hash and content
-        source_hash = compute_source_hash(source_file)
-        source_content = source_file.read_text()
-
-        # Hash the build's lockfile if the env has one (envs built before
-        # lockfiles existed won't)
-        lock_file = env_path / "env_source.py.lock"
-        lock_hash = compute_source_hash(lock_file) if lock_file.exists() else None
+        source_content = env.source_file.read_text()
 
         # Get python requires from source
-        python_requires = get_requires_python(source_file) or ">=3.11"
+        python_requires = get_requires_python(env.source_file) or ">=3.11"
 
         # Get direct dependencies from source
-        direct_deps = get_dependencies(source_file)
+        direct_deps = get_dependencies(env.source_file)
         # Always track rootstock itself
         if "rootstock" not in [d.lower() for d in direct_deps]:
             direct_deps.append("rootstock")
 
         # Get installed package versions (filtered to direct dependencies)
-        dependencies = get_installed_versions(env_path, only_packages=direct_deps)
+        dependencies = get_installed_versions(env.path, only_packages=direct_deps)
 
         # Get checkpoints (from existing manifest if available)
-        existing_env = manifest.environments.get(env_name)
-        checkpoints = existing_env.checkpoints if existing_env else {}
+        checkpoints = env.record.checkpoints if env.record else {}
 
         if env_name == built_env:
             built_at = now_iso()
-        elif existing_env:
-            built_at = existing_env.built_at
+        elif env.record:
+            built_at = env.record.built_at
         else:
-            built_at = built_at_estimate(env_path)
+            built_at = built_at_estimate(env.path)
 
         manifest.environments[env_name] = EnvironmentInfo(
             built_at=built_at,
-            source_hash=source_hash,
+            source_hash=env.source_hash,
             source=source_content,
             python_requires=python_requires,
             dependencies=dependencies,
             checkpoints=checkpoints,
-            lock_hash=lock_hash,
+            lock_hash=env.lock_hash,
         )
+
+    # The filesystem is the truth for what's installed: a record whose env
+    # is gone from disk describes nothing and must not reach the push payload.
+    for env_name in sorted(state.manifest_only_envs):
+        print(
+            f"Note: dropping manifest record for '{env_name}' — env no longer on disk",
+            file=sys.stderr,
+        )
+        del manifest.environments[env_name]
 
     return manifest
 

--- a/rootstock/commands/status.py
+++ b/rootstock/commands/status.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import json
 
 from ..config import DEFAULT_CONFIG_FILE
-from ..manifest import is_verified, load_manifest
+from ..install_state import InstallState, read_install_state
+from ..manifest import is_verified
 from .common import get_root_or_exit, resolve_cache_root
 
 
@@ -42,46 +43,50 @@ def _checkpoint_line(env, ckpt_name: str, ckpt) -> str:
 
 def cmd_status(args) -> int:
     """Show status of rootstock installation."""
-    from ..environment import list_built_environments, list_environments
-
     root = get_root_or_exit(args)
-    manifest = load_manifest(root)
+    state = read_install_state(root)
 
     if getattr(args, "json", False):
-        return _cmd_status_json(root, manifest)
+        return _cmd_status_json(state)
 
     print(f"Rootstock root: {root}")
 
     # List environment sources
     print("\nEnvironment sources:")
-    sources = list_environments(root)
-    if not sources:
+    if not state.sources:
         print("  (none)")
     else:
-        for name, path in sources:
+        for name, path in state.sources:
             print(f"  {name}")
 
     # List built environments + per-checkpoint verification state
     print("\nBuilt environments:")
-    built = list_built_environments(root)
-    if not built:
+    if not state.envs and not state.manifest_only_envs:
         print("  (none)")
     else:
-        for name, path in built:
-            has_source = (path / "env_source.py").exists()
-            status = "ready" if has_source else "incomplete"
+        for name, env in state.envs.items():
+            status = "ready" if env.source_file is not None else "incomplete"
             print(f"  {name:<20} [{status}]")
 
-            env = manifest.environments.get(name) if manifest else None
-            if env is None:
+            if env.source_hash_drifted:
+                print(
+                    "    ⚠ env_source.py on disk differs from the manifest "
+                    "(in-place hotfix?) — run 'rootstock smoke-test' to re-record"
+                )
+
+            if env.record is None:
                 continue
-            if not env.checkpoints:
+            if not env.record.checkpoints:
                 print("    (no checkpoints — run 'rootstock add <checkpoint-id>')")
                 continue
-            print(f"    Built: {env.built_at}")
-            print(f"    Checkpoints ({len(env.checkpoints)}):")
-            for ckpt_name, ckpt in env.checkpoints.items():
-                print(_checkpoint_line(env, ckpt_name, ckpt))
+            print(f"    Built: {env.record.built_at}")
+            print(f"    Checkpoints ({len(env.record.checkpoints)}):")
+            for ckpt_name, ckpt in env.record.checkpoints.items():
+                print(_checkpoint_line(env.record, ckpt_name, ckpt))
+
+        # Records the manifest still carries for envs that are gone from disk.
+        for name in sorted(state.manifest_only_envs):
+            print(f"  {name:<20} [manifest only — not on disk]")
 
     # Show cache sizes. Cache may live under the install root or under a
     # separate cluster-registered cache_root. Some libraries respect
@@ -117,18 +122,45 @@ def cmd_status(args) -> int:
     return 0
 
 
-def _cmd_status_json(root, manifest) -> int:
-    """Emit raw manifest data plus computed verified_current per checkpoint."""
-    if manifest is None:
-        print(json.dumps({"root": str(root), "manifest": None}))
-        return 0
+def _cmd_status_json(state: InstallState) -> int:
+    """Emit the merged install state as JSON.
 
-    data = manifest.to_dict()
-    for env_name, env in manifest.environments.items():
-        env_data = data["environments"][env_name]
-        for ckpt_name, ckpt in env.checkpoints.items():
-            env_data["checkpoints"][ckpt_name]["verified_current"] = is_verified(env, ckpt)
-    print(json.dumps({"root": str(root), "manifest": data}, indent=2))
+    Environments are enumerated from the filesystem (the truth for what's
+    installed); manifest metadata (built_at, checkpoint fetch/verify state)
+    is joined in where it exists. Manifest records for envs no longer on
+    disk are listed separately rather than passed off as installed.
+    """
+    environments = {}
+    for name, env in state.envs.items():
+        checkpoints = {}
+        if env.record is not None:
+            for ckpt_name, ckpt in env.record.checkpoints.items():
+                ckpt_data = ckpt.to_dict()
+                ckpt_data["verified_current"] = is_verified(env.record, ckpt)
+                checkpoints[ckpt_name] = ckpt_data
+        environments[name] = {
+            "has_source": env.source_file is not None,
+            "source_hash": env.source_hash,
+            "lock_hash": env.lock_hash,
+            "declared_checkpoints": sorted(env.declared_checkpoints or {}),
+            "in_manifest": env.record is not None,
+            "built_at": env.record.built_at if env.record else None,
+            "manifest_source_hash": env.record.source_hash if env.record else None,
+            "checkpoints": checkpoints,
+        }
+
+    manifest = state.manifest
+    payload = {
+        "root": str(state.root),
+        "cluster": manifest.cluster if manifest else None,
+        "maintainer": manifest.maintainer.to_dict() if manifest else None,
+        "rootstock_version": manifest.rootstock_version if manifest else None,
+        "last_updated": manifest.last_updated if manifest else None,
+        "sources": [name for name, _ in state.sources],
+        "environments": environments,
+        "manifest_only_environments": sorted(state.manifest_only_envs),
+    }
+    print(json.dumps(payload, indent=2))
     return 0
 
 

--- a/rootstock/install_state.py
+++ b/rootstock/install_state.py
@@ -1,0 +1,130 @@
+"""
+Unified reader for the state of a rootstock installation.
+
+The filesystem is the source of truth for *what is installed*: which envs
+are built, their source files, hashes, and declared checkpoints. The
+manifest is the source of truth only for what cannot be derived from disk:
+fetch/verify timestamps, build times, maintainer, and cluster identity.
+
+Everything that renders or publishes install state — the ``status`` human
+view, ``status --json``, and the manifest refresh behind ``manifest push`` —
+reads through :func:`read_install_state` so the views cannot disagree about
+which environments exist.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .environment import (
+    list_built_environments,
+    list_environments,
+    parse_checkpoints_dict,
+)
+from .manifest import (
+    EnvironmentInfo,
+    Manifest,
+    compute_source_hash,
+    load_manifest,
+)
+
+# Sentinel distinguishing "load the manifest for me" from an explicit
+# manifest (including an explicit None).
+_LOAD = object()
+
+
+@dataclass
+class EnvState:
+    """Merged view of one built environment.
+
+    Disk-derived fields describe what is actually installed. ``record`` is
+    the manifest's metadata for the env and may be absent (manifest lagging
+    the filesystem) or stale (``source_hash_drifted``).
+    """
+
+    name: str
+    path: Path
+    source_file: Path | None  # envs/<name>/env_source.py, if present
+    source_hash: str | None
+    lock_hash: str | None
+    # CHECKPOINTS parsed from env_source.py; None when the source file is
+    # missing or its CHECKPOINTS dict is malformed.
+    declared_checkpoints: dict[str, str] | None
+    record: EnvironmentInfo | None
+
+    @property
+    def source_hash_drifted(self) -> bool:
+        """True when env_source.py on disk no longer matches the manifest —
+        e.g. an in-place hotfix that hasn't been re-recorded yet."""
+        return (
+            self.record is not None
+            and self.source_hash is not None
+            and self.record.source_hash != self.source_hash
+        )
+
+
+@dataclass
+class InstallState:
+    root: Path
+    sources: list[tuple[str, Path]]  # environments/*.py source files
+    envs: dict[str, EnvState]  # every built env under envs/
+    manifest: Manifest | None
+
+    @property
+    def manifest_only_envs(self) -> dict[str, EnvironmentInfo]:
+        """Manifest environment records with no built env behind them."""
+        if self.manifest is None:
+            return {}
+        return {
+            name: env for name, env in self.manifest.environments.items() if name not in self.envs
+        }
+
+
+def read_install_state(root: Path | str, manifest: object = _LOAD) -> InstallState:
+    """Read the merged filesystem + manifest state of an installation.
+
+    Args:
+        root: Rootstock install root.
+        manifest: Pass an already-loaded (or freshly created) ``Manifest`` to
+            join against instead of loading from disk — callers that are
+            about to mutate a manifest must pass their own instance so the
+            per-env ``record`` fields alias it.
+    """
+    root = Path(root)
+    if manifest is _LOAD:
+        manifest = load_manifest(root)
+
+    envs: dict[str, EnvState] = {}
+    for name, path in list_built_environments(root):
+        source_file: Path | None = path / "env_source.py"
+        source_hash = None
+        declared = None
+        if source_file.exists():
+            source_hash = compute_source_hash(source_file)
+            try:
+                declared = parse_checkpoints_dict(source_file)
+            except ValueError:
+                declared = None
+        else:
+            source_file = None
+
+        lock_file = path / "env_source.py.lock"
+        lock_hash = compute_source_hash(lock_file) if lock_file.exists() else None
+
+        envs[name] = EnvState(
+            name=name,
+            path=path,
+            source_file=source_file,
+            source_hash=source_hash,
+            lock_hash=lock_hash,
+            declared_checkpoints=declared,
+            record=manifest.environments.get(name) if manifest else None,
+        )
+
+    return InstallState(
+        root=root,
+        sources=list_environments(root),
+        envs=envs,
+        manifest=manifest,
+    )

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -10,20 +10,43 @@ from rootstock.config import UserConfig
 from rootstock.manifest import (
     CheckpointInfo,
     EnvironmentInfo,
+    compute_source_hash,
     create_manifest,
     save_manifest,
 )
 
+ENV_SOURCE = 'CHECKPOINTS = {"mace-mp-0-small": "small", "mace-mp-0-medium": "medium"}\n'
 
-def _env_with_checkpoints(built_at: str, **checkpoints) -> EnvironmentInfo:
+
+def _make_built_env(root: Path, name: str = "mace") -> Path:
+    env_dir = root / "envs" / name
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+    (env_dir / "env_source.py").write_text(ENV_SOURCE)
+    return env_dir
+
+
+def _env_with_checkpoints(
+    built_at: str, source_hash: str = "sha256:abc", **checkpoints
+) -> EnvironmentInfo:
     return EnvironmentInfo(
         built_at=built_at,
-        source_hash="sha256:abc",
+        source_hash=source_hash,
         source="",
         python_requires=">=3.10",
         dependencies={},
         checkpoints=dict(checkpoints),
     )
+
+
+def _args(root: Path, as_json: bool):
+    class _Args:
+        pass
+
+    args = _Args()
+    args.root = str(root)
+    args.json = as_json
+    return args
 
 
 def test_checkpoint_line_marks_verified():
@@ -71,10 +94,12 @@ def test_checkpoint_line_includes_last_error():
 
 def test_status_json_includes_verified_current(tmp_path: Path, capsys):
     """--json should add a computed verified_current bool per checkpoint."""
+    env_dir = _make_built_env(tmp_path)
     cfg = UserConfig(name="t", email="t@t.t")
     manifest = create_manifest(tmp_path, "test", cfg)
     manifest.environments["mace"] = _env_with_checkpoints(
         "2026-01-01T00:00:00Z",
+        source_hash=compute_source_hash(env_dir / "env_source.py"),
         **{
             "mace-mp-0-medium": CheckpointInfo(
                 fetched_at="2026-01-02T00:00:00Z",
@@ -86,33 +111,65 @@ def test_status_json_includes_verified_current(tmp_path: Path, capsys):
     )
     save_manifest(manifest, tmp_path)
 
-    class _Args:
-        pass
-
-    args = _Args()
-    args.root = str(tmp_path)
-    args.json = True
-
-    rc = cmd_status(args)
+    rc = cmd_status(_args(tmp_path, as_json=True))
     assert rc == 0
 
     parsed = json.loads(capsys.readouterr().out)
-    ckpts = parsed["manifest"]["environments"]["mace"]["checkpoints"]
-    assert ckpts["mace-mp-0-medium"]["verified_current"] is True
-    assert ckpts["mace-mp-0-small"]["verified_current"] is False
+    env = parsed["environments"]["mace"]
+    assert env["in_manifest"] is True
+    assert env["built_at"] == "2026-01-01T00:00:00Z"
+    assert env["checkpoints"]["mace-mp-0-medium"]["verified_current"] is True
+    assert env["checkpoints"]["mace-mp-0-small"]["verified_current"] is False
+    assert env["declared_checkpoints"] == ["mace-mp-0-medium", "mace-mp-0-small"]
+    assert parsed["cluster"] == "test"
 
 
 def test_status_json_no_manifest(tmp_path: Path, capsys):
-    """--json without a manifest should still emit valid JSON."""
+    """--json without a manifest still lists what's installed on disk."""
+    _make_built_env(tmp_path)
 
-    class _Args:
-        pass
-
-    args = _Args()
-    args.root = str(tmp_path)
-    args.json = True
-
-    rc = cmd_status(args)
+    rc = cmd_status(_args(tmp_path, as_json=True))
     assert rc == 0
+
     parsed = json.loads(capsys.readouterr().out)
-    assert parsed["manifest"] is None
+    assert parsed["cluster"] is None
+    env = parsed["environments"]["mace"]
+    assert env["in_manifest"] is False
+    assert env["built_at"] is None
+    assert env["has_source"] is True
+
+
+def test_status_json_separates_manifest_only_envs(tmp_path: Path, capsys):
+    """An env recorded in the manifest but gone from disk must not be
+    presented as installed."""
+    _make_built_env(tmp_path)
+    cfg = UserConfig(name="t", email="t@t.t")
+    manifest = create_manifest(tmp_path, "test", cfg)
+    manifest.environments["deleted"] = _env_with_checkpoints("2026-01-01T00:00:00Z")
+    save_manifest(manifest, tmp_path)
+
+    rc = cmd_status(_args(tmp_path, as_json=True))
+    assert rc == 0
+
+    parsed = json.loads(capsys.readouterr().out)
+    assert "deleted" not in parsed["environments"]
+    assert parsed["manifest_only_environments"] == ["deleted"]
+    assert "mace" in parsed["environments"]
+
+
+def test_status_human_view_flags_drift_and_manifest_only(tmp_path: Path, capsys):
+    _make_built_env(tmp_path)
+    cfg = UserConfig(name="t", email="t@t.t")
+    manifest = create_manifest(tmp_path, "test", cfg)
+    manifest.environments["mace"] = _env_with_checkpoints(
+        "2026-01-01T00:00:00Z", source_hash="sha256:stale"
+    )
+    manifest.environments["deleted"] = _env_with_checkpoints("2026-01-01T00:00:00Z")
+    save_manifest(manifest, tmp_path)
+
+    rc = cmd_status(_args(tmp_path, as_json=False))
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    assert "differs from the manifest" in out
+    assert "manifest only — not on disk" in out

--- a/tests/manifest/test_refresh_prune.py
+++ b/tests/manifest/test_refresh_prune.py
@@ -1,0 +1,91 @@
+"""_refresh_manifest_environments drops records for envs gone from disk.
+
+The filesystem is the truth for what's installed; a manifest record with no
+built env behind it must not survive a refresh (and hence must never reach
+the push payload the Almanac renders from).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rootstock.commands.manifest import _refresh_manifest_environments
+from rootstock.manifest import (
+    SCHEMA_VERSION,
+    EnvironmentInfo,
+    Maintainer,
+    Manifest,
+)
+
+ENV_SOURCE = (
+    "# /// script\n"
+    '# requires-python = ">=3.10"\n'
+    '# dependencies = ["six>=1.0"]\n'
+    "# ///\n"
+    "CHECKPOINTS = {}\n"
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_version_probe(monkeypatch):
+    """Version probing shells out to the env's python; not under test here."""
+    monkeypatch.setattr(
+        "rootstock.commands.manifest.get_installed_versions", lambda *a, **k: {}
+    )
+
+
+def _make_built_env(root: Path, name: str, with_source: bool = True) -> Path:
+    env_dir = root / "envs" / name
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+    if with_source:
+        (env_dir / "env_source.py").write_text(ENV_SOURCE)
+    return env_dir
+
+
+def _record() -> EnvironmentInfo:
+    return EnvironmentInfo(
+        built_at="2026-01-01T00:00:00Z",
+        source_hash="sha256:abc",
+        source="",
+        python_requires=">=3.10",
+        dependencies={},
+    )
+
+
+def _manifest(root: Path, environments: dict) -> Manifest:
+    return Manifest(
+        schema_version=SCHEMA_VERSION,
+        cluster="test",
+        root=str(root),
+        maintainer=Maintainer(name="a", email="a@b.c"),
+        rootstock_version="0.0.0",
+        python_version="3.10",
+        last_updated="2026-01-01T00:00:00Z",
+        environments=environments,
+    )
+
+
+def test_refresh_drops_record_for_env_gone_from_disk(tmp_path, capsys):
+    _make_built_env(tmp_path, "mace")
+    manifest = _manifest(tmp_path, {"mace": _record(), "deleted": _record()})
+
+    manifest = _refresh_manifest_environments(manifest, tmp_path)
+
+    assert set(manifest.environments) == {"mace"}
+    assert "dropping manifest record for 'deleted'" in capsys.readouterr().err
+
+
+def test_refresh_keeps_record_for_built_env_missing_source(tmp_path, capsys):
+    """A built env whose env_source.py is missing is still installed; its
+    existing record is kept untouched rather than pruned or refreshed."""
+    _make_built_env(tmp_path, "sourceless", with_source=False)
+    record = _record()
+    manifest = _manifest(tmp_path, {"sourceless": record})
+
+    manifest = _refresh_manifest_environments(manifest, tmp_path)
+
+    assert manifest.environments["sourceless"] is record
+    assert "dropping" not in capsys.readouterr().err

--- a/tests/test_install_state.py
+++ b/tests/test_install_state.py
@@ -1,0 +1,167 @@
+"""InstallState: filesystem decides what's installed; manifest supplies the rest."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rootstock.install_state import read_install_state
+from rootstock.manifest import (
+    SCHEMA_VERSION,
+    EnvironmentInfo,
+    Maintainer,
+    Manifest,
+    compute_source_hash,
+    save_manifest,
+)
+
+ENV_SOURCE = (
+    "# /// script\n"
+    '# requires-python = ">=3.10"\n'
+    '# dependencies = ["six>=1.0"]\n'
+    "# ///\n"
+    'CHECKPOINTS = {"mace-mp-0-small": "small"}\n'
+)
+
+
+def _make_built_env(root: Path, name: str = "mace", source: str | None = ENV_SOURCE) -> Path:
+    env_dir = root / "envs" / name
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+    if source is not None:
+        (env_dir / "env_source.py").write_text(source)
+    return env_dir
+
+
+def _env_record(source_hash: str = "sha256:abc") -> EnvironmentInfo:
+    return EnvironmentInfo(
+        built_at="2026-01-01T00:00:00Z",
+        source_hash=source_hash,
+        source="",
+        python_requires=">=3.10",
+        dependencies={},
+    )
+
+
+def _manifest(root: Path, environments: dict | None = None) -> Manifest:
+    return Manifest(
+        schema_version=SCHEMA_VERSION,
+        cluster="test",
+        root=str(root),
+        maintainer=Maintainer(name="a", email="a@b.c"),
+        rootstock_version="0.0.0",
+        python_version="3.10",
+        last_updated="2026-01-01T00:00:00Z",
+        environments=environments or {},
+    )
+
+
+def test_envs_enumerated_from_filesystem_without_manifest(tmp_path):
+    _make_built_env(tmp_path)
+
+    state = read_install_state(tmp_path)
+
+    assert state.manifest is None
+    assert set(state.envs) == {"mace"}
+    env = state.envs["mace"]
+    assert env.source_hash == compute_source_hash(env.source_file)
+    assert env.declared_checkpoints == {"mace-mp-0-small": "small"}
+    assert env.record is None
+
+
+def test_manifest_record_joined_when_present(tmp_path):
+    env_dir = _make_built_env(tmp_path)
+    source_hash = compute_source_hash(env_dir / "env_source.py")
+    manifest = _manifest(tmp_path, {"mace": _env_record(source_hash)})
+    save_manifest(manifest, tmp_path)
+
+    state = read_install_state(tmp_path)
+
+    env = state.envs["mace"]
+    assert env.record is not None
+    assert env.record.built_at == "2026-01-01T00:00:00Z"
+    assert not env.source_hash_drifted
+
+
+def test_source_hash_drift_detected(tmp_path):
+    _make_built_env(tmp_path)
+    manifest = _manifest(tmp_path, {"mace": _env_record("sha256:stale")})
+    save_manifest(manifest, tmp_path)
+
+    state = read_install_state(tmp_path)
+
+    assert state.envs["mace"].source_hash_drifted
+
+
+def test_manifest_only_envs_are_not_installed(tmp_path):
+    _make_built_env(tmp_path)
+    manifest = _manifest(
+        tmp_path, {"mace": _env_record(), "deleted": _env_record()}
+    )
+    save_manifest(manifest, tmp_path)
+
+    state = read_install_state(tmp_path)
+
+    assert set(state.envs) == {"mace"}
+    assert set(state.manifest_only_envs) == {"deleted"}
+
+
+def test_env_without_source_file(tmp_path):
+    _make_built_env(tmp_path, source=None)
+
+    state = read_install_state(tmp_path)
+
+    env = state.envs["mace"]
+    assert env.source_file is None
+    assert env.source_hash is None
+    assert env.declared_checkpoints is None
+
+
+def test_malformed_checkpoints_dict_yields_none(tmp_path):
+    _make_built_env(tmp_path, source="CHECKPOINTS = [1, 2]\n")
+
+    state = read_install_state(tmp_path)
+
+    env = state.envs["mace"]
+    assert env.declared_checkpoints is None
+    assert env.source_hash is not None  # hash still derivable
+
+
+def test_lock_hash_read_from_disk(tmp_path):
+    env_dir = _make_built_env(tmp_path)
+    lock = env_dir / "env_source.py.lock"
+    lock.write_text("version = 1\n")
+
+    state = read_install_state(tmp_path)
+
+    assert state.envs["mace"].lock_hash == compute_source_hash(lock)
+
+
+def test_explicit_manifest_instance_is_aliased(tmp_path):
+    """A caller about to mutate a manifest passes its own instance; the
+    per-env records must alias it, not a fresh load from disk."""
+    _make_built_env(tmp_path)
+    manifest = _manifest(tmp_path, {"mace": _env_record()})
+
+    state = read_install_state(tmp_path, manifest=manifest)
+
+    assert state.manifest is manifest
+    assert state.envs["mace"].record is manifest.environments["mace"]
+
+
+def test_explicit_none_manifest_skips_loading(tmp_path):
+    _make_built_env(tmp_path)
+    save_manifest(_manifest(tmp_path, {"mace": _env_record()}), tmp_path)
+
+    state = read_install_state(tmp_path, manifest=None)
+
+    assert state.manifest is None
+    assert state.envs["mace"].record is None
+
+
+def test_sources_listed(tmp_path):
+    (tmp_path / "environments").mkdir()
+    (tmp_path / "environments" / "mace.py").write_text(ENV_SOURCE)
+
+    state = read_install_state(tmp_path)
+
+    assert [name for name, _ in state.sources] == ["mace"]


### PR DESCRIPTION
## Summary

Fixes #110 (from the pre-1.0 audit issue #80). Runtime checkpoint resolution, `status`'s human view, `status --json`, and the manifest refresh each derived "what's installed" independently, and the views could disagree — `--json` printed the manifest only, so an env deleted from disk still looked installed, while an env the manifest lagged was invisible.

**The rule now:** the filesystem is the truth for *what's installed*; the manifest is the truth only for what disk can't derive (fetch/verify timestamps, `built_at`, maintainer, cluster identity). A new `rootstock/install_state.py` module implements it as one `read_install_state(root)` reader returning an `InstallState` — per-env disk facts (source file, source/lock hashes, declared `CHECKPOINTS`) joined with the manifest record — and all three consumers read through it:

- **`status` (human)** renders from `InstallState`; same output as before, plus two honest additions: a `⚠ env_source.py on disk differs from the manifest` marker (surfaces the in-place-hotfix drift from #100) and a `[manifest only — not on disk]` line for orphaned records.
- **`status --json`** now emits the merged view: environments enumerated from disk with manifest metadata joined in (`in_manifest`, `built_at`, `manifest_source_hash`, checkpoints with `verified_current`), plus `manifest_only_environments`. **This is a shape change** — the old `{"root", "manifest"}` wrapper is gone. (Nothing consumed the old shape: the jq paths in our driver scripts already didn't match it.)
- **`_refresh_manifest_environments`** (the push payload the Almanac renders from) consumes the reader for enumeration and hashes, and now **prunes records for envs gone from disk**, with a note to stderr. Records for a built env missing its `env_source.py` are kept untouched (nothing derivable to refresh), as before.

`built_at` semantics from #97 are unchanged: stamp on build, preserve on refresh, dir-mtime estimate for unknown envs.

## Test plan
- New `tests/test_install_state.py` (10 tests): disk enumeration without manifest, record joining and aliasing for mutating callers, drift detection, manifest-only separation, sourceless/malformed-CHECKPOINTS envs, lock hash.
- New `tests/manifest/test_refresh_prune.py`: prune on refresh + note; sourceless built env's record survives.
- `tests/cli/test_status.py` updated to the new `--json` shape; new tests for manifest-only separation and the human-view drift/orphan markers.
- E2E against a fake install root: human view, `--json`, hotfix drift marker, ghost-record separation, and prune-on-refresh all exercised through the real CLI.
- Full suite: 282 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)