### PR TITLE
Exception taxonomy: RootstockError base class

### DIFF
--- a/rootstock/__init__.py
+++ b/rootstock/__init__.py
@@ -15,6 +15,7 @@ from importlib.metadata import version as _pkg_version
 from .calculator import RootstockCalculator
 from .clusters import CLUSTER_REGISTRY, Cluster, get_cluster, get_root_for_cluster
 from .environment import CheckpointNotFoundError, list_declared_checkpoints
+from .exceptions import RootstockError
 from .server import RootstockServer, WorkerDiedError
 
 __all__ = [
@@ -22,6 +23,7 @@ __all__ = [
     "RootstockCalculator",
     "RootstockServer",
     "WorkerDiedError",
+    "RootstockError",
     # Checkpoint discovery
     "list_declared_checkpoints",
     "CheckpointNotFoundError",

--- a/rootstock/environment.py
+++ b/rootstock/environment.py
@@ -16,8 +16,10 @@ import shutil
 import tempfile
 from pathlib import Path
 
+from .exceptions import RootstockError
 
-class CheckpointNotFoundError(LookupError):
+
+class CheckpointNotFoundError(RootstockError, LookupError):
     """Raised when a canonical checkpoint id is not declared by any installed env."""
 
 

--- a/rootstock/exceptions.py
+++ b/rootstock/exceptions.py
@@ -1,0 +1,21 @@
+"""Rootstock's exception taxonomy.
+
+One base class so callers can catch every rootstock domain error with a
+single ``except RootstockError``. The concrete exceptions live next to the
+code that raises them and inherit both this base and the stdlib category
+they historically subclassed, so existing ``except LookupError`` /
+``except RuntimeError`` call sites keep working:
+
+- ``CheckpointNotFoundError`` (rootstock.environment) — no installed env
+  declares the requested canonical checkpoint id.
+- ``WorkerDiedError`` (rootstock.server) — the worker process failed at the
+  socket level; carries a post-mortem.
+- ``OperationError`` (rootstock.operations) — an install/add operation
+  failed; message is user-presentable.
+"""
+
+from __future__ import annotations
+
+
+class RootstockError(Exception):
+    """Base class for all rootstock domain errors."""

--- a/rootstock/operations.py
+++ b/rootstock/operations.py
@@ -32,6 +32,7 @@ from .client import RootstockClient
 from .clusters import get_cluster_for_root
 from .config import load_config
 from .environment import find_env_for_checkpoint, get_model_cache_env, parse_checkpoints_dict
+from .exceptions import RootstockError
 from .layout import resolve_cache_root
 from .manifest import (
     CheckpointInfo,
@@ -57,7 +58,7 @@ ROOTSTOCK_GITHUB_URL = "https://github.com/Garden-AI/rootstock.git"
 Progress = Callable[[str], None]
 
 
-class OperationError(RuntimeError):
+class OperationError(RootstockError, RuntimeError):
     """An operation failed; the message is presentable to the user as-is."""
 
 

--- a/rootstock/server.py
+++ b/rootstock/server.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import numpy as np
 
+from .exceptions import RootstockError
 from .protocol import (
     IPIProtocol,
     SocketClosed,
@@ -26,7 +27,7 @@ from .protocol import (
 logger = logging.getLogger("rootstock.server")
 
 
-class WorkerDiedError(RuntimeError):
+class WorkerDiedError(RootstockError, RuntimeError):
     """The worker process failed at the socket level (died, hung, or the
     connection broke) — as opposed to reporting a calculation error in-band
     while staying healthy. The message carries the post-mortem: process fate

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,28 @@
+"""One base class catches every rootstock domain error."""
+
+from __future__ import annotations
+
+import pytest
+
+from rootstock import RootstockError
+from rootstock.environment import CheckpointNotFoundError
+from rootstock.operations import OperationError
+from rootstock.server import WorkerDiedError
+
+
+@pytest.mark.parametrize("exc", [CheckpointNotFoundError, WorkerDiedError, OperationError])
+def test_domain_errors_share_the_base(exc):
+    assert issubclass(exc, RootstockError)
+
+
+def test_historic_stdlib_categories_preserved():
+    """Existing `except LookupError` / `except RuntimeError` call sites must
+    keep working across the taxonomy change."""
+    assert issubclass(CheckpointNotFoundError, LookupError)
+    assert issubclass(WorkerDiedError, RuntimeError)
+    assert issubclass(OperationError, RuntimeError)
+
+
+def test_catching_the_base_catches_a_raise():
+    with pytest.raises(RootstockError):
+        raise CheckpointNotFoundError("no env declares 'nope'")

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -15,6 +15,7 @@ BLESSED = {
     "RootstockCalculator",
     "RootstockServer",
     "WorkerDiedError",
+    "RootstockError",
     "list_declared_checkpoints",
     "CheckpointNotFoundError",
     "CLUSTER_REGISTRY",


### PR DESCRIPTION
## Summary

Fixes #129 (the remainder of #79's exception-taxonomy item after #119 pruned the export surface). Users had no way to catch "any rootstock error" without enumerating classes.

- New tiny `rootstock/exceptions.py` defines `RootstockError(Exception)` — a leaf module so `environment`/`server`/`operations` can all import it without cycles.
- The three blessed domain errors inherit it **alongside their historic stdlib categories**: `CheckpointNotFoundError(RootstockError, LookupError)`, `WorkerDiedError(RootstockError, RuntimeError)`, `OperationError(RootstockError, RuntimeError)` — every existing `except LookupError`/`except RuntimeError` call site keeps working (test-pinned).
- `RootstockError` is exported and added to the blessed-surface test from #119.

Deliberately not included: `ManifestError` from the open #133 (would conflict; one-line follow-up to add it to the taxonomy once both merge), and the internal `(bool, str)` returners (`verify_checkpoint`, `push_manifest`, `Manifest.validate`) — those are no longer public API after #119, so converting them is internal cleanup with no API-freeze urgency.

## Test plan
New `tests/test_exceptions.py`: all three subclass the base; historic stdlib categories preserved; catching the base catches a raise. Full suite: 337 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)