### PR TITLE
Create sockets in private 0700 directories instead of /tmp/ipi_<name>

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -249,14 +249,19 @@ Exit code is 0 if all tested checkpoints passed, 1 otherwise.
 Start a worker process for an external i-PI server (advanced usage). Takes a single canonical checkpoint id; the hosting env is resolved from the id.
 
 ```bash
+# Create the socket inside a private directory — a socket directly in /tmp
+# is world-visible and race-able by other users on shared nodes.
+SOCKET_DIR=$(mktemp -d)
 rootstock serve mace-mp-0-medium \
-  --socket /tmp/ipi_socket \
+  --socket "$SOCKET_DIR/ipi.sock" \
   --device cuda
 ```
 
 Options:
 
-- `--socket <path>`: Unix socket path for the i-PI server
+- `--socket <path>`: Unix socket path for the i-PI server. Place it inside a
+  private (0700) directory, e.g. from `mktemp -d` — the LAMMPS styles and
+  `RootstockServer` do this automatically for the sockets they create.
 - `--device <dev>`: Device (default: `cuda`)
 - `--kwarg KEY=VAL`: Repeatable extra kwarg passed to `setup()` (same JSON-decoding as `add`)
 

--- a/lammps/rootstock_ipi.cpp
+++ b/lammps/rootstock_ipi.cpp
@@ -91,8 +91,9 @@ RootstockIPI::~RootstockIPI() {
     }
   }
 
-  // Clean up socket file
+  // Clean up socket file and its private directory
   if (!socket_path_.empty()) ::unlink(socket_path_.c_str());
