### PR TITLE
Make installs self-describing: cache_root declared in layout.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,8 +102,10 @@ is mounted (HPC shared filesystem, NFS, Lustre, etc.).
 
 On clusters where the right filesystem for code is different from the right
 filesystem for the model-weight cache (e.g., Perlmutter — code on CFS, cache
-on PSCRATCH), the cluster registry encodes both as `root` and `cache_root`.
-Most clusters use the same path for both.
+on PSCRATCH), the install declares its own `cache_root` in `{root}/layout.json`
+(written by `install`/`init`). The cluster registry is only a name → path
+bootstrap; its `cache_root` field is a fallback for legacy installs that
+predate the declaration. Most clusters use the same path for both.
 
 ### Known Clusters
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -30,7 +30,7 @@ with RootstockCalculator(
 | `checkpoint` | `str` | Yes | Canonical checkpoint id (e.g., `"mace-mp-0-medium"`, `"uma-s-1p1"`). The hosting env is resolved automatically by walking the installed envs and matching against each env's `CHECKPOINTS` table |
 | `cluster` | `str` | Yes* | Cluster name (e.g., `"della"`, `"perlmutter"`) |
 | `root` | `str` | Yes* | Custom install-root path instead of a known cluster |
-| `cache_root` | `str` | No | Override path for the model-weight cache and redirected `HOME`. Defaults to the cluster's registered `cache_root`, or to `root` if no cluster is in play |
+| `cache_root` | `str` | No | Override path for the model-weight cache and redirected `HOME`. When omitted, the install's own declaration (`{root}/layout.json`) decides, falling back to the cluster registry for legacy roots, then to `root` |
 | `device` | `str` | No | `"cuda"` (default) or `"cpu"` |
 | `setup_kwargs` | `dict` | No | Extra keyword arguments forwarded to the env's `setup()` function (e.g., `{"task": "omol"}`). Cannot contain `checkpoint` or `device` |
 
@@ -42,10 +42,11 @@ with RootstockCalculator(
 # Using a known cluster
 RootstockCalculator(cluster="della", checkpoint="mace-mp-0-medium")
 
-# Perlmutter — install root and cache root come from the registry
+# Perlmutter — cluster name bootstraps the install path; the install itself
+# declares where its cache lives (layout.json), e.g. PSCRATCH
 RootstockCalculator(cluster="perlmutter", checkpoint="uma-s-1p1")
 
-# Custom install root (cache_root defaults to the install root)
+# Custom install root (cache_root from the install's declaration, else the root)
 RootstockCalculator(root="/scratch/gpfs/specific/install/rootstock", checkpoint="mace-mp-0-medium")
 
 # Explicit split between install root and cache root

--- a/docs/cluster-setup.md
+++ b/docs/cluster-setup.md
@@ -30,16 +30,18 @@ Choose a location on a shared filesystem where other users have access:
 
 On most clusters a single shared filesystem hosts both the rootstock install (code, venvs, manifest) and the model-weight cache. Some clusters require these to live on different filesystems — typically because the recommended persistent project filesystem doesn't support `flock`, which the HuggingFace cache requires. NERSC Perlmutter is one such case: code lives on CFS, model weights on PSCRATCH.
 
-The cluster registry (`rootstock/clusters.py`) encodes both paths per cluster:
+The install declares its own cache root in `{root}/layout.json` — `rootstock install` and `rootstock init` record it automatically. Every reader (CLI commands and `RootstockCalculator`, whether given `cluster=` or `root=`) resolves the cache root the same way: an explicit override wins, then the install's declaration, then — for legacy installs that predate the declaration — the cluster registry's entry, then the install root itself.
+
+The cluster registry (`rootstock/clusters.py`) is only a name → install-path bootstrap so users can say `cluster="perlmutter"` instead of remembering a path. Its per-cluster `cache_root` field remains solely as the legacy fallback above; new split-filesystem deployments don't need a registry entry at all, just a declaration in the install:
 
 ```python
 "perlmutter": Cluster(
     root=Path("/global/cfs/cdirs/m4845/rootstock"),
-    cache_root=Path("/pscratch/sd/w/wengler/rootstock-cache"),
+    cache_root=Path("/pscratch/sd/w/wengler/rootstock-cache"),  # legacy fallback only
 ),
 ```
 
-When `cache_root` is omitted from the registry, both paths are the same. Users don't need to set environment variables — `RootstockCalculator(cluster="perlmutter", ...)` resolves both automatically.
+Users don't need to set environment variables — `RootstockCalculator(cluster="perlmutter", ...)` resolves both automatically.
 
 ### Permissions for shared installs
 

--- a/rootstock/calculator.py
+++ b/rootstock/calculator.py
@@ -15,7 +15,7 @@ from ase.stress import full_3x3_to_voigt_6_stress
 
 from .clusters import get_cluster
 from .environment import find_env_for_checkpoint
-from .layout import ensure_layout_compatible
+from .layout import ensure_layout_compatible, resolve_cache_root
 from .server import RootstockServer
 
 
@@ -79,12 +79,13 @@ class RootstockCalculator(Calculator):
                         "uma-s-1p1"). Required. The hosting env is resolved
                         from the installed envs at ``root``.
             cluster: Known cluster name (e.g., "della", "perlmutter"). Mutually
-                     exclusive with root. The cluster's registered cache_root is
-                     used unless `cache_root` is also passed.
+                     exclusive with root; a name -> install-path bootstrap.
             root: Path to rootstock install directory. Mutually exclusive with cluster.
-            cache_root: Optional separate root for the model-weight cache and
-                        redirected HOME. Defaults to the cluster's registered
-                        cache_root, or to ``root`` if no cluster is in play.
+            cache_root: Optional override for the model-weight cache and
+                        redirected HOME. When omitted, the install's own
+                        declaration ({root}/layout.json) decides, falling back
+                        to the cluster registry for legacy roots, then to
+                        ``root`` — the same resolution the CLI uses.
             device: PyTorch device ("cuda", "cuda:0", "cpu")
             setup_kwargs: Extra keyword arguments forwarded to the env's setup()
                           function. May not contain "checkpoint" or "device" —
@@ -108,22 +109,21 @@ class RootstockCalculator(Calculator):
         self.setup_kwargs = setup_kwargs
         self.log = log
 
-        # Resolve install root and cache root.
-        # Resolution: explicit kwarg > cluster registry default > install root.
+        # Resolve the install root: the cluster name is only a name -> path
+        # bootstrap. Everything else about the install (including where its
+        # cache lives) is read from the install itself, identically for both
+        # entry points — see resolve_cache_root.
         if cluster is not None and root is not None:
             raise ValueError("Cannot specify both 'cluster' and 'root'")
 
         if cluster is not None:
-            cluster_info = get_cluster(cluster)
-            self.root = cluster_info.root
-            self.cache_root = (
-                Path(cache_root) if cache_root is not None else cluster_info.resolved_cache_root
-            )
+            self.root = get_cluster(cluster).root
         elif root is not None:
             self.root = Path(root)
-            self.cache_root = Path(cache_root) if cache_root is not None else self.root
         else:
             raise ValueError("Must specify either 'cluster' or 'root'")
+
+        self.cache_root = resolve_cache_root(self.root, explicit=cache_root)
 
         # A root laid out by a newer rootstock may not be readable by this
         # client's conventions — fail with "upgrade rootstock", not a

--- a/rootstock/clusters.py
+++ b/rootstock/clusters.py
@@ -1,10 +1,14 @@
 """
-Cluster configuration for Rootstock.
+Cluster registry for Rootstock: a name -> path bootstrap.
 
-This module provides mappings from cluster names to install roots and
-model-weight cache roots. On most clusters the two coincide; on clusters
-where they live on different filesystems (e.g., Perlmutter — CFS for code,
-PSCRATCH for the flock-friendly cache) the cluster declares both.
+The registry exists so users can say ``cluster="perlmutter"`` instead of
+remembering an install path. Everything else about an install — most
+importantly where its model-weight cache lives — is declared by the install
+itself in ``{root}/layout.json`` (see ``rootstock.layout``), because a
+registry baked into every release goes stale in pinned clients while the
+install's own declaration travels with the install. The per-cluster
+``cache_root`` here remains only as a fallback for legacy roots that predate
+the declaration.
 """
 
 from __future__ import annotations
@@ -72,9 +76,15 @@ def get_cache_root_for_cluster(cluster: str) -> Path:
 
 
 def get_cluster_for_root(root: Path | str) -> str | None:
-    """Reverse lookup: cluster name for a given install root path."""
+    """Reverse lookup: cluster name for a given install root path.
+
+    Returns None when the root is unknown — or when it is ambiguous because
+    several clusters share one install (e.g. sophia/polaris on Eagle), in
+    which case picking one by registry order would be a guess. Callers that
+    need a definite identity must ask for an explicit cluster name.
+    """
     root_str = str(root)
-    for cluster, info in CLUSTER_REGISTRY.items():
-        if str(info.root) == root_str:
-            return cluster
+    matches = [name for name, info in CLUSTER_REGISTRY.items() if str(info.root) == root_str]
+    if len(matches) == 1:
+        return matches[0]
     return None

--- a/rootstock/commands/common.py
+++ b/rootstock/commands/common.py
@@ -5,24 +5,14 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-from ..clusters import get_cluster, get_cluster_for_root
 from ..config import load_config
+
+# Re-exported so command modules keep one import site; the resolution itself
+# lives in rootstock.layout so the CLI and the calculator share it.
+from ..layout import resolve_cache_root  # noqa: F401
 
 # Environment variable for default root directory
 ROOTSTOCK_ROOT_ENV = "ROOTSTOCK_ROOT"
-
-
-def resolve_cache_root(root: Path) -> Path:
-    """Reverse-lookup the cache root for a given install root.
-
-    If the install root matches a registered cluster, that cluster's
-    ``cache_root`` is returned (defaulting to ``root`` itself when the cluster
-    didn't register a separate cache root). For unknown roots, returns ``root``.
-    """
-    cluster_name = get_cluster_for_root(root)
-    if cluster_name is None:
-        return root
-    return get_cluster(cluster_name).resolved_cache_root
 
 
 def get_root_or_exit(args) -> Path:

--- a/rootstock/commands/init.py
+++ b/rootstock/commands/init.py
@@ -146,7 +146,9 @@ def cmd_init(args) -> int:
                 print(f"  Exists:  {dir_path}")
 
         try:
-            write_layout_marker(root)
+            # Declare the cache root so the install is self-describing —
+            # readers prefer this over the baked-in cluster registry.
+            write_layout_marker(root, cache_root=cache_root)
             print(f"  Created: {root / 'layout.json'}")
         except PermissionError:
             print(f"  Skipped (no permission): {root / 'layout.json'}")

--- a/rootstock/commands/install.py
+++ b/rootstock/commands/install.py
@@ -636,8 +636,11 @@ def cmd_install(args) -> int:
     if not getattr(args, "no_perm_check", False):
         _warn_on_permissions(root)
 
-    # Stamp (or backfill, for pre-marker installs) the layout version.
-    write_layout_marker(root)
+    # Stamp (or backfill, for pre-marker installs) the layout version, and
+    # make the install self-describing: declare its cache root. For legacy
+    # roots without a declaration this persists the registry's answer, so
+    # the install keeps working after pinned clients' registries go stale.
+    write_layout_marker(root, cache_root=resolve_cache_root(root))
 
     # DIRECTORY MODE: install all *.py files
     if source_path.is_dir():

--- a/rootstock/layout.py
+++ b/rootstock/layout.py
@@ -30,6 +30,16 @@ LAYOUT_VERSION = 1
 MARKER_NAME = "layout.json"
 
 
+def _read_marker(root: Path) -> dict:
+    """Best-effort read of {root}/layout.json; {} when absent or corrupt."""
+    marker = Path(root) / MARKER_NAME
+    try:
+        data = json.loads(marker.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
 def read_layout_version(root: Path) -> int | None:
     """Return the root's recorded layout version, or None if unrecorded.
 
@@ -38,12 +48,49 @@ def read_layout_version(root: Path) -> int | None:
     reads as None: a broken metadata file must not brick an otherwise
     working install.
     """
-    marker = Path(root) / MARKER_NAME
-    try:
-        version = json.loads(marker.read_text()).get("layout_version")
-    except (OSError, json.JSONDecodeError, AttributeError):
-        return None
+    version = _read_marker(root).get("layout_version")
     return version if isinstance(version, int) else None
+
+
+def read_declared_cache_root(root: Path) -> Path | None:
+    """Return the cache root this install declares for itself, if any.
+
+    The declaration lives in {root}/layout.json — it is layout information:
+    where the cache/home half of the install is, which may be a different
+    filesystem than the install root (e.g. Perlmutter: code on CFS, cache on
+    PSCRATCH). Installs written before the declaration existed return None.
+    """
+    declared = _read_marker(root).get("cache_root")
+    return Path(declared) if isinstance(declared, str) and declared else None
+
+
+def resolve_cache_root(root: Path, explicit: Path | str | None = None) -> Path:
+    """Resolve the model-weight cache root for an install root.
+
+    Resolution order:
+      1. an explicit override from the caller (CLI flag / calculator kwarg),
+      2. the install's own declaration in {root}/layout.json,
+      3. legacy fallback for installs predating the declaration: the cluster
+         registry's entry for this root (reverse lookup),
+      4. the install root itself.
+
+    Every entry point resolves through here, so the CLI and the calculator
+    can't disagree about where an install's cache lives.
+    """
+    root = Path(root)
+    if explicit is not None:
+        return Path(explicit)
+
+    declared = read_declared_cache_root(root)
+    if declared is not None:
+        return declared
+
+    from .clusters import get_cluster, get_cluster_for_root
+
+    cluster_name = get_cluster_for_root(root)
+    if cluster_name is not None:
+        return get_cluster(cluster_name).resolved_cache_root
+    return root
 
 
 def ensure_layout_compatible(root: Path) -> None:
@@ -61,19 +108,27 @@ def ensure_layout_compatible(root: Path) -> None:
         )
 
 
-def write_layout_marker(root: Path) -> None:
-    """Record the current layout version in {root}/layout.json.
+def write_layout_marker(root: Path, cache_root: Path | str | None = None) -> None:
+    """Record the layout version — and the install's cache root — in
+    {root}/layout.json.
 
     Called from maintainer commands that write the root anyway (install,
-    init). No-op when the recorded version is already current, so repeated
-    installs don't churn the file. Atomic write, mode honoring the process
-    umask — same recipe as save_manifest.
+    init). ``cache_root`` records where this install keeps its model-weight
+    cache; when omitted, an existing declaration is preserved. No-op when
+    nothing would change, so repeated installs don't churn the file. Atomic
+    write, mode honoring the process umask — same recipe as save_manifest.
     """
     from . import __version__
     from .manifest import now_iso
 
     root = Path(root)
-    if read_layout_version(root) == LAYOUT_VERSION:
+    declared = str(cache_root) if cache_root is not None else None
+    if declared is None:
+        existing = read_declared_cache_root(root)
+        declared = str(existing) if existing is not None else None
+
+    current = _read_marker(root)
+    if current.get("layout_version") == LAYOUT_VERSION and current.get("cache_root") == declared:
         return
 
     data = {
@@ -81,6 +136,8 @@ def write_layout_marker(root: Path) -> None:
         "written_by": f"rootstock {__version__}",
         "written_at": now_iso(),
     }
+    if declared is not None:
+        data["cache_root"] = declared
 
     root.mkdir(parents=True, exist_ok=True)
     fd, temp_path = tempfile.mkstemp(dir=root, suffix=".json")

--- a/tests/calculator/test_calculator_cache_root.py
+++ b/tests/calculator/test_calculator_cache_root.py
@@ -1,0 +1,106 @@
+"""RootstockCalculator resolves cache_root from the install itself.
+
+Historically the two entry points disagreed: CLI `--root` reverse-looked-up
+the cluster registry (so Perlmutter got its PSCRATCH cache) while
+``RootstockCalculator(root=...)`` silently defaulted cache_root to the
+install root. Both now resolve through ``rootstock.layout.resolve_cache_root``:
+explicit override > the install's own declaration in layout.json > registry
+fallback for legacy roots > the root itself.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rootstock.calculator import RootstockCalculator
+from rootstock.clusters import CLUSTER_REGISTRY, Cluster
+from rootstock.layout import write_layout_marker
+
+_ENV_SOURCE = """\
+CHECKPOINTS = {
+    "mace-mp-0-medium": "medium",
+}
+
+
+def setup(checkpoint, device="cuda"):
+    return None
+"""
+
+
+@pytest.fixture
+def fake_root(tmp_path: Path) -> Path:
+    env_dir = tmp_path / "envs" / "mace"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+    (env_dir / "env_source.py").write_text(_ENV_SOURCE)
+    return tmp_path
+
+
+def _calc(**kwargs) -> RootstockCalculator:
+    return RootstockCalculator(checkpoint="mace-mp-0-medium", device="cpu", **kwargs)
+
+
+def test_root_entry_point_honors_install_declaration(fake_root: Path):
+    write_layout_marker(fake_root, cache_root="/declared/cache")
+
+    calc = _calc(root=fake_root)
+
+    assert calc.cache_root == Path("/declared/cache")
+
+
+def test_explicit_cache_root_overrides_declaration(fake_root: Path):
+    write_layout_marker(fake_root, cache_root="/declared/cache")
+
+    calc = _calc(root=fake_root, cache_root="/explicit/cache")
+
+    assert calc.cache_root == Path("/explicit/cache")
+
+
+def test_unknown_root_without_declaration_defaults_to_root(fake_root: Path):
+    calc = _calc(root=fake_root)
+
+    assert calc.cache_root == fake_root
+
+
+def test_cluster_entry_point_honors_install_declaration(fake_root: Path, monkeypatch):
+    """cluster= is only a name->path bootstrap; the install's declaration
+    beats the registry's (possibly stale) cache_root."""
+    monkeypatch.setitem(
+        CLUSTER_REGISTRY,
+        "faketest",
+        Cluster(root=fake_root, cache_root=Path("/registry/stale-cache")),
+    )
+    write_layout_marker(fake_root, cache_root="/declared/cache")
+
+    calc = _calc(cluster="faketest")
+
+    assert calc.root == fake_root
+    assert calc.cache_root == Path("/declared/cache")
+
+
+def test_cluster_entry_point_falls_back_to_registry_for_legacy_roots(fake_root: Path, monkeypatch):
+    monkeypatch.setitem(
+        CLUSTER_REGISTRY,
+        "faketest",
+        Cluster(root=fake_root, cache_root=Path("/registry/cache")),
+    )
+
+    calc = _calc(cluster="faketest")
+
+    assert calc.cache_root == Path("/registry/cache")
+
+
+def test_root_entry_point_matches_cli_for_registered_legacy_roots(fake_root: Path, monkeypatch):
+    """The historical divergence: root= must reverse-look-up the registry
+    exactly like CLI --root does, not silently default to the install root."""
+    monkeypatch.setitem(
+        CLUSTER_REGISTRY,
+        "faketest",
+        Cluster(root=fake_root, cache_root=Path("/registry/cache")),
+    )
+
+    calc = _calc(root=fake_root)
+
+    assert calc.cache_root == Path("/registry/cache")

