### PR TITLE
Clean up client.py and quiet the non-maintainer push path

### DIFF
--- a/rootstock/client.py
+++ b/rootstock/client.py
@@ -43,12 +43,10 @@ class RootstockClient:
         if not self.config.api_url:
             return False, "API URL not configured"
 
-        url = f"{self.config.api_url}"
-
         data = json.dumps(manifest.to_dict()).encode("utf-8")
 
         request = Request(
-            url,
+            self.config.api_url,
             data=data,
             headers={
                 "Content-Type": "application/json",

--- a/rootstock/commands/manifest.py
+++ b/rootstock/commands/manifest.py
@@ -143,7 +143,5 @@ def cmd_manifest_init(args) -> int:
         else:
             print(f"Warning: Failed to push manifest: {message}", file=sys.stderr)
             print("Run 'rootstock manifest push' to retry.", file=sys.stderr)
-    elif not config.is_maintainer:
-        print("Manifest saved locally (not pushing - you are not the maintainer).")
 
     return 0

--- a/rootstock/operations.py
+++ b/rootstock/operations.py
@@ -283,10 +283,10 @@ def update_and_push_manifest(
                     file=sys.stderr,
                 )
         return success
-    elif not config.is_maintainer and not quiet:
-        print("Manifest saved locally (not pushing - you are not the maintainer).")
 
-    return True  # Not maintainer or no API key = skip push (not an error)
+    # Not the configured maintainer (or no API credentials): saving locally
+    # is the normal, expected outcome — nothing to warn about.
+    return True
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #130 (from #81). Two small things with user-facing effect:

- `client.py`: `url = f"{self.config.api_url}"` → pass `self.config.api_url` directly to `Request`.
- The "Manifest saved locally (not pushing - you are not the maintainer)." prints in `update_and_push_manifest` and `manifest init` read as warnings to regular users, implying something went wrong. For everyone except the configured maintainer, a local save *is* the expected outcome, so the non-maintainer path is now silent. Real push attempts (maintainer + credentials) keep their success/failure messages, and `--no-push` keeps its confirmation.

The backend remains load-bearing (the Almanac renders from pushed manifests) — nothing about the push path's behavior changes, only the noise.

## Test plan
Full suite: 332 passed, 2 skipped (existing add/smoke-test/manifest CLI tests cover these paths; none pinned the removed message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)