### PR TITLE
ManifestError joins the RootstockError taxonomy

### DIFF
--- a/rootstock/exceptions.py
+++ b/rootstock/exceptions.py
@@ -12,6 +12,8 @@ they historically subclassed, so existing ``except LookupError`` /
   socket level; carries a post-mortem.
 - ``OperationError`` (rootstock.operations) — an install/add operation
   failed; message is user-presentable.
+- ``ManifestError`` (rootstock.manifest) — the manifest exists but cannot
+  be used; deliberately not treated as "no manifest".
 """
 
 from __future__ import annotations

--- a/rootstock/manifest.py
+++ b/rootstock/manifest.py
@@ -23,11 +23,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from .config import UserConfig
+from .exceptions import RootstockError
 
 SCHEMA_VERSION = 4
 
 
-class ManifestError(RuntimeError):
+class ManifestError(RootstockError, RuntimeError):
     """The manifest exists but cannot be used: corrupt JSON, missing required
     fields, or a schema this client has no path to. Deliberately NOT treated
     as "no manifest" — a silent fresh start would let the next save overwrite

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -6,11 +6,14 @@ import pytest
 
 from rootstock import RootstockError
 from rootstock.environment import CheckpointNotFoundError
+from rootstock.manifest import ManifestError
 from rootstock.operations import OperationError
 from rootstock.server import WorkerDiedError
 
 
-@pytest.mark.parametrize("exc", [CheckpointNotFoundError, WorkerDiedError, OperationError])
+@pytest.mark.parametrize(
+    "exc", [CheckpointNotFoundError, WorkerDiedError, OperationError, ManifestError]
+)
 def test_domain_errors_share_the_base(exc):
     assert issubclass(exc, RootstockError)
 
@@ -21,6 +24,7 @@ def test_historic_stdlib_categories_preserved():
     assert issubclass(CheckpointNotFoundError, LookupError)
     assert issubclass(WorkerDiedError, RuntimeError)
     assert issubclass(OperationError, RuntimeError)
+    assert issubclass(ManifestError, RuntimeError)
 
 
 def test_catching_the_base_catches_a_raise():


### PR DESCRIPTION
Follow-up to #133 + #136 (refs #129): `ManifestError` now inherits `RootstockError` alongside `RuntimeError`, matching the dual-inheritance pattern of the other domain errors — `except RootstockError` catches it, existing `except RuntimeError` call sites keep working. Added to the taxonomy docstring and the shared-base test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)