--- a/tests/test_clusters.py
+++ b/tests/test_clusters.py
@@ -1,0 +1,21 @@
+"""Cluster registry: a name -> path bootstrap, with an honest reverse lookup."""
+
+from __future__ import annotations
+
+from rootstock.clusters import CLUSTER_REGISTRY, get_cluster_for_root
+
+
+def test_reverse_lookup_unique_root():
+    assert get_cluster_for_root(CLUSTER_REGISTRY["della"].root) == "della"
+
+
+def test_reverse_lookup_unknown_root_is_none():
+    assert get_cluster_for_root("/nonexistent/rootstock") is None
+
+
+def test_reverse_lookup_shared_root_is_ambiguous():
+    """sophia and polaris share one Eagle install; picking one by registry
+    order would be a guess, so the lookup must decline to answer."""
+    shared = CLUSTER_REGISTRY["sophia"].root
+    assert str(CLUSTER_REGISTRY["polaris"].root) == str(shared)  # test premise
+    assert get_cluster_for_root(shared) is None

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -15,7 +15,9 @@ import pytest
 from rootstock.layout import (
     LAYOUT_VERSION,
     ensure_layout_compatible,
+    read_declared_cache_root,
     read_layout_version,
+    resolve_cache_root,
     write_layout_marker,
 )
 
