### PR TITLE
Prune the public API to the blessed surface

### DIFF
--- a/rootstock/__init__.py
+++ b/rootstock/__init__.py
@@ -3,56 +3,62 @@ Rootstock: MLIP calculators with isolated Python environments.
 
 This package provides ASE-compatible calculators that run MLIPs in isolated
 subprocess environments, communicating via the i-PI protocol.
+
+The names exported here are the public, semver-protected API. Everything
+else (config, manifest, environment management, the worker, the wire
+protocol) is internal: importable from its submodule when you need it, but
+subject to change without a major version bump.
 """
 
 from importlib.metadata import version as _pkg_version
 
 from .calculator import RootstockCalculator
-from .client import RootstockClient
-from .clusters import (
-    CLUSTER_REGISTRY,
-    Cluster,
-    get_cache_root_for_cluster,
-    get_cluster,
-    get_cluster_for_root,
-    get_root_for_cluster,
-)
-from .config import UserConfig, load_config, save_config
-from .environment import (
-    EnvironmentManager,
-    get_model_cache_env,
-    list_built_environments,
-    list_declared_checkpoints,
-    list_environments,
-)
-from .manifest import Manifest, load_manifest, save_manifest
-from .pep723 import parse_pep723_metadata, validate_environment_file
+from .clusters import CLUSTER_REGISTRY, Cluster, get_cluster, get_root_for_cluster
+from .environment import CheckpointNotFoundError, list_declared_checkpoints
 from .server import RootstockServer
-from .worker import run_worker
 
 __all__ = [
+    # Calculators and servers
     "RootstockCalculator",
     "RootstockServer",
-    "RootstockClient",
-    "EnvironmentManager",
-    "list_environments",
-    "list_built_environments",
+    # Checkpoint discovery
     "list_declared_checkpoints",
-    "get_model_cache_env",
-    "parse_pep723_metadata",
-    "validate_environment_file",
-    "run_worker",
+    "CheckpointNotFoundError",
+    # Cluster name -> path bootstrap
     "CLUSTER_REGISTRY",
     "Cluster",
     "get_cluster",
     "get_root_for_cluster",
-    "get_cache_root_for_cluster",
-    "get_cluster_for_root",
-    "UserConfig",
-    "load_config",
-    "save_config",
-    "Manifest",
-    "load_manifest",
-    "save_manifest",
 ]
 __version__ = _pkg_version("rootstock")
+
+# Names removed from the top level in the pre-1.0 API prune, mapped to where
+# they live. Gives 0.x users a pointed error instead of a bare AttributeError.
+_MOVED = {
+    "RootstockClient": "rootstock.client",
+    "EnvironmentManager": "rootstock.environment",
+    "list_environments": "rootstock.environment",
+    "list_built_environments": "rootstock.environment",
+    "get_model_cache_env": "rootstock.environment",
+    "parse_pep723_metadata": "rootstock.pep723",
+    "validate_environment_file": "rootstock.pep723",
+    "run_worker": "rootstock.worker",
+    "get_cache_root_for_cluster": "rootstock.clusters",
+    "get_cluster_for_root": "rootstock.clusters",
+    "UserConfig": "rootstock.config",
+    "load_config": "rootstock.config",
+    "save_config": "rootstock.config",
+    "Manifest": "rootstock.manifest",
+    "load_manifest": "rootstock.manifest",
+    "save_manifest": "rootstock.manifest",
+}
+
+
+def __getattr__(name: str):
+    if name in _MOVED:
+        raise AttributeError(
+            f"'{name}' is no longer part of the public rootstock API. "
+            f"It is internal; if you depend on it, import it from "
+            f"{_MOVED[name]} (no compatibility guarantees)."
+        )
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,50 @@
+"""The public API surface is a deliberate, pinned decision.
+
+Once 1.0 tags, every top-level export is implicitly semver-protected — so
+the blessed list is asserted exactly, and anything that grows it must be a
+conscious change to this test.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import rootstock
+
+BLESSED = {
+    "RootstockCalculator",
+    "RootstockServer",
+    "list_declared_checkpoints",
+    "CheckpointNotFoundError",
+    "CLUSTER_REGISTRY",
+    "Cluster",
+    "get_cluster",
+    "get_root_for_cluster",
+}
+
+
+def test_all_is_exactly_the_blessed_surface():
+    assert set(rootstock.__all__) == BLESSED
+
+
+def test_every_blessed_name_resolves():
+    for name in BLESSED:
+        assert getattr(rootstock, name) is not None
+
+
+def test_version_is_available():
+    assert isinstance(rootstock.__version__, str)
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["run_worker", "save_config", "parse_pep723_metadata", "Manifest", "EnvironmentManager"],
+)
+def test_pruned_internals_raise_with_guidance(name: str):
+    with pytest.raises(AttributeError, match="no longer part of the public rootstock API"):
+        getattr(rootstock, name)
+
+
+def test_unknown_attribute_raises_plain_attributeerror():
+    with pytest.raises(AttributeError, match="has no attribute"):
+        rootstock.definitely_not_a_name


### PR DESCRIPTION
## Summary

Fixes #106 (from the pre-1.0 audit issue #79). `rootstock/__init__.py` re-exported ~24 names including plain internals (`run_worker`, `save_config`, `parse_pep723_metadata`, ...); once 1.0 tags, all of it becomes implicitly semver-protected.

**The blessed surface** (everything users and our own scripts/docs actually import — verified by grepping the repo, driver scripts, and docs, where only `RootstockCalculator` and `__version__` appear):

- `RootstockCalculator` — the entry point
- `RootstockServer` — advanced embedding (external i-PI-style drivers)
- `list_declared_checkpoints` + `CheckpointNotFoundError` — "what ids can I use here" discovery and the one domain exception raised at users
- `Cluster`, `CLUSTER_REGISTRY`, `get_cluster`, `get_root_for_cluster` — the name→path bootstrap
- `__version__`

Everything else stays importable from its submodule but is no longer top-level API. Rather than vanish silently, pruned names raise a **pointed `AttributeError`** via module `__getattr__` — naming the submodule the symbol lives in and stating there's no compatibility guarantee — so a 0.x user upgrading gets a migration hint instead of a bare attribute error. `get_cluster_for_root` and `get_cache_root_for_cluster` are pruned too: with #118 they become legacy-fallback machinery rather than API.

The exception-taxonomy item from #79 remains open — this PR fixes the *export* surface; a fuller exception hierarchy can land behind it without churning the top level again.

## Test plan
- New `tests/test_public_api.py`: asserts `__all__` equals the blessed set exactly (growing the surface must be a conscious edit to the test), every blessed name resolves, pruned internals raise the guidance error, unknown attributes still raise a plain `AttributeError`.
- Full suite: 291 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)