### PR TITLE
Docs: stale version strings, trust model, LAMMPS as frozen protocol peer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Rootstock is a proof-of-concept for running MLIP (Machine Learning Interatomic Potential) calculators in isolated pre-built Python environments, communicating via the i-PI protocol over Unix sockets.
 
-**Current version: v0.8** - Manifest schema v4 (older schemas migrate in place on load); canonical-checkpoint-id API.
+Versioning is dynamic (git tags via uv-dynamic-versioning) — check `rootstock --version`. Manifest schema v4 (older schemas migrate in place on load); canonical-checkpoint-id API.
 
 ## Commands
 
@@ -65,7 +65,7 @@ Main Process                          Worker Process (subprocess)
 
 ### Core Files
 
-- `rootstock/cli.py` - CLI commands (`build`, `status`, `list`, `register`)
+- `rootstock/cli.py` + `rootstock/commands/` - CLI (`install`, `add`, `smoke-test`, `status`, `serve`, ... — thin adapters over `rootstock/operations.py`)
 - `rootstock/calculator.py` - ASE Calculator interface (main entry point)
 - `rootstock/server.py` - Spawns worker subprocess, manages socket lifecycle
 - `rootstock/worker.py` - i-PI client state machine
@@ -120,7 +120,7 @@ predate the declaration. Most clusters use the same path for both.
 ## API
 
 ```python
-# v0.8: single canonical checkpoint id; env is resolved automatically.
+# Single canonical checkpoint id; the hosting env is resolved automatically.
 with RootstockCalculator(
     cluster="della",
     checkpoint="mace-mp-0-medium",

--- a/docs/cluster-setup.md
+++ b/docs/cluster-setup.md
@@ -43,6 +43,21 @@ The cluster registry (`rootstock/clusters.py`) is only a name → install-path b
 
 Users don't need to set environment variables — `RootstockCalculator(cluster="perlmutter", ...)` resolves both automatically.
 
+### Trust model
+
+Using a shared install means trusting its maintainer. An environment's
+`setup()` function is **maintainer-authored Python executed with the calling
+user's credentials** — inside the worker subprocess, as you, with your
+filesystem access and your HF tokens (forwarded so gated models work).
+Rootstock isolates *dependencies*, not *privilege*: the pre-built venv keeps
+MLIP stacks out of your Python environment, but it is not a sandbox.
+
+Concretely: only use installs whose maintainer you trust, exactly as you
+would a module farm or a shared conda env maintained by your facility. The
+permission recipe below makes installs world-*readable*, and only
+maintainers can modify `env_source.py` — so the code you run is the code the
+maintainer published, but what that code does runs as you.
+
 ### Permissions for shared installs
 
 Shared installs on HPC clusters should be **world-readable**: anyone on the cluster (not just members of the maintainer's project group) should be able to use the environments and model weights. Nothing in a rootstock install is sensitive — it's all derived from public PyPI packages and public model checkpoints. Maintainer secrets (API tokens) live in the maintainer's `~/.config/rootstock/config.toml`, not in the shared root.

--- a/docs/development.md
+++ b/docs/development.md
@@ -74,6 +74,16 @@ Never: new message types, changed payload layouts, new required
 one of the four channels above, it waits for a major protocol revision and
 a coordinated env rebuild.
 
+**The LAMMPS styles are a third frozen peer.** `rootstock_ipi.cpp` (shared
+by `fix rootstock` and `pair_style rootstock`) is an independent
+implementation of the wire protocol that users compile into their LAMMPS
+binaries — it has its own freeze horizon, separate from both the PyPI
+client and the env-pinned worker. A binary built today must keep driving
+every worker ever deployed, and no client- or worker-side change may assume
+LAMMPS binaries get rebuilt. Wire-protocol changes must be checked against
+all **three** implementations: `protocol.py` server side, `protocol.py`
+worker side, and `lammps/rootstock_ipi.cpp`.
+
 `tests/protocol/test_wire_golden.py` pins the exact bytes of every message.
 If it fails, the change breaks compatibility with every deployed
 environment — fix the change, not the test. (Post-1.0, a CI job should

--- a/rootstock/environment.py
+++ b/rootstock/environment.py
@@ -135,7 +135,7 @@ class EnvironmentManager:
     """
     Manages pre-built rootstock environments and worker spawning.
 
-    In v0.4+, environments are pre-built virtual environments located in
+    Environments are pre-built virtual environments located in
     {root}/envs/{env_name}/. The environment source file is copied into
     the venv as env_source.py during build.
     """
@@ -177,7 +177,7 @@ class EnvironmentManager:
 
             raise RuntimeError(
                 f"Environment '{env_name}' not built. "
-                f"Run: rootstock build {env_name} --root {self.root}\n"
+                f"Run: rootstock install {env_name} --root {self.root}\n"
                 f"Available environments: {available}"
             )
 


### PR DESCRIPTION
## Summary

Fixes #131 (docs items from #79/#81). Four independent freshness/completeness fixes, no behavior changes except one error string:

- **Stale `rootstock build` error**: `EnvironmentManager.get_env_python` told users to run a command that no longer exists; now says `rootstock install`. Also drops the "In v0.4+" framing from the class docstring.
- **CLAUDE.md**: the hardcoded "Current version: v0.8" becomes a pointer at dynamic versioning (`rootstock --version`); the core-files list no longer claims the CLI commands are `build/status/list/register` (three of four didn't exist) and now reflects the post-#121 commands/operations split; the API example drops its version-pinned comment.
- **Compat policy names the third peer** (#79's item): `docs/development.md`'s worker-compatibility policy now states that `rootstock_ipi.cpp` (shared by both LAMMPS styles) is an independent frozen implementation of the wire protocol compiled into users' LAMMPS binaries — its own freeze horizon, and wire changes must be checked against all three implementations.
- **Trust model documented** (#81's item): new section in `docs/cluster-setup.md` — an env's `setup()` is maintainer-authored code executed with the calling user's credentials and tokens; rootstock isolates dependencies, not privilege; trust an install's maintainer as you would a facility module farm.

The `# Removed in v0.8.0` comment in `cli.py` stays — that one is accurate history, not drift.

## Test plan
Full suite: 332 passed, 2 skipped (no test pinned the old error string; grep confirms no remaining `rootstock build` references or stale version claims outside genuine changelog-style comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)