### PR TITLE
Read worker output on any worker failure, not only pre-connect death

### DIFF
--- a/rootstock/server.py
+++ b/rootstock/server.py
@@ -22,6 +22,14 @@ from .protocol import (
 )
 
 
+def _tail(text: str, limit: int = 8192) -> str:
+    """Last ``limit`` characters of ``text`` — worker output can be huge
+    (chatty model loads), and the useful part of a crash is at the end."""
+    if len(text) <= limit:
+        return text
+    return f"...[{len(text) - limit} chars truncated]...\n{text[-limit:]}"
+
+
 def _worker_error_from_extra(extra: bytes) -> str | None:
     """Extract an in-band worker error from the FORCEREADY extra field.
 
@@ -192,11 +200,7 @@ class RootstockServer:
             except TimeoutError:
                 # Check if process died
                 if self._process.poll() is not None:
-                    stdout, stderr = self._read_worker_output()
-                    raise RuntimeError(
-                        f"Worker process died with code {self._process.returncode}.\n"
-                        f"stdout: {stdout}\nstderr: {stderr}"
-                    )
+                    raise self._worker_failure_error("Worker process died before connecting")
 
         # Restore original timeout
         self._server_socket.settimeout(self.timeout)
@@ -226,6 +230,39 @@ class RootstockServer:
 
         return _drain(self._stdout_file), _drain(self._stderr_file)
 
+    def _worker_failure_error(self, context: str, exc: Exception | None = None) -> RuntimeError:
+        """Build a post-mortem error for a worker failure.
+
+        A worker that dies mid-``calculate`` (GPU OOM, batch-system kill)
+        surfaces as a bare socket timeout or closed socket while the actual
+        traceback sits unread in the captured output files — so read them on
+        *any* worker failure and report the cause, not just the symptom.
+        """
+        if self._process is None:
+            fate = "worker process was never started"
+        elif self._process.poll() is not None:
+            fate = f"worker process exited with code {self._process.returncode}"
+        else:
+            fate = "worker process is still running (hung, or blocked on the device?)"
+
+        lines = [f"{context}: {fate}."]
+        if exc is not None:
+            lines.append(f"Cause: {type(exc).__name__}: {exc}")
+
+        stdout, stderr = self._read_worker_output()
+        captured = False
+        for name, text in (("stdout", stdout), ("stderr", stderr)):
+            text = text.strip()
+            if text:
+                captured = True
+                lines.append(f"--- worker {name} (tail) ---\n{_tail(text)}")
+        if not captured:
+            note = "(no worker output captured"
+            if self.log:
+                note += " — logging mode inherits the parent's stdio"
+            lines.append(note + ")")
+        return RuntimeError("\n".join(lines))
+
     def calculate(
         self,
         positions: np.ndarray,
@@ -250,43 +287,50 @@ class RootstockServer:
         if not self._connected:
             raise RuntimeError("Server not connected. Call start() first.")
 
-        # Check worker status
-        self._protocol.send_status()
-        status = self._protocol.recv_status()
-
-        if status == "NEEDINIT":
-            # Send INIT with atomic species info
-            init_data = {
-                "numbers": atomic_numbers.tolist() if atomic_numbers is not None else None,
-                "pbc": [bool(p) for p in pbc] if pbc is not None else [True, True, True],
-            }
-            init_bytes = json.dumps(init_data).encode("utf-8")
-            self._protocol.send_init(bead_index=0, init_string=init_bytes)
-
-            # Track what we sent
-            self._init_sent = True
-            self._init_numbers = init_data["numbers"]
-            self._init_pbc = init_data["pbc"]
-
+        # A worker that dies mid-exchange (GPU OOM, batch-system kill) can't
+        # report in-band; the failure shows up here as a socket timeout,
+        # closed socket, or broken pipe. Turn that into a post-mortem that
+        # includes the worker's captured output instead of a bare socket error.
+        try:
+            # Check worker status
             self._protocol.send_status()
             status = self._protocol.recv_status()
 
-        if status != "READY":
-            raise RuntimeError(f"Worker not ready, status: {status}")
+            if status == "NEEDINIT":
+                # Send INIT with atomic species info
+                init_data = {
+                    "numbers": atomic_numbers.tolist() if atomic_numbers is not None else None,
+                    "pbc": [bool(p) for p in pbc] if pbc is not None else [True, True, True],
+                }
+                init_bytes = json.dumps(init_data).encode("utf-8")
+                self._protocol.send_init(bead_index=0, init_string=init_bytes)
 
-        # Send positions
-        self._protocol.send_posdata(cell, positions)
+                # Track what we sent
+                self._init_sent = True
+                self._init_numbers = init_data["numbers"]
+                self._init_pbc = init_data["pbc"]
 
-        # Check status - worker should now be calculating
-        self._protocol.send_status()
-        status = self._protocol.recv_status()
+                self._protocol.send_status()
+                status = self._protocol.recv_status()
 
-        if status != "HAVEDATA":
-            raise RuntimeError(f"Worker failed to calculate, status: {status}")
+            if status != "READY":
+                raise RuntimeError(f"Worker not ready, status: {status}")
 
-        # Get results
-        self._protocol.send_getforce()
-        energy, forces, virial, extra = self._protocol.recv_forceready()
+            # Send positions
+            self._protocol.send_posdata(cell, positions)
+
+            # Check status - worker should now be calculating
+            self._protocol.send_status()
+            status = self._protocol.recv_status()
+
+            if status != "HAVEDATA":
+                raise RuntimeError(f"Worker failed to calculate, status: {status}")
+
+            # Get results
+            self._protocol.send_getforce()
+            energy, forces, virial, extra = self._protocol.recv_forceready()
+        except (TimeoutError, SocketClosed, OSError) as exc:
+            raise self._worker_failure_error("Worker failed mid-calculation", exc) from exc
 
         error = _worker_error_from_extra(extra)
         if error is not None:

--- a/tests/server/test_worker_postmortem.py
+++ b/tests/server/test_worker_postmortem.py
@@ -1,0 +1,137 @@
+"""Worker output is read on *any* worker failure, not only pre-connect death.
+
+A worker that dies mid-``calculate`` (GPU OOM, batch-system kill) can't use
+the in-band FORCEREADY error channel; historically the server surfaced it as
+a bare socket timeout/closed-socket while the traceback sat unread in the
+captured output tempfiles. ``RootstockServer`` now attaches a post-mortem —
+exit code plus stdout/stderr tails — to every worker failure.
+
+Uses the faked-env harness from the pipe-deadlock test: ``bin/python``
+symlinked to this interpreter, ``PYTHONPATH`` handed down so the worker can
+import rootstock + ase.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from rootstock.server import RootstockServer, _tail
+
+_CHECKPOINT = "postmortem-dummy"
+_MID_CALC_MARKER = "MID-CALCULATE-BOOM-MARKER"
+_SETUP_MARKER = "SETUP-BOOM-MARKER"
+_EXIT_CODE = 19
+
+
+def _fake_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, env_source: str) -> Path:
+    import ase
+
+    import rootstock
+
+    pythonpath = os.pathsep.join(
+        sorted({str(Path(m.__file__).resolve().parents[1]) for m in (ase, rootstock)})
+    )
+    monkeypatch.setenv("PYTHONPATH", pythonpath)
+
+    env_dir = tmp_path / "envs" / "doomed"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").symlink_to(sys.executable)
+    (env_dir / "env_source.py").write_text(env_source)
+    return tmp_path
+
+
+@pytest.fixture
+def mid_calculate_death_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Env whose calculator kills the worker process on the first force call —
+    the shape of a GPU OOM: no exception to catch, no in-band error, just a
+    dead peer."""
+    return _fake_root(
+        tmp_path,
+        monkeypatch,
+        f"CHECKPOINTS = {{{_CHECKPOINT!r}: 'dummy'}}\n\n"
+        "def setup(checkpoint, device='cpu', **kwargs):\n"
+        "    from ase.calculators.lj import LennardJones\n"
+        "    class Doomed(LennardJones):\n"
+        "        def calculate(self, *a, **k):\n"
+        "            import os, sys\n"
+        f"            sys.stderr.write({_MID_CALC_MARKER!r})\n"
+        "            sys.stderr.flush()\n"
+        f"            os._exit({_EXIT_CODE})\n"
+        "    return Doomed()\n",
+    )
+
+
+@pytest.fixture
+def setup_death_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Env whose setup() raises before the worker ever connects."""
+    return _fake_root(
+        tmp_path,
+        monkeypatch,
+        f"CHECKPOINTS = {{{_CHECKPOINT!r}: 'dummy'}}\n\n"
+        "def setup(checkpoint, device='cpu', **kwargs):\n"
+        f"    raise RuntimeError({_SETUP_MARKER!r})\n",
+    )
+
+
+def _calculate_h2(server: RootstockServer):
+    positions = np.array([[0.0, 0.0, 0.0], [0.74, 0.0, 0.0]])
+    cell = np.zeros((3, 3))
+    numbers = np.array([1, 1])
+    return server.calculate(positions, cell, numbers, pbc=[False, False, False])
+
+
+def test_mid_calculate_death_reports_exit_code_and_stderr(mid_calculate_death_root: Path):
+    server = RootstockServer(
+        env_name="doomed",
+        checkpoint=_CHECKPOINT,
+        device="cpu",
+        root=mid_calculate_death_root,
+        timeout=15.0,
+        socket_name=f"postmortem_{os.getpid()}",
+    )
+    server.start()
+    try:
+        with pytest.raises(RuntimeError) as excinfo:
+            _calculate_h2(server)
+    finally:
+        server.stop()
+
+    message = str(excinfo.value)
+    assert "Worker failed mid-calculation" in message
+    assert f"exited with code {_EXIT_CODE}" in message
+    assert _MID_CALC_MARKER in message  # the traceback-bearing stderr tail
+
+
+def test_death_before_connect_reports_stderr_tail(setup_death_root: Path):
+    server = RootstockServer(
+        env_name="doomed",
+        checkpoint=_CHECKPOINT,
+        device="cpu",
+        root=setup_death_root,
+        timeout=15.0,
+        socket_name=f"postmortem_pre_{os.getpid()}",
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        server.start()
+    server.stop()
+
+    message = str(excinfo.value)
+    assert "died before connecting" in message
+    assert _SETUP_MARKER in message
+
+
+def test_tail_truncates_long_output():
+    text = "x" * 100_000 + "THE-END"
+    tailed = _tail(text)
+    assert len(tailed) < 10_000
+    assert tailed.endswith("THE-END")
+    assert "truncated" in tailed
+
+
+def test_tail_passes_short_output_through():
+    assert _tail("short") == "short"


### PR DESCRIPTION
## Summary

Fixes #112 (from the pre-1.0 audit issue #81). The server only read the worker's captured stdout/stderr in `_accept_connection` — a worker that died *mid-`calculate`* (the GPU-OOM shape: no exception to catch, no in-band FORCEREADY error from #86, just a dead peer) surfaced as a bare socket timeout while the traceback sat unread in the output tempfiles.

- The protocol exchange in `RootstockServer.calculate()` now catches socket-level failures (`TimeoutError`/`SocketClosed`/`OSError`) and raises a post-mortem `RuntimeError` built by a new `_worker_failure_error()`: whether the worker exited (and its code) or is still running/hung, the causing exception, and the worker's stdout/stderr tails. In logging mode (worker inherits parent stdio, nothing captured) it says so instead of showing nothing.
- The pre-connect death path in `_accept_connection` now uses the same builder, so its message gains the exit-code phrasing and — importantly — **output tails instead of full output**: a 256 KB chatty model load no longer lands verbatim inside the exception message (`_tail` keeps the last 8 KB, where the crash actually is).
- In-band worker errors (worker alive, exception caught and reported via FORCEREADY extras) and protocol-status errors are unchanged — those already carry the real traceback.

Recovery/restart after such a failure is deliberately out of scope — that's the calculator-lifecycle decision tracked in #108.

## Test plan
New `tests/server/test_worker_postmortem.py`, driving the real server against faked envs (same symlinked-interpreter harness as the pipe-deadlock test):
- a calculator that writes a marker to stderr and `os._exit(19)`s on the first force call → the raised error names "Worker failed mid-calculation", carries "exited with code 19", and contains the stderr marker;
- a `setup()` that raises before connecting → "died before connecting" + stderr traceback marker;
- `_tail` unit tests (truncation keeps the end, short output passes through).

Full suite: 286 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)