### PR TITLE
Corrupted manifests fail loudly instead of reading as missing

### DIFF
--- a/rootstock/cli.py
+++ b/rootstock/cli.py
@@ -69,6 +69,7 @@ from .commands import (
 )
 from .commands.common import ROOTSTOCK_ROOT_ENV
 from .config import DEFAULT_CONFIG_FILE
+from .manifest import ManifestError
 
 
 def main():
@@ -492,7 +493,13 @@ def main():
     manifest_init_parser.set_defaults(func=cmd_manifest)
 
     args = parser.parse_args()
-    sys.exit(args.func(args))
+    try:
+        sys.exit(args.func(args))
+    except ManifestError as exc:
+        # A corrupt or incompatible manifest is a data-integrity stop, not a
+        # crash: print the diagnosis cleanly instead of a traceback.
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/rootstock/manifest.py
+++ b/rootstock/manifest.py
@@ -27,6 +27,13 @@ from .config import UserConfig
 SCHEMA_VERSION = 4
 
 
+class ManifestError(RuntimeError):
+    """The manifest exists but cannot be used: corrupt JSON, missing required
+    fields, or a schema this client has no path to. Deliberately NOT treated
+    as "no manifest" — a silent fresh start would let the next save overwrite
+    all fetch/verify history."""
+
+
 def _migrate_v1_to_v2(data: dict) -> tuple[dict, str | None]:
     """v1 stored ``checkpoints: list[str]``; v2 stores a dict of CheckpointInfo.
 
@@ -97,7 +104,7 @@ def migrate_manifest_data(data: dict) -> tuple[dict, list[str]]:
     """Upgrade a raw manifest dict to SCHEMA_VERSION, one step at a time.
 
     Returns the upgraded dict and human-readable notes about lossy steps
-    (empty when the manifest was already current). Raises RuntimeError for
+    (empty when the manifest was already current). Raises ManifestError for
     manifests from a *newer* rootstock or with no migration path.
     """
     version = data.get("schema_version")
@@ -105,13 +112,13 @@ def migrate_manifest_data(data: dict) -> tuple[dict, list[str]]:
         version = int(version)  # v1 wrote schema_version as a string
 
     if not isinstance(version, int):
-        raise RuntimeError(
+        raise ManifestError(
             f"manifest has invalid schema_version={data.get('schema_version')!r}; "
             f"expected an integer <= {SCHEMA_VERSION}."
         )
 
     if version > SCHEMA_VERSION:
-        raise RuntimeError(
+        raise ManifestError(
             f"manifest is schema_version={version}, but this rootstock only "
             f"understands up to {SCHEMA_VERSION}. It was written by a newer "
             f"rootstock — upgrade this client (`pip install -U rootstock`)."
@@ -130,7 +137,7 @@ def migrate_manifest_data(data: dict) -> tuple[dict, list[str]]:
     while version < SCHEMA_VERSION:
         migrate = MIGRATIONS.get(version)
         if migrate is None:
-            raise RuntimeError(
+            raise ManifestError(
                 f"manifest is schema_version={version} and no migration path "
                 f"to {SCHEMA_VERSION} exists."
             )
@@ -436,7 +443,11 @@ def load_manifest(root: Path) -> Manifest | None:
         root: Rootstock root directory
 
     Returns:
-        Manifest object, or None if not found
+        Manifest object, or None when no manifest.json exists.
+
+    Raises:
+        ManifestError: the file exists but is corrupt or unmigratable —
+            never silently treated as missing.
     """
     manifest_path = root / "manifest.json"
     if not manifest_path.exists():
@@ -455,9 +466,15 @@ def load_manifest(root: Path) -> Manifest | None:
                 file=sys.stderr,
             )
         return Manifest.from_dict(data)
-    except (json.JSONDecodeError, KeyError):
-        # Invalid manifest - could log warning here
-        return None
+    except (json.JSONDecodeError, KeyError, TypeError, AttributeError) as exc:
+        # A manifest that exists but can't be parsed must NOT read as "no
+        # manifest": callers would create a fresh one and the next save would
+        # silently erase all fetch/verify history.
+        raise ManifestError(
+            f"manifest at {manifest_path} is corrupted "
+            f"({type(exc).__name__}: {exc}); refusing to treat it as missing. "
+            f"Fix the file, or move it aside to start fresh deliberately."
+        ) from exc
 
 
 def save_manifest(manifest: Manifest, root: Path) -> None:

--- a/tests/manifest/test_corruption.py
+++ b/tests/manifest/test_corruption.py
@@ -1,0 +1,96 @@
+"""A corrupted manifest fails loudly instead of reading as missing.
+
+``load_manifest`` used to swallow parse errors and return None; callers then
+created a fresh manifest and the next save overwrote all fetch/verify
+history without a word. Now the file's absence is the only thing that means
+"no manifest" — anything else raises ManifestError, which the CLI turns
+into a clean error message.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from rootstock.config import UserConfig
+from rootstock.manifest import (
+    ManifestError,
+    create_manifest,
+    load_manifest,
+    save_manifest,
+)
+
+
+def test_missing_manifest_is_none(tmp_path: Path):
+    assert load_manifest(tmp_path) is None
+
+
+def test_corrupt_json_raises_with_path(tmp_path: Path):
+    (tmp_path / "manifest.json").write_text("{not json")
+
+    with pytest.raises(ManifestError, match=str(tmp_path / "manifest.json")):
+        load_manifest(tmp_path)
+
+
+def test_missing_required_field_raises(tmp_path: Path):
+    """Valid JSON with required keys stripped is corruption, not absence."""
+    manifest = create_manifest(tmp_path, "test", UserConfig(name="t", email="t@t.t"))
+    save_manifest(manifest, tmp_path)
+    data = json.loads((tmp_path / "manifest.json").read_text())
+    del data["maintainer"]
+    (tmp_path / "manifest.json").write_text(json.dumps(data))
+
+    with pytest.raises(ManifestError, match="refusing to treat it as missing"):
+        load_manifest(tmp_path)
+
+
+def test_wrong_top_level_type_raises(tmp_path: Path):
+    (tmp_path / "manifest.json").write_text('["not", "a", "manifest"]')
+
+    with pytest.raises(ManifestError):
+        load_manifest(tmp_path)
+
+
+def test_valid_manifest_still_loads(tmp_path: Path):
+    manifest = create_manifest(tmp_path, "test", UserConfig(name="t", email="t@t.t"))
+    save_manifest(manifest, tmp_path)
+
+    loaded = load_manifest(tmp_path)
+
+    assert loaded is not None
+    assert loaded.cluster == "test"
+
+
+def test_newer_schema_raises_manifest_error(tmp_path: Path):
+    """Schema mismatches share the taxonomy: a clean ManifestError, not a
+    bare RuntimeError traceback."""
+    manifest = create_manifest(tmp_path, "test", UserConfig(name="t", email="t@t.t"))
+    save_manifest(manifest, tmp_path)
+    data = json.loads((tmp_path / "manifest.json").read_text())
+    data["schema_version"] = 99
+    (tmp_path / "manifest.json").write_text(json.dumps(data))
+
+    with pytest.raises(ManifestError, match="upgrade this client"):
+        load_manifest(tmp_path)
+
+
+def test_cli_reports_corruption_cleanly(tmp_path: Path, monkeypatch, capsys):
+    """End to end: `rootstock status` on a corrupt manifest exits 1 with a
+    clean error, no traceback, and does not clobber the file."""
+    import rootstock.cli as cli
+
+    (tmp_path / "manifest.json").write_text("{not json")
+    before = (tmp_path / "manifest.json").read_text()
+
+    monkeypatch.setattr("sys.argv", ["rootstock", "status", "--root", str(tmp_path)])
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main()
+
+    assert excinfo.value.code == 1
+    err = capsys.readouterr().err
+    assert "Error:" in err
+    assert "corrupted" in err
+    assert "Traceback" not in err
+    assert (tmp_path / "manifest.json").read_text() == before


### PR DESCRIPTION
## Summary

Fixes #123 (from #80). `load_manifest` swallowed `JSONDecodeError`/`KeyError` and returned None — indistinguishable from "no manifest" — so callers created a fresh manifest and the next save silently erased all fetch/verify history. Meanwhile a schema-version mismatch raised an uncaught `RuntimeError` traceback: inconsistent failure modes in both directions.

- New `ManifestError(RuntimeError)`: the manifest exists but cannot be used. `load_manifest` raises it for corrupt JSON, missing required fields, or wrong top-level type, with the path and a pointed "refusing to treat it as missing — fix the file, or move it aside to start fresh deliberately". Only true absence returns None.
- The migration errors (`schema_version` invalid / newer-than-client / no migration path) are reclassified from bare `RuntimeError` to `ManifestError` — same taxonomy, and since it subclasses `RuntimeError`, every existing `pytest.raises(RuntimeError)` and caller `except RuntimeError` keeps working.
- `cli.py` catches `ManifestError` at the dispatch boundary and prints a clean `Error: …` with exit 1 — a data-integrity stop, not a crash traceback. One catch site; nothing else is masked.

## Test plan
New `tests/manifest/test_corruption.py` (7 tests): missing→None unchanged; corrupt JSON / stripped required field / wrong top-level type raise with the path in the message; valid manifests still load; newer-schema now raises `ManifestError` with "upgrade this client"; and an end-to-end `rootstock status` on a corrupt manifest exits 1 with a clean error, no traceback, and the corrupt file left byte-identical (nothing clobbered). Full suite: 339 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)