+  if (!socket_dir_.empty()) ::rmdir(socket_dir_.c_str());
 }
 
 void RootstockIPI::set_atomic_numbers(std::vector<int> numbers) {
@@ -174,9 +175,15 @@ void RootstockIPI::start(const std::string &style, const std::string &tag) {
   // Resolve cluster root directory
   std::string root = resolve_cluster();
 
-  // Generate unique socket path
-  socket_path_ =
-      "/tmp/rootstock_" + std::to_string(getpid()) + "_" + tag + ".sock";
+  // Create the socket inside a fresh private (0700) directory. A bare
+  // /tmp/<name>.sock is world-visible with umask-derived permissions and
+  // race-able by other local users on shared nodes; a socket inside a
+  // mkdtemp directory is unreachable by anyone else.
+  char dir_template[] = "/tmp/rootstock.XXXXXX";
+  if (::mkdtemp(dir_template) == nullptr)
+    error_->all(FLERR, "{}: mkdtemp() failed for socket directory", style_);
+  socket_dir_ = dir_template;
+  socket_path_ = socket_dir_ + "/ipi_" + tag + ".sock";
 
   // Create Unix domain socket
   server_fd_ = ::socket(AF_UNIX, SOCK_STREAM, 0);
@@ -188,9 +195,6 @@ void RootstockIPI::start(const std::string &style, const std::string &tag) {
   if (socket_path_.size() >= sizeof(addr.sun_path))
     error_->all(FLERR, "{}: socket path too long", style_);
   std::strncpy(addr.sun_path, socket_path_.c_str(), sizeof(addr.sun_path) - 1);
-
-  // Remove stale socket file
-  ::unlink(socket_path_.c_str());
 
   if (::bind(server_fd_, (struct sockaddr *) &addr, sizeof(addr)) < 0)
     error_->all(FLERR, "{}: bind() failed on {}", style_, socket_path_);

--- a/lammps/rootstock_ipi.h
+++ b/lammps/rootstock_ipi.h
@@ -70,6 +70,7 @@ class RootstockIPI {
  private:
   Error *error_;
   std::string style_ = "rootstock";
+  std::string socket_dir_;
   std::string socket_path_;
   int server_fd_ = -1;
   int client_fd_ = -1;

--- a/rootstock/protocol.py
+++ b/rootstock/protocol.py
@@ -241,13 +241,31 @@ class IPIProtocol:
 # -----------------------------------------------------------------------------
 
 
-def create_unix_socket_path(name: str) -> str:
+def create_private_socket_path(name: str) -> str:
     """
-    Create path for Unix domain socket following i-PI convention.
+    Create a fresh private (0700) directory and return a socket path inside it.
 
-    i-PI uses /tmp/ipi_<name> as the socket path.
+    Sockets historically lived at ``/tmp/ipi_<name>`` (the i-PI convention):
+    world-visible, with umask-derived permissions — race-able by other local
+    users on shared login nodes. A socket inside a ``mkdtemp`` directory is
+    reachable only by the owning user; no peer check is needed because other
+    users cannot traverse into the directory at all.
+
+    The caller owns the directory and must remove it (socket included) on
+    shutdown. Created under the default temp dir unless the resulting path
+    would threaten the ~104-byte ``sun_path`` limit, in which case /tmp is
+    used instead.
     """
-    return f"/tmp/ipi_{name}"
+    import os
+    import tempfile
+
+    sock_dir = tempfile.mkdtemp(prefix="rootstock-")
+    path = os.path.join(sock_dir, f"ipi_{name}")
+    if len(path) >= 100:
+        os.rmdir(sock_dir)
+        sock_dir = tempfile.mkdtemp(prefix="rootstock-", dir="/tmp")
+        path = os.path.join(sock_dir, f"ipi_{name}")
+    return path
 
 
 def create_server_socket(socket_path: str, timeout: float = None) -> socket.socket:

--- a/rootstock/server.py
+++ b/rootstock/server.py
@@ -7,6 +7,7 @@ sending atomic positions and receiving forces from a worker process.
 
 import json
 import os
+import shutil
 import socket
 import subprocess
 import tempfile
@@ -17,8 +18,8 @@ import numpy as np
 from .protocol import (
     IPIProtocol,
     SocketClosed,
+    create_private_socket_path,
     create_server_socket,
-    create_unix_socket_path,
 )
 
 
@@ -80,7 +81,9 @@ class RootstockServer:
             env_name: Name of pre-built environment (e.g., "mace")
             checkpoint: Canonical checkpoint id passed to the env's setup()
             device: Device string to pass to setup()
-            socket_name: Name for the Unix socket (will be /tmp/ipi_<name>)
+            socket_name: Name for the Unix socket. The socket is created as
+                ipi_<name> inside a fresh private (0700) temp directory on
+                start(), so it is unreachable by other local users.
             root: Root directory for environments and cache (required)
             log: Optional file object for protocol logging
             timeout: Socket timeout in seconds
@@ -90,7 +93,10 @@ class RootstockServer:
             raise ValueError("root is required for pre-built environments")
 
         self.socket_name = socket_name
-        self.socket_path = create_unix_socket_path(socket_name)
+        # Created by start(): the socket lives in a private per-server temp
+        # directory that stop() removes.
+        self.socket_path: str | None = None
+        self._socket_dir: str | None = None
         self.log = log
         self.timeout = timeout
 
@@ -124,7 +130,9 @@ class RootstockServer:
 
     def start(self):
         """Start the server and launch the worker process."""
-        # Create server socket
+        # Create server socket inside a fresh private (0700) directory
+        self.socket_path = create_private_socket_path(self.socket_name)
+        self._socket_dir = os.path.dirname(self.socket_path)
         self._server_socket = create_server_socket(self.socket_path, timeout=self.timeout)
         self._server_socket.listen(1)
 
@@ -329,9 +337,11 @@ class RootstockServer:
                     pass
                 setattr(self, attr, None)
 
-        # Clean up socket file
-        if os.path.exists(self.socket_path):
-            os.unlink(self.socket_path)
+        # Clean up the socket and its private directory
+        if self._socket_dir is not None:
+            shutil.rmtree(self._socket_dir, ignore_errors=True)
+            self._socket_dir = None
+            self.socket_path = None
 
         # Clean up wrapper script
         if self._wrapper_path is not None:

--- a/tests/server/test_private_socket_dir.py
+++ b/tests/server/test_private_socket_dir.py
@@ -1,0 +1,115 @@
+"""Sockets live in a private 0700 directory, not world-visible /tmp.
+
+Sockets used to follow the i-PI convention ``/tmp/ipi_<name>``: visible to
+every local user, permissions at the mercy of the umask, and the path
+squattable/race-able on shared login nodes. The server now creates each
+socket inside a fresh ``mkdtemp`` directory (0700 by contract) and removes
+the directory on stop.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from rootstock.protocol import create_private_socket_path
+from rootstock.server import RootstockServer
+
+_CHECKPOINT = "socket-dummy"
+
+
+def test_socket_path_is_inside_fresh_private_dir():
+    path = Path(create_private_socket_path("testsock"))
+    try:
+        parent = path.parent
+        assert not path.exists()  # the path is reserved, not yet bound
+        assert parent.is_dir()
+        assert parent != Path(tempfile.gettempdir())  # never directly in /tmp
+        mode = stat.S_IMODE(parent.stat().st_mode)
+        assert mode == 0o700
+        assert parent.stat().st_uid == os.getuid()
+        assert path.name == "ipi_testsock"
+    finally:
+        os.rmdir(path.parent)
+
+
+def test_socket_paths_are_unique_per_call():
+    a = create_private_socket_path("same-name")
+    b = create_private_socket_path("same-name")
+    try:
+        assert a != b
+    finally:
+        os.rmdir(Path(a).parent)
+        os.rmdir(Path(b).parent)
+
+
+def test_long_tempdir_falls_back_to_tmp(monkeypatch, tmp_path):
+    """sun_path is ~104 bytes on macOS; a deep TMPDIR must not produce an
+    unbindable socket path."""
+    deep = tmp_path / ("d" * 80) / ("e" * 40)
+    deep.mkdir(parents=True)
+    monkeypatch.setenv("TMPDIR", str(deep))
+    tempfile.tempdir = None  # force gettempdir() to re-read TMPDIR
+    try:
+        path = create_private_socket_path("fallback")
+        assert len(path) < 100
+        assert path.startswith("/tmp/")
+        os.rmdir(Path(path).parent)
+    finally:
+        tempfile.tempdir = None
+
+
+@pytest.fixture
+def lj_env_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A faked install with a quiet Lennard-Jones env (same trick as the
+    pipe-deadlock test: symlink bin/python to this interpreter and hand the
+    worker a PYTHONPATH so it can import rootstock + ase)."""
+    import ase
+
+    import rootstock
+
+    pythonpath = os.pathsep.join(
+        sorted({str(Path(m.__file__).resolve().parents[1]) for m in (ase, rootstock)})
+    )
+    monkeypatch.setenv("PYTHONPATH", pythonpath)
+
+    env_dir = tmp_path / "envs" / "lj"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").symlink_to(sys.executable)
+
+    (env_dir / "env_source.py").write_text(
+        f"CHECKPOINTS = {{{_CHECKPOINT!r}: 'dummy'}}\n\n"
+        "def setup(checkpoint, device='cpu', **kwargs):\n"
+        "    from ase.calculators.lj import LennardJones\n"
+        "    return LennardJones()\n"
+    )
+    return tmp_path
+
+
+def test_server_socket_lives_in_private_dir_and_is_removed_on_stop(lj_env_root: Path):
+    server = RootstockServer(
+        env_name="lj",
+        checkpoint=_CHECKPOINT,
+        device="cpu",
+        root=lj_env_root,
+    )
+    assert server.socket_path is None  # nothing on disk before start()
+
+    server.start()
+    try:
+        socket_path = Path(server.socket_path)
+        socket_dir = socket_path.parent
+        assert socket_path.exists()
+        assert socket_dir != Path("/tmp")
+        assert stat.S_IMODE(socket_dir.stat().st_mode) == 0o700
+    finally:
+        server.stop()
+
+    assert not socket_path.exists()
+    assert not socket_dir.exists()
+    assert server.socket_path is None


### PR DESCRIPTION
## Summary

Fixes #109 (from the pre-1.0 audit issue #79). Sockets lived at world-visible paths with umask-derived permissions and no peer check — `/tmp/ipi_<name>` from the Python server, `/tmp/rootstock_<pid>_<tag>.sock` from the LAMMPS styles — race-able/squattable by other local users on shared login nodes, where people demonstrably run (`--no-verify` exists for exactly that). Fixed before 1.0 ossifies the convention.

**The fix, on both socket creators:** create each socket inside a fresh `mkdtemp` directory (0700 by contract) and remove the directory on shutdown. No peer check is needed — other users can't traverse into the directory at all.

- **Python** (`RootstockServer`): `protocol.create_unix_socket_path` is replaced by `create_private_socket_path`, which also falls back to `/tmp` if a deep `$TMPDIR` would threaten the ~104-byte `sun_path` limit. The socket dir is created in `start()` (nothing touches disk at construction) and removed in `stop()`. `create_unix_socket_path` was not exported from `__init__.py`, so no API surface changes.
- **LAMMPS** (`rootstock_ipi.cpp`): same treatment — `mkdtemp("/tmp/rootstock.XXXXXX")`, socket at `<dir>/ipi_<tag>.sock`, `rmdir` in the destructor. Worth landing now because this file compiles into users' LAMMPS binaries and has its own freeze horizon (#79's third-protocol-peer point).
- **Docs**: the `rootstock serve` example in `docs/api.md` cited `--socket /tmp/ipi_socket`; it now demonstrates `mktemp -d` and the option text explains why. (`serve` connects a worker to a caller-chosen path, so the caller owns that dir's hygiene — the LAMMPS styles and `RootstockServer` handle theirs automatically.) No other doc cites the old convention.

## Test plan
- New `tests/server/test_private_socket_dir.py`: path is inside a fresh 0700 dir owned by the caller (never `/tmp` directly), unique per call, long-`$TMPDIR` fallback stays under the `sun_path` limit, and an end-to-end server start/stop against a faked LJ env (same harness as the pipe-deadlock test) asserting the socket exists in a 0700 dir while running and both socket and dir are gone after `stop()`.
- LAMMPS side syntax-checked with `clang++ -fsyntax-only` against a stubbed `error.h` (no LAMMPS tree available here); the change is a straight path-generation swap plus one `rmdir`.
- Full suite: 272 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)