@@ -52,9 +54,7 @@ def test_current_layout_is_compatible(tmp_path: Path):
 
 
 def test_newer_layout_tells_user_to_upgrade(tmp_path: Path):
-    (tmp_path / "layout.json").write_text(
-        json.dumps({"layout_version": LAYOUT_VERSION + 1})
-    )
+    (tmp_path / "layout.json").write_text(json.dumps({"layout_version": LAYOUT_VERSION + 1}))
     with pytest.raises(RuntimeError, match="upgrade this client"):
         ensure_layout_compatible(tmp_path)
 
@@ -74,3 +74,83 @@ def test_stale_marker_is_upgraded(tmp_path: Path):
     (tmp_path / "layout.json").write_text(json.dumps({"layout_version": 0}))
     write_layout_marker(tmp_path)
     assert read_layout_version(tmp_path) == LAYOUT_VERSION
+
+
+# --- self-describing cache root ------------------------------------------------
+
+
+def test_cache_root_declaration_round_trip(tmp_path: Path):
+    write_layout_marker(tmp_path, cache_root="/pscratch/whatever/cache")
+    assert read_declared_cache_root(tmp_path) == Path("/pscratch/whatever/cache")
+
+
+def test_no_declaration_reads_as_none(tmp_path: Path):
+    write_layout_marker(tmp_path)
+    assert read_declared_cache_root(tmp_path) is None
+
+
+def test_rewrite_without_cache_root_preserves_declaration(tmp_path: Path):
+    """A marker rewrite by a command that doesn't know the cache root (or an
+    older client) must not erase the install's declaration."""
+    write_layout_marker(tmp_path, cache_root="/cache/elsewhere")
+    write_layout_marker(tmp_path)
+    assert read_declared_cache_root(tmp_path) == Path("/cache/elsewhere")
+
+
+def test_rewrite_with_same_cache_root_is_a_noop(tmp_path: Path):
+    write_layout_marker(tmp_path, cache_root="/cache/elsewhere")
+    before = (tmp_path / "layout.json").read_text()
+
+    write_layout_marker(tmp_path, cache_root="/cache/elsewhere")
+
+    assert (tmp_path / "layout.json").read_text() == before
+
+
+def test_declaration_can_be_updated(tmp_path: Path):
+    write_layout_marker(tmp_path, cache_root="/cache/old")
+    write_layout_marker(tmp_path, cache_root="/cache/new")
+    assert read_declared_cache_root(tmp_path) == Path("/cache/new")
+
+
+def test_resolve_explicit_override_wins(tmp_path: Path):
+    write_layout_marker(tmp_path, cache_root="/cache/declared")
+    assert resolve_cache_root(tmp_path, explicit="/cache/explicit") == Path("/cache/explicit")
+
+
+def test_resolve_prefers_declaration_over_registry(tmp_path: Path, monkeypatch):
+    """A pinned client's stale registry must lose to what the install says
+    about itself."""
+    from rootstock.clusters import CLUSTER_REGISTRY, Cluster
+
+    monkeypatch.setitem(
+        CLUSTER_REGISTRY,
+        "faketest",
+        Cluster(root=tmp_path, cache_root=Path("/registry/stale-cache")),
+    )
+    write_layout_marker(tmp_path, cache_root="/cache/declared")
+
+    assert resolve_cache_root(tmp_path) == Path("/cache/declared")
+
+
+def test_resolve_falls_back_to_registry_for_legacy_roots(tmp_path: Path, monkeypatch):
+    from rootstock.clusters import CLUSTER_REGISTRY, Cluster
+
+    monkeypatch.setitem(
+        CLUSTER_REGISTRY,
+        "faketest",
+        Cluster(root=tmp_path, cache_root=Path("/registry/cache")),
+    )
+
+    assert resolve_cache_root(tmp_path) == Path("/registry/cache")
+
+
+def test_resolve_defaults_to_root_for_unknown_installs(tmp_path: Path):
+    assert resolve_cache_root(tmp_path) == tmp_path
+
+
+def test_cli_and_calculator_share_one_resolver():
+    """The CLI-facing name is the same function object — the two entry
+    points cannot diverge again."""
+    from rootstock.commands.common import resolve_cache_root as cli_resolver
+
+    assert cli_resolver is resolve_cache_root


### PR DESCRIPTION
## Summary

Fixes #107 (from the pre-1.0 audit issue #79; see also #61). `clusters.py` baked cluster→path mappings into every release, so pinned clients keep stale roots forever, and cache-root resolution diverged by entry point: CLI `--root` reverse-looked-up the registry (Perlmutter got its PSCRATCH cache) while `RootstockCalculator(root=...)` silently defaulted `cache_root` to the install root.

**Design: the install declares its own `cache_root` in `{root}/layout.json`.** That file (from #99) already *is* the install's layout metadata, is read at calculator startup anyway, and is backfilled by maintainer commands — and "where the cache half of the install lives" is layout information. The key is additive, so no layout-version bump per #99's rules.

- `layout.py` gains `read_declared_cache_root()` and the single resolver `resolve_cache_root(root, explicit=None)`: **explicit override > install's declaration > registry fallback (legacy roots only) > root**. `write_layout_marker(root, cache_root=...)` records the declaration; rewrites without one preserve an existing declaration (an older client's marker rewrite can't erase it), and the no-op check covers both fields.
- **One resolver, both entry points**: `commands/common.resolve_cache_root` is now a re-export of the layout resolver, and the calculator resolves through it for both `cluster=` and `root=` — a test pins that they are literally the same function object. `cluster=` is now purely a name→install-path bootstrap.
- **Writers**: `rootstock install` declares `cache_root` on every run (persisting the registry's answer for legacy roots — the install keeps working after pinned registries go stale); `rootstock init` records the cache root it already computes interactively.
- **`get_cluster_for_root` is ambiguity-safe**: sophia/polaris share one Eagle install, and picking "sophia" by registry order was a guess. It now returns None unless the match is unique; manifest cluster detection on a fresh shared-root manifest will ask for an explicit `--cluster` instead of mislabeling (existing manifests already record their cluster, so this only affects fresh detection).
- Docs updated (`docs/cluster-setup.md`, `docs/api.md`, `CLAUDE.md`): registry described as bootstrap + legacy fallback; new split-filesystem deployments need no registry entry at all.

Not included (deliberately): an `--cache-root` flag on `install` — for a new split-cache deployment without a registry entry, the declaration comes from `init` or editing `layout.json`; happy to add the flag as a follow-up knob if you want it.

## Test plan
- `tests/test_layout.py`: declaration round-trip, preserve-on-rewrite, update, no-op stability, full resolver chain (explicit > declared > registry > root), CLI/calculator resolver identity.
- New `tests/calculator/test_calculator_cache_root.py`: `root=` honors the declaration, explicit kwarg wins, unknown root defaults to root, `cluster=` prefers declaration over a (monkeypatched) stale registry entry, and the historical `root=`-vs-CLI divergence case now matches.
- New `tests/test_clusters.py`: unique reverse lookup works; the real sophia/polaris shared root now resolves to None.
- Full suite: 301 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)