### PR TITLE
Replace hand-rolled log= threading with stdlib logging on the client side

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -70,6 +70,17 @@ with RootstockCalculator(...) as calc:
 # Worker process is automatically terminated when exiting the context
 ```
 
+### Logging
+
+Client-side diagnostics use stdlib logging under the `rootstock` namespace — server lifecycle on `rootstock.server` (INFO/DEBUG), the full i-PI wire trace on `rootstock.protocol` (DEBUG):
+
+```python
+import logging
+logging.basicConfig(level=logging.DEBUG)  # or logging.getLogger("rootstock").setLevel(...)
+```
+
+The worker subprocess is separate: its verbosity is controlled by the `ROOTSTOCK_WORKER_LOG` environment variable (`stderr`, `stdout`, or a file path), and its output is captured and shown automatically when the worker fails.
+
 ## Available models
 
 What is deployed and verified per cluster changes over time. The authoritative, current list lives in the [Matter Model Almanac](https://garden-ai.github.io/almanac).

--- a/rootstock/calculator.py
+++ b/rootstock/calculator.py
@@ -68,11 +68,15 @@ class RootstockCalculator(Calculator):
         cache_root: str | Path | None = None,
         device: str = "cuda",
         setup_kwargs: dict | None = None,
-        log=None,
         **kwargs,
     ):
         """
         Initialize the Rootstock calculator.
+
+        Diagnostics go to stdlib logging under the ``rootstock`` namespace:
+        server lifecycle on ``rootstock.server`` (INFO/DEBUG), the wire trace
+        on ``rootstock.protocol`` (DEBUG). Enable with e.g.
+        ``logging.basicConfig(level=logging.DEBUG)``.
 
         Args:
             checkpoint: Canonical checkpoint id (e.g., "mace-mp-0-medium",
@@ -90,9 +94,17 @@ class RootstockCalculator(Calculator):
             setup_kwargs: Extra keyword arguments forwarded to the env's setup()
                           function. May not contain "checkpoint" or "device" —
                           those are passed at the top level.
-            log: Optional file object for logging
             **kwargs: Additional arguments passed to ASE Calculator
         """
+        # ASE's Calculator quietly absorbs unknown kwargs as parameters, so a
+        # 0.x caller passing the removed log= would silently lose their logs.
+        if "log" in kwargs:
+            raise TypeError(
+                "RootstockCalculator no longer takes 'log'. Client-side "
+                "diagnostics use stdlib logging — e.g. "
+                "logging.basicConfig(level=logging.DEBUG) — and worker "
+                "verbosity is controlled by the ROOTSTOCK_WORKER_LOG env var."
+            )
         super().__init__(**kwargs)
 
         if setup_kwargs is None:
@@ -107,7 +119,6 @@ class RootstockCalculator(Calculator):
         self.checkpoint = checkpoint
         self.device = device
         self.setup_kwargs = setup_kwargs
-        self.log = log
 
         # Resolve the install root: the cluster name is only a name -> path
         # bootstrap. Everything else about the install (including where its
@@ -149,7 +160,6 @@ class RootstockCalculator(Calculator):
                 socket_name=self._socket_name,
                 root=self.root,
                 cache_root=self.cache_root,
-                log=self.log,
                 setup_kwargs=self.setup_kwargs,
             )
             self._server.start()

--- a/rootstock/protocol.py
+++ b/rootstock/protocol.py
@@ -13,9 +13,12 @@ Protocol Overview:
 Reference: https://docs.ipi-code.org/
 """
 
+import logging
 import socket
 
 import numpy as np
+
+logger = logging.getLogger("rootstock.protocol")
 
 # ASE units conversion
 BOHR_TO_ANGSTROM = 0.52917721067
@@ -46,15 +49,21 @@ class IPIProtocol:
 
         Args:
             sock: Connected socket object
-            log: Optional file object for logging (useful for debugging)
+            log: Optional file object for wire tracing. Only the worker side
+                passes this — worker logging is a file-object affair
+                controlled by ROOTSTOCK_WORKER_LOG (see worker_config.py).
+                When None (the client side), traces go to the
+                ``rootstock.protocol`` logger at DEBUG level.
         """
         self.socket = sock
         self.log = log
 
     def _log(self, *args):
-        """Write to log if logging is enabled."""
+        """Trace a wire event: to the worker's log file, or to stdlib logging."""
         if self.log is not None:
             print(*args, file=self.log, flush=True)
+        else:
+            logger.debug(" ".join(str(a) for a in args))
 
     # -------------------------------------------------------------------------
     # Low-level send/receive

--- a/rootstock/server.py
+++ b/rootstock/server.py
@@ -6,6 +6,7 @@ sending atomic positions and receiving forces from a worker process.
 """
 
 import json
+import logging
 import os
 import shutil
 import socket
@@ -21,6 +22,8 @@ from .protocol import (
     create_private_socket_path,
     create_server_socket,
 )
+
+logger = logging.getLogger("rootstock.server")
 
 
 def _tail(text: str, limit: int = 8192) -> str:
@@ -78,12 +81,16 @@ class RootstockServer:
         socket_name: str = "rootstock",
         root: Path | None = None,
         cache_root: Path | None = None,
-        log=None,
         timeout: float = 60.0,
         setup_kwargs: dict | None = None,
     ):
         """
         Initialize the server.
+
+        Server-side diagnostics go to the ``rootstock.server`` logger
+        (lifecycle at INFO, detail at DEBUG); the wire trace goes to
+        ``rootstock.protocol`` at DEBUG. Enable with e.g.
+        ``logging.basicConfig(level=logging.DEBUG)``.
 
         Args:
             env_name: Name of pre-built environment (e.g., "mace")
@@ -93,7 +100,6 @@ class RootstockServer:
                 ipi_<name> inside a fresh private (0700) temp directory on
                 start(), so it is unreachable by other local users.
             root: Root directory for environments and cache (required)
-            log: Optional file object for protocol logging
             timeout: Socket timeout in seconds
             setup_kwargs: Extra keyword arguments forwarded to setup()
         """
@@ -105,7 +111,6 @@ class RootstockServer:
         # directory that stop() removes.
         self.socket_path: str | None = None
         self._socket_dir: str | None = None
-        self.log = log
         self.timeout = timeout
 
         self.env_name = env_name
@@ -144,14 +149,18 @@ class RootstockServer:
         self._server_socket = create_server_socket(self.socket_path, timeout=self.timeout)
         self._server_socket.listen(1)
 
-        if self.log:
-            print(f"Server listening on {self.socket_path}", file=self.log, flush=True)
+        logger.debug("Server listening on %s", self.socket_path)
 
         # Launch worker process
         self._start_worker()
 
-        if self.log:
-            print(f"Launched worker process (PID {self._process.pid})", file=self.log, flush=True)
+        logger.info(
+            "Launched worker (PID %s) for %s/%s on %s",
+            self._process.pid,
+            self.env_name,
+            self.checkpoint,
+            self.device,
+        )
 
         # Wait for worker to connect
         self._accept_connection()
@@ -176,18 +185,17 @@ class RootstockServer:
         cmd = self._env_manager.get_spawn_command(self.env_name, self._wrapper_path)
         env = self._env_manager.get_environment_variables()
 
-        if self.log:
-            print(f"Spawning worker: {' '.join(cmd)}", file=self.log, flush=True)
+        logger.debug("Spawning worker: %s", " ".join(cmd))
 
         # Redirect worker output to temp files rather than pipes. The worker
         # loads the model in setup() *before* connecting to the socket; a noisy
         # load that exceeds the OS pipe buffer (~64 KB) would block on the write
         # and never connect, deadlocking _accept_connection. Regular files have
-        # no such buffer limit, and we can still read them back to report errors
-        # if the worker dies. When logging, inherit the parent's fds as before.
-        if not self.log:
-            self._stdout_file = tempfile.TemporaryFile()
-            self._stderr_file = tempfile.TemporaryFile()
+        # no such buffer limit, and we read them back for the post-mortem when
+        # the worker fails. (The worker's own verbosity is controlled by the
+        # ROOTSTOCK_WORKER_LOG env var — see worker_config.py.)
+        self._stdout_file = tempfile.TemporaryFile()
+        self._stderr_file = tempfile.TemporaryFile()
 
         self._process = subprocess.Popen(
             cmd,
@@ -214,11 +222,10 @@ class RootstockServer:
         self._server_socket.settimeout(self.timeout)
         self._client_socket.settimeout(self.timeout)
 
-        self._protocol = IPIProtocol(self._client_socket, log=self.log)
+        self._protocol = IPIProtocol(self._client_socket)
         self._connected = True
 
-        if self.log:
-            print("Worker connected", file=self.log, flush=True)
+        logger.info("Worker connected")
 
     def _read_worker_output(self) -> tuple[str, str]:
         """Read the worker's captured stdout/stderr from the temp files.
@@ -265,10 +272,7 @@ class RootstockServer:
                 captured = True
                 lines.append(f"--- worker {name} (tail) ---\n{_tail(text)}")
         if not captured:
-            note = "(no worker output captured"
-            if self.log:
-                note += " — logging mode inherits the parent's stdio"
-            lines.append(note + ")")
+            lines.append("(worker produced no output)")
         return RuntimeError("\n".join(lines))
 
     def calculate(
@@ -403,8 +407,7 @@ class RootstockServer:
         self._connected = False
         self._protocol = None
 
-        if self.log:
-            print("Server stopped", file=self.log, flush=True)
+        logger.info("Server stopped")
 
     def __enter__(self):
         self.start()

--- a/tests/server/test_logging.py
+++ b/tests/server/test_logging.py
@@ -1,0 +1,113 @@
+"""Client-side diagnostics use stdlib logging, not a hand-threaded log= file.
+
+Server lifecycle goes to ``rootstock.server`` (INFO/DEBUG), the wire trace to
+``rootstock.protocol`` (DEBUG). The worker side is deliberately untouched:
+workers frozen inside built envs log to a file object controlled by the
+ROOTSTOCK_WORKER_LOG env var (worker_config.py), so ``IPIProtocol`` still
+honors an explicit ``log=`` file for that path.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import os
+import socket
+import sys
+from pathlib import Path
+
+import pytest
+from ase.build import molecule
+
+from rootstock.calculator import RootstockCalculator
+from rootstock.protocol import IPIProtocol
+
+_CHECKPOINT = "logging-dummy"
+
+
+@pytest.fixture
+def lj_env_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Faked install with a quiet LJ env (symlinked-interpreter harness)."""
+    import ase
+
+    import rootstock
+
+    pythonpath = os.pathsep.join(
+        sorted({str(Path(m.__file__).resolve().parents[1]) for m in (ase, rootstock)})
+    )
+    monkeypatch.setenv("PYTHONPATH", pythonpath)
+
+    env_dir = tmp_path / "envs" / "lj"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").symlink_to(sys.executable)
+    (env_dir / "env_source.py").write_text(
+        f"CHECKPOINTS = {{{_CHECKPOINT!r}: 'dummy'}}\n\n"
+        "def setup(checkpoint, device='cpu', **kwargs):\n"
+        "    from ase.calculators.lj import LennardJones\n"
+        "    return LennardJones()\n"
+    )
+    return tmp_path
+
+
+def test_lifecycle_and_wire_trace_reach_stdlib_logging(lj_env_root: Path, caplog):
+    atoms = molecule("H2O")
+    calc = RootstockCalculator(checkpoint=_CHECKPOINT, root=lj_env_root, device="cpu")
+    try:
+        atoms.calc = calc
+        with caplog.at_level(logging.DEBUG, logger="rootstock"):
+            atoms.get_potential_energy()
+    finally:
+        calc.close()
+
+    server_records = [r for r in caplog.records if r.name == "rootstock.server"]
+    protocol_records = [r for r in caplog.records if r.name == "rootstock.protocol"]
+
+    assert any("Launched worker" in r.message for r in server_records)
+    assert any("Worker connected" in r.message for r in server_records)
+    assert any("send_posdata" in r.message for r in protocol_records)
+    assert any("send_getforce" in r.message for r in protocol_records)
+
+
+def test_quiet_at_default_level(lj_env_root: Path, caplog):
+    """At WARNING (logging's default), a healthy run says nothing."""
+    atoms = molecule("H2O")
+    calc = RootstockCalculator(checkpoint=_CHECKPOINT, root=lj_env_root, device="cpu")
+    try:
+        atoms.calc = calc
+        with caplog.at_level(logging.WARNING, logger="rootstock"):
+            atoms.get_potential_energy()
+    finally:
+        calc.close()
+
+    assert [r for r in caplog.records if r.name.startswith("rootstock")] == []
+
+
+def test_calculator_log_kwarg_raises_with_guidance(tmp_path: Path):
+    with pytest.raises(TypeError, match="stdlib logging"):
+        RootstockCalculator(checkpoint="x", root=tmp_path, log=io.StringIO())
+
+
+def test_protocol_still_honors_worker_side_log_file():
+    """The worker path passes an explicit file object; that must keep working
+    (worker logging is env-var-driven, not stdlib-logging-driven)."""
+    a, b = socket.socketpair()
+    try:
+        log = io.StringIO()
+        proto = IPIProtocol(a, log=log)
+        proto.send_status()
+        assert "send_status" in log.getvalue()
+    finally:
+        a.close()
+        b.close()
+
+
+def test_protocol_without_log_file_uses_stdlib_logging(caplog):
+    a, b = socket.socketpair()
+    try:
+        proto = IPIProtocol(a)
+        with caplog.at_level(logging.DEBUG, logger="rootstock.protocol"):
+            proto.send_status()
+        assert any("send_status" in r.message for r in caplog.records)
+    finally:
+        a.close()
+        b.close()


### PR DESCRIPTION
## Summary

Fixes #113 (from the pre-1.0 audit issue #81). The `log=` file object was hand-threaded through calculator → server → protocol, and its presence doubled as a mode switch: log mode let the worker inherit parent stdio while capture mode wrote temp files — so #112's post-mortems were silently empty whenever logging was on.

- **Client side moves to stdlib logging.** Server lifecycle (`Launched worker (PID …)`, `Worker connected`, `Server stopped`) logs to `rootstock.server` at INFO with detail at DEBUG; the full i-PI wire trace logs to `rootstock.protocol` at DEBUG. A healthy run at logging's default WARNING level prints nothing (test-pinned).
- **`log=` is removed from `RootstockServer` and `RootstockCalculator`.** The server raises a natural `TypeError`; the calculator raises a pointed one — ASE's `Calculator.__init__` quietly absorbs unknown kwargs as parameters, so a 0.x caller passing `log=` would otherwise just silently lose their logs.
- **Worker output capture is now unconditional**, deleting the dual capture-mode branch in `_start_worker` — post-mortems now carry worker output in every mode, and the "logging mode inherits stdio" caveat is gone.
- **The worker side is deliberately untouched** (its logging contract was settled worker-side in #77/#85: `ROOTSTOCK_WORKER_LOG` env var → file object, frozen in built envs). `IPIProtocol` therefore still honors an explicit `log=` file object — the worker's path — and uses the `rootstock.protocol` logger only when none is given (the client's path). `run_worker(log=…)` and `MLIPWorker` are unchanged.
- `docs/api.md` gains a short Logging section covering both halves.

## Test plan
New `tests/server/test_logging.py`:
- e2e through the real calculator against a faked LJ env: `caplog` sees `rootstock.server` lifecycle records and `rootstock.protocol` wire records (`send_posdata`, `send_getforce`);
- a healthy run at WARNING emits zero `rootstock.*` records;
- `RootstockCalculator(log=…)` raises the guidance `TypeError`;
- `IPIProtocol(log=fileobj)` still prints to the file (worker path), and without it routes to stdlib logging.

Full suite: 323 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)