### PR TITLE
Serialize manifest with dataclasses.asdict

### DIFF
--- a/rootstock/manifest.py
+++ b/rootstock/manifest.py
@@ -18,7 +18,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -159,7 +159,7 @@ class Maintainer:
     email: str
 
     def to_dict(self) -> dict:
-        return {"name": self.name, "email": self.email}
+        return asdict(self)
 
     @classmethod
     def from_dict(cls, data: dict) -> Maintainer:
@@ -176,12 +176,7 @@ class CheckpointInfo:
     last_error: str | None = None       # most recent error from add or smoke-test
 
     def to_dict(self) -> dict:
-        return {
-            "fetched_at": self.fetched_at,
-            "verified_at": self.verified_at,
-            "verified_device": self.verified_device,
-            "last_error": self.last_error,
-        }
+        return asdict(self)
 
     @classmethod
     def from_dict(cls, data: dict) -> CheckpointInfo:
@@ -207,23 +202,17 @@ class EnvironmentInfo:
     source: str  # Full source code of the environment file
     python_requires: str  # ">=3.11"
     dependencies: dict[str, str]  # {"mace-torch": "0.3.6"}
-    checkpoints: dict[str, CheckpointInfo] = field(default_factory=dict)
     # sha256 of the env's uv lockfile (envs/<name>/env_source.py.lock).
     # None means the env was built without one — either by a pre-lockfile
     # rootstock or because the env defeats universal resolution — and can
     # only be re-resolved, not faithfully rebuilt.
     lock_hash: str | None = None
+    # Field order is the JSON key order (asdict): lock_hash stays ahead of
+    # checkpoints to match the layout pushed manifests have always had.
+    checkpoints: dict[str, CheckpointInfo] = field(default_factory=dict)
 
     def to_dict(self) -> dict:
-        return {
-            "built_at": self.built_at,
-            "source_hash": self.source_hash,
-            "source": self.source,
-            "python_requires": self.python_requires,
-            "dependencies": self.dependencies,
-            "lock_hash": self.lock_hash,
-            "checkpoints": {name: ckpt.to_dict() for name, ckpt in self.checkpoints.items()},
-        }
+        return asdict(self)
 
     @classmethod
     def from_dict(cls, data: dict) -> EnvironmentInfo:
@@ -264,16 +253,7 @@ class Manifest:
     environments: dict[str, EnvironmentInfo] = field(default_factory=dict)
 
     def to_dict(self) -> dict:
-        return {
-            "schema_version": self.schema_version,
-            "cluster": self.cluster,
-            "root": self.root,
-            "maintainer": self.maintainer.to_dict(),
-            "rootstock_version": self.rootstock_version,
-            "python_version": self.python_version,
-            "last_updated": self.last_updated,
-            "environments": {name: env.to_dict() for name, env in self.environments.items()},
-        }
+        return asdict(self)
 
     @classmethod
     def from_dict(cls, data: dict) -> Manifest:

--- a/tests/manifest/test_manifest.py
+++ b/tests/manifest/test_manifest.py
@@ -106,6 +106,39 @@ def test_manifest_round_trip_preserves_checkpoint_metadata():
     assert ckpts["mace-mp-0-small"].fetched_at is None
 
 
+def test_to_dict_key_layout_is_stable():
+    """Pushed manifests are consumed downstream (the Almanac renders them) —
+    the JSON key layout is a contract, not an implementation detail."""
+    data = _make_manifest({"mace": _make_env(**{"mace-mp-0-small": CheckpointInfo()})}).to_dict()
+    assert list(data) == [
+        "schema_version",
+        "cluster",
+        "root",
+        "maintainer",
+        "rootstock_version",
+        "python_version",
+        "last_updated",
+        "environments",
+    ]
+    assert list(data["maintainer"]) == ["name", "email"]
+    env = data["environments"]["mace"]
+    assert list(env) == [
+        "built_at",
+        "source_hash",
+        "source",
+        "python_requires",
+        "dependencies",
+        "lock_hash",
+        "checkpoints",
+    ]
+    assert list(env["checkpoints"]["mace-mp-0-small"]) == [
+        "fetched_at",
+        "verified_at",
+        "verified_device",
+        "last_error",
+    ]
+
+
 def test_from_dict_migrates_v2():
     """Old manifests load via migration instead of demanding a reinstall.
 


### PR DESCRIPTION
Closes #124.

The handwritten `to_dict` bodies restated every field by hand and had to be kept in sync with the dataclasses on every schema change. `dataclasses.asdict` recurses through nested dataclasses and emits keys in field order, so the four bodies collapse to one line each.

- **Key layout preserved**: `EnvironmentInfo.lock_hash` moves ahead of `checkpoints` in field order so the asdict output matches the layout pushed manifests have always had (the Almanac consumes them). Every construction site is keyword-based, so the reorder is safe. A new test pins the full JSON key layout as a contract.
- **`from_dict` stays handwritten**: the constructors tolerate missing keys via defaults (`lock_hash`, `source`, `checkpoints`), and `Manifest.from_dict` must keep calling `migrate_manifest_data` first — that half isn't mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)