### PR TITLE
Make status cache sizes opt-in via --sizes

### DIFF
--- a/rootstock/cli.py
+++ b/rootstock/cli.py
@@ -272,6 +272,14 @@ def main():
         action="store_true",
         help="Output the manifest as JSON (with computed verified_current per checkpoint)",
     )
+    status_parser.add_argument(
+        "--sizes",
+        action="store_true",
+        help=(
+            "Also compute per-directory cache sizes (full recursive stat of the "
+            "model cache — can take minutes on Lustre/GPFS for large caches)"
+        ),
+    )
     status_parser.set_defaults(func=cmd_status)
 
     # list command

--- a/rootstock/commands/status.py
+++ b/rootstock/commands/status.py
@@ -88,12 +88,20 @@ def cmd_status(args) -> int:
         for name in sorted(state.manifest_only_envs):
             print(f"  {name:<20} [manifest only — not on disk]")
 
-    # Show cache sizes. Cache may live under the install root or under a
-    # separate cluster-registered cache_root. Some libraries respect
-    # XDG_CACHE_HOME and write under cache/; others hardcode ~/.cache/ or
-    # ~/.matgl/ etc. and write under our redirected home/. Sum both.
+    # Show the cache location; computing sizes is opt-in. Cache may live
+    # under the install root or under a separate declared cache_root. Some
+    # libraries respect XDG_CACHE_HOME and write under cache/; others
+    # hardcode ~/.cache/ or ~/.matgl/ etc. and write under our redirected
+    # home/ — sizing sums both, which means a full rglob+stat over the model
+    # cache: minutes of metadata traffic on Lustre/GPFS for big HF caches,
+    # so it only runs with --sizes.
     cache_root = resolve_cache_root(root)
     print(f"\nCache: {cache_root}")
+
+    if not getattr(args, "sizes", False):
+        print("  (pass --sizes to compute per-directory cache sizes)")
+        print(f"\nConfig file: {DEFAULT_CONFIG_FILE}")
+        return 0
 
     locations: list = []
     for parent in (cache_root / "cache", cache_root / "home" / ".cache"):

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -173,3 +173,46 @@ def test_status_human_view_flags_drift_and_manifest_only(tmp_path: Path, capsys)
     out = capsys.readouterr().out
     assert "differs from the manifest" in out
     assert "manifest only — not on disk" in out
+
+
+def test_status_skips_cache_sizes_by_default(tmp_path: Path, capsys, monkeypatch):
+    """The rglob+stat sweep is minutes on Lustre for big HF caches — it must
+    not run unless asked."""
+    _make_built_env(tmp_path)
+    cache_dir = tmp_path / "cache" / "huggingface"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "weights.bin").write_bytes(b"x" * 2048)
+
+    sweep = []
+    real_rglob = Path.rglob
+
+    def counting_rglob(self, pattern):
+        sweep.append(self)
+        return real_rglob(self, pattern)
+
+    monkeypatch.setattr(Path, "rglob", counting_rglob)
+
+    rc = cmd_status(_args(tmp_path, as_json=False))
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    assert "--sizes" in out  # points the user at the opt-in
+    assert "MB" not in out
+    assert sweep == []  # no recursive sweep happened
+
+
+def test_status_sizes_flag_computes_cache_sizes(tmp_path: Path, capsys):
+    _make_built_env(tmp_path)
+    cache_dir = tmp_path / "cache" / "huggingface"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "weights.bin").write_bytes(b"x" * 2048)
+
+    args = _args(tmp_path, as_json=False)
+    args.sizes = True
+    rc = cmd_status(args)
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    assert "huggingface/" in out
+    assert "MB" in out
+    assert "TOTAL" in out


### PR DESCRIPTION
## Summary

Fixes #128 (from #81). `rootstock status` unconditionally walked the entire model cache with `rglob` + per-file `stat` to print per-directory sizes — on Lustre/GPFS with a large HuggingFace cache that's minutes of metadata traffic for a command people run casually.

The cache *location* still prints on every run. The recursive sweep now runs only with `--sizes` (flag help warns about the cost); without it, status prints a one-line pointer at the opt-in. `--json` output is unaffected (it never included sizes).

## Test plan
Two new tests in `tests/cli/test_status.py`: the default path performs **zero** `rglob` calls (instrumented via monkeypatched `Path.rglob`) and shows the `--sizes` hint with no size lines; `--sizes` computes and prints per-directory sizes and the total as before. Full suite: 334 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)