### PR TITLE
One context-managed spawn helper for running code inside envs

### DIFF
--- a/rootstock/__init__.py
+++ b/rootstock/__init__.py
@@ -39,7 +39,7 @@ __version__ = _pkg_version("rootstock")
 # they live. Gives 0.x users a pointed error instead of a bare AttributeError.
 _MOVED = {
     "RootstockClient": "rootstock.client",
-    "EnvironmentManager": "rootstock.environment",
+    "EnvironmentManager": "rootstock.spawn — its replacement is spawn_in_env",
     "list_environments": "rootstock.environment",
     "list_built_environments": "rootstock.environment",
     "get_model_cache_env": "rootstock.environment",

--- a/rootstock/commands/serve.py
+++ b/rootstock/commands/serve.py
@@ -22,10 +22,11 @@ def cmd_serve(args) -> int:
     """
     from ..environment import (
         CheckpointNotFoundError,
-        EnvironmentManager,
         find_env_for_checkpoint,
+        get_env_python,
     )
     from ..operations import parse_setup_kwargs
+    from ..spawn import WORKER_WRAPPER, spawn_in_env
     from .common import resolve_cache_root
 
     root = get_root_or_exit(args)
@@ -46,26 +47,12 @@ def cmd_serve(args) -> int:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
 
-    # Create environment manager and validate environment exists
-    env_mgr = EnvironmentManager(root=root, cache_root=cache_root)
+    # Validate environment exists before printing the startup banner
     try:
-        env_mgr.get_env_python(env_name)
+        get_env_python(root, env_name)
     except RuntimeError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
-
-    # Generate wrapper script
-    wrapper_path = env_mgr.generate_wrapper(
-        env_name=env_name,
-        checkpoint=checkpoint,
-        device=device,
-        socket_path=socket_path,
-        setup_kwargs=setup_kwargs,
-    )
-
-    # Get spawn command and environment
-    cmd = env_mgr.get_spawn_command(env_name, wrapper_path)
-    env = env_mgr.get_environment_variables()
 
     print("Starting rootstock worker:")
     print(f"  Env: {env_name}")
@@ -73,20 +60,28 @@ def cmd_serve(args) -> int:
     print(f"  Device: {device}")
     print(f"  Socket: {socket_path}")
 
-    # Spawn worker subprocess
-    proc = subprocess.Popen(cmd, env=env)
+    # The context must stay open until the worker exits — it reads the
+    # wrapper and sidecar at startup.
+    with spawn_in_env(
+        root,
+        env_name,
+        WORKER_WRAPPER,
+        {
+            "checkpoint": checkpoint,
+            "device": device,
+            "socket_path": socket_path,
+            "setup_kwargs": setup_kwargs,
+        },
+        cache_root=cache_root,
+    ) as spec:
+        proc = subprocess.Popen(spec.cmd, env=spec.env, cwd=spec.cwd)
 
-    # Forward signals to worker
-    def forward_signal(signum, frame):
-        proc.send_signal(signum)
+        # Forward signals to worker
+        def forward_signal(signum, frame):
+            proc.send_signal(signum)
 
-    signal.signal(signal.SIGTERM, forward_signal)
-    signal.signal(signal.SIGINT, forward_signal)
+        signal.signal(signal.SIGTERM, forward_signal)
+        signal.signal(signal.SIGINT, forward_signal)
 
-    # Block until worker exits
-    try:
-        rc = proc.wait()
-    finally:
-        env_mgr.cleanup()
-
-    return rc
+        # Block until worker exits
+        return proc.wait()

--- a/rootstock/environment.py
+++ b/rootstock/environment.py
@@ -2,18 +2,18 @@
 Environment management for Rootstock.
 
 This module handles:
-- Managing pre-built virtual environments
-- Generating wrapper scripts for worker processes
-- Providing spawn commands for worker processes
+- Locating pre-built virtual environments and their interpreters
+- Cache-redirection environment variables for worker processes
+- Checkpoint discovery from installed env sources
+
+Running code inside an env lives in rootstock.spawn.
 """
 
 from __future__ import annotations
 
 import ast
-import json
 import os
 import shutil
-import tempfile
 from pathlib import Path
 
 from .exceptions import RootstockError
@@ -110,167 +110,37 @@ def get_model_cache_env(root: Path, cache_root: Path | None = None) -> dict[str,
     return env
 
 
-# Simplified wrapper template for pre-built environments.
-# No PEP 723 metadata needed since dependencies are already installed.
-# setup_kwargs travel via a JSON sidecar file rather than being baked into
-# the source — keeps us out of the repr()/escaping business for arbitrary values.
-WRAPPER_TEMPLATE = """
-import sys, json
-sys.path.insert(0, "{env_dir}")
-from env_source import setup
-from rootstock.worker import run_worker
-
-with open("{kwargs_path}") as f:
-    setup_kwargs = json.load(f)
-
-run_worker(
-    setup_fn=setup,
-    checkpoint="{checkpoint}",
-    device="{device}",
-    socket_path="{socket_path}",
-    setup_kwargs=setup_kwargs,
-)
-"""
-
-
-class EnvironmentManager:
+def get_env_python(root: Path | str, env_name: str) -> Path:
     """
-    Manages pre-built rootstock environments and worker spawning.
+    Get path to Python executable for a pre-built environment.
 
-    Environments are pre-built virtual environments located in
-    {root}/envs/{env_name}/. The environment source file is copied into
-    the venv as env_source.py during build.
+    Args:
+        root: Install root directory (envs, environments, manifest).
+        env_name: Name of the environment (e.g., "mace_env").
+
+    Returns:
+        Path to the environment's Python executable.
+
+    Raises:
+        RuntimeError: If the environment is not built.
     """
+    root = Path(root)
+    env_python = root / "envs" / env_name / "bin" / "python"
 
-    def __init__(self, root: Path | str, cache_root: Path | str | None = None):
-        """
-        Initialize the environment manager.
+    if not env_python.exists():
+        envs_dir = root / "envs"
+        if envs_dir.exists():
+            available = [p.name for p in envs_dir.iterdir() if p.is_dir()]
+        else:
+            available = []
 
-        Args:
-            root: Install root directory (envs, environments, manifest).
-            cache_root: Optional separate root for the model-weight cache and
-                        redirected HOME. Defaults to ``root``.
-        """
-        self.root = Path(root)
-        self.cache_root = Path(cache_root) if cache_root is not None else None
-        self._temp_files: list[Path] = []
-
-    def get_env_python(self, env_name: str) -> Path:
-        """
-        Get path to Python executable for a pre-built environment.
-
-        Args:
-            env_name: Name of the environment (e.g., "mace_env").
-
-        Returns:
-            Path to the environment's Python executable.
-
-        Raises:
-            RuntimeError: If the environment is not built.
-        """
-        env_python = self.root / "envs" / env_name / "bin" / "python"
-
-        if not env_python.exists():
-            envs_dir = self.root / "envs"
-            if envs_dir.exists():
-                available = [p.name for p in envs_dir.iterdir() if p.is_dir()]
-            else:
-                available = []
-
-            raise RuntimeError(
-                f"Environment '{env_name}' not built. "
-                f"Run: rootstock install {env_name} --root {self.root}\n"
-                f"Available environments: {available}"
-            )
-
-        return env_python
-
-    def generate_wrapper(
-        self,
-        env_name: str,
-        checkpoint: str,
-        device: str,
-        socket_path: str,
-        setup_kwargs: dict | None = None,
-    ) -> Path:
-        """
-        Generate a wrapper script for the given environment.
-
-        Args:
-            env_name: Name of the pre-built environment
-            checkpoint: Canonical checkpoint id to pass to setup()
-            device: Device string to pass to setup()
-            socket_path: Unix socket path for IPC
-            setup_kwargs: Extra keyword arguments forwarded to setup() via JSON sidecar
-
-        Returns:
-            Path to the generated wrapper script (temp file).
-        """
-        env_dir = self.root / "envs" / env_name
-
-        # Write setup_kwargs to a JSON sidecar that the wrapper reads at startup.
-        kwargs_fd, kwargs_path = tempfile.mkstemp(suffix=".json", prefix="rootstock_kwargs_")
-        with open(kwargs_fd, "w") as f:
-            json.dump(setup_kwargs or {}, f)
-        kwargs_path = Path(kwargs_path)
-        self._temp_files.append(kwargs_path)
-
-        # Generate wrapper content
-        wrapper_content = WRAPPER_TEMPLATE.format(
-            env_dir=str(env_dir),
-            checkpoint=checkpoint,
-            device=device,
-            socket_path=socket_path,
-            kwargs_path=str(kwargs_path),
+        raise RuntimeError(
+            f"Environment '{env_name}' not built. "
+            f"Run: rootstock install {env_name} --root {root}\n"
+            f"Available environments: {available}"
         )
 
-        # Write to temp file
-        fd, tmp_path = tempfile.mkstemp(suffix=".py", prefix="rootstock_wrapper_")
-        with open(fd, "w") as f:
-            f.write(wrapper_content)
-
-        tmp_path = Path(tmp_path)
-        self._temp_files.append(tmp_path)
-
-        return tmp_path
-
-    def get_spawn_command(self, env_name: str, wrapper_path: Path) -> list[str]:
-        """
-        Get the command to spawn a worker using pre-built environment.
-
-        Args:
-            env_name: Name of the pre-built environment.
-            wrapper_path: Path to the generated wrapper script.
-
-        Returns:
-            Command list for subprocess.Popen, e.g.:
-            ["/vol/rootstock/envs/mace_env/bin/python", "/tmp/wrapper.py"]
-        """
-        env_python = self.get_env_python(env_name)
-        return [str(env_python), str(wrapper_path)]
-
-    def get_environment_variables(self) -> dict[str, str]:
-        """
-        Get environment variables to set for the worker process.
-
-        Returns:
-            Dict of environment variables for model caching.
-        """
-        env = os.environ.copy()
-        env.update(get_model_cache_env(self.root, self.cache_root))
-        return env
-
-    def cleanup(self):
-        """Clean up temporary wrapper files."""
-        for path in self._temp_files:
-            try:
-                path.unlink(missing_ok=True)
-            except Exception:
-                pass
-        self._temp_files.clear()
-
-    def __del__(self):
-        self.cleanup()
+    return env_python
 
 
 def check_uv_available() -> bool:

--- a/rootstock/operations.py
+++ b/rootstock/operations.py
@@ -31,7 +31,7 @@ from pathlib import Path
 from .client import RootstockClient
 from .clusters import get_cluster_for_root
 from .config import load_config
-from .environment import find_env_for_checkpoint, get_model_cache_env, parse_checkpoints_dict
+from .environment import find_env_for_checkpoint, parse_checkpoints_dict
 from .exceptions import RootstockError
 from .layout import resolve_cache_root
 from .manifest import (
@@ -51,6 +51,7 @@ from .pep723 import (
     parse_pep723_metadata,
     validate_environment_file,
 )
+from .spawn import DOWNLOAD_WRAPPER, spawn_in_env
 from .verify import verify_checkpoint
 
 ROOTSTOCK_GITHUB_URL = "https://github.com/Garden-AI/rootstock.git"
@@ -843,43 +844,23 @@ def _run_download(
     """Run ``setup(checkpoint, "cpu", **setup_kwargs)`` to trigger the cache-aware
     download path. Returns ``(ok, error)``."""
     env_dir = root / "envs" / env_name
-    env_python = env_dir / "bin" / "python"
-    if not env_python.exists():
+    if not (env_dir / "bin" / "python").exists():
         return False, f"environment not built at {env_dir}"
 
-    fd, kwargs_path = tempfile.mkstemp(suffix=".json", prefix="rootstock_add_kwargs_")
-    try:
-        with open(fd, "w") as f:
-            json.dump(setup_kwargs, f)
-
-        script = (
-            "import sys, json\n"
-            f'sys.path.insert(0, "{env_dir}")\n'
-            "from env_source import setup\n"
-            f'with open("{kwargs_path}") as _f: kwargs = json.load(_f)\n'
-            f'setup({checkpoint!r}, "cpu", **kwargs)\n'
-        )
-
-        env = {**os.environ, **get_model_cache_env(root, cache_root)}
-        # Run from env_dir so the implicit "" entry that `python -c` puts on
-        # sys.path resolves to the env directory (which holds only env_source.py
-        # and the venv internals) rather than the caller's CWD. Without this, a
-        # config whose top-level import name matches a file in the caller's CWD
-        # — e.g. running from environments/ where mace.py lives while adding a
-        # checkpoint whose setup() does `import mace` — shadows the installed
-        # package and fails with "'mace' is not a package".
+    with spawn_in_env(
+        root,
+        env_name,
+        DOWNLOAD_WRAPPER,
+        {"checkpoint": checkpoint, "device": "cpu", "setup_kwargs": setup_kwargs},
+        cache_root=cache_root,
+    ) as spec:
         result = subprocess.run(
-            [str(env_python), "-c", script],
-            env=env,
-            cwd=str(env_dir),
+            spec.cmd,
+            env=spec.env,
+            cwd=spec.cwd,
             capture_output=True,
             text=True,
         )
-    finally:
-        try:
-            Path(kwargs_path).unlink()
-        except OSError:
-            pass
 
     if result.returncode != 0:
         err = result.stderr.strip().splitlines()

--- a/rootstock/server.py
+++ b/rootstock/server.py
@@ -5,6 +5,7 @@ This runs in the main process and acts as an i-PI server,
 sending atomic positions and receiving forces from a worker process.
 """
 
+import contextlib
 import json
 import logging
 import os
@@ -151,9 +152,9 @@ class RootstockServer:
         self._init_numbers: list[int] | None = None
         self._init_pbc: list[bool] | None = None
 
-        # Environment manager
-        self._env_manager = None
-        self._wrapper_path: Path | None = None
+        # Holds the spawn_in_env context (staged wrapper + sidecar) open for
+        # the life of the worker process; stop() closes it.
+        self._spawn_stack: contextlib.ExitStack | None = None
 
     def start(self):
         """Start the server and launch the worker process."""
@@ -181,25 +182,25 @@ class RootstockServer:
 
     def _start_worker(self):
         """Start worker using pre-built environment."""
-        from .environment import EnvironmentManager
+        from .spawn import WORKER_WRAPPER, spawn_in_env
 
-        # Create environment manager
-        self._env_manager = EnvironmentManager(root=self.root, cache_root=self.cache_root)
-
-        # Generate wrapper script
-        self._wrapper_path = self._env_manager.generate_wrapper(
-            env_name=self.env_name,
-            checkpoint=self.checkpoint,
-            device=self.device,
-            socket_path=self.socket_path,
-            setup_kwargs=self.setup_kwargs,
+        self._spawn_stack = contextlib.ExitStack()
+        spec = self._spawn_stack.enter_context(
+            spawn_in_env(
+                self.root,
+                self.env_name,
+                WORKER_WRAPPER,
+                {
+                    "checkpoint": self.checkpoint,
+                    "device": self.device,
+                    "socket_path": self.socket_path,
+                    "setup_kwargs": self.setup_kwargs,
+                },
+                cache_root=self.cache_root,
+            )
         )
 
-        # Get spawn command and environment
-        cmd = self._env_manager.get_spawn_command(self.env_name, self._wrapper_path)
-        env = self._env_manager.get_environment_variables()
-
-        logger.debug("Spawning worker: %s", " ".join(cmd))
+        logger.debug("Spawning worker: %s", " ".join(spec.cmd))
 
         # Redirect worker output to temp files rather than pipes. The worker
         # loads the model in setup() *before* connecting to the socket; a noisy
@@ -212,8 +213,9 @@ class RootstockServer:
         self._stderr_file = tempfile.TemporaryFile()
 
         self._process = subprocess.Popen(
-            cmd,
-            env=env,
+            spec.cmd,
+            env=spec.env,
+            cwd=spec.cwd,
             stdout=self._stdout_file,
             stderr=self._stderr_file,
         )
@@ -405,18 +407,10 @@ class RootstockServer:
             self._socket_dir = None
             self.socket_path = None
 
-        # Clean up wrapper script
-        if self._wrapper_path is not None:
-            try:
-                self._wrapper_path.unlink(missing_ok=True)
-            except Exception:
-                pass
-            self._wrapper_path = None
-
-        # Clean up environment manager
-        if self._env_manager is not None:
-            self._env_manager.cleanup()
-            self._env_manager = None
+        # Remove the staged wrapper + sidecar (the worker is gone by now)
+        if self._spawn_stack is not None:
+            self._spawn_stack.close()
+            self._spawn_stack = None
 
         self._connected = False
         self._protocol = None

--- a/rootstock/spawn.py
+++ b/rootstock/spawn.py
@@ -1,0 +1,123 @@
+"""
+Run code inside a pre-built environment.
+
+One mechanism serves every "execute in an env" need: the worker spawned by
+``RootstockServer``, the standalone worker started by ``rootstock serve``,
+and the checkpoint download run by ``rootstock add``.
+
+The wrapper sources below are static. Every runtime value — checkpoint,
+device, socket path, setup kwargs, even the env directory — travels through
+a JSON sidecar passed as ``argv[1]``, so no value is ever interpolated into
+Python source and there is no repr()/escaping business for arbitrary values.
+
+``spawn_in_env`` is a context manager: it stages the wrapper and sidecar in
+a private temp directory and yields the command to run. The caller executes
+it however it needs (``subprocess.run``, ``Popen``) but must keep the
+context open for the life of the process — the worker reads both files at
+startup, and the exit path removes the directory. Cleanup is exception-safe;
+a SIGKILL still leaks the directory into TMPDIR, which is at least
+node-local and auto-cleaned rather than shared.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+from .environment import get_env_python, get_model_cache_env
+
+WORKER_WRAPPER = """\
+import json, sys
+
+with open(sys.argv[1]) as f:
+    spec = json.load(f)
+
+sys.path.insert(0, spec["env_dir"])
+from env_source import setup
+from rootstock.worker import run_worker
+
+run_worker(
+    setup_fn=setup,
+    checkpoint=spec["checkpoint"],
+    device=spec["device"],
+    socket_path=spec["socket_path"],
+    setup_kwargs=spec["setup_kwargs"],
+)
+"""
+
+DOWNLOAD_WRAPPER = """\
+import json, sys
+
+with open(sys.argv[1]) as f:
+    spec = json.load(f)
+
+sys.path.insert(0, spec["env_dir"])
+from env_source import setup
+
+setup(spec["checkpoint"], spec["device"], **spec["setup_kwargs"])
+"""
+
+
+@dataclass
+class SpawnCommand:
+    """How to execute the staged wrapper: argv, environment, and cwd."""
+
+    cmd: list[str]
+    env: dict[str, str]
+    cwd: str
+
+
+@contextmanager
+def spawn_in_env(
+    root: Path,
+    env_name: str,
+    wrapper_source: str,
+    payload: dict,
+    cache_root: Path | None = None,
+) -> Iterator[SpawnCommand]:
+    """
+    Stage ``wrapper_source`` + a JSON sidecar for ``payload`` and yield the
+    command that runs them with the env's Python.
+
+    Args:
+        root: Rootstock install root.
+        env_name: Name of the pre-built environment.
+        wrapper_source: One of the static wrapper sources in this module.
+        payload: JSON-serializable values the wrapper reads from the sidecar.
+            ``env_dir`` is filled in here; everything else is the caller's.
+        cache_root: Optional split cache root (see get_model_cache_env).
+
+    Raises:
+        RuntimeError: the environment is not built.
+    """
+    root = Path(root)
+    env_python = get_env_python(root, env_name)
+    env_dir = root / "envs" / env_name
+
+    env = os.environ.copy()
+    env.update(get_model_cache_env(root, cache_root))
+
+    tmp_dir = tempfile.mkdtemp(prefix="rootstock_spawn_")
+    try:
+        wrapper = Path(tmp_dir) / "wrapper.py"
+        wrapper.write_text(wrapper_source)
+        sidecar = Path(tmp_dir) / "spec.json"
+        sidecar.write_text(json.dumps({**payload, "env_dir": str(env_dir)}))
+
+        # cwd=env_dir keeps runtime relative-path resolution inside the env
+        # rather than the caller's CWD, where a file named after the model
+        # package (e.g. mace.py in environments/) would shadow the installed
+        # package on import.
+        yield SpawnCommand(
+            cmd=[str(env_python), str(wrapper), str(sidecar)],
+            env=env,
+            cwd=str(env_dir),
+        )
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)

--- a/tests/cache/test_cache_root.py
+++ b/tests/cache/test_cache_root.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 import pytest
@@ -16,11 +15,8 @@ from rootstock.clusters import (
     get_root_for_cluster,
 )
 from rootstock.commands.common import resolve_cache_root
-from rootstock.environment import (
-    EnvironmentManager,
-    get_model_cache_env,
-    get_user_cache_dir,
-)
+from rootstock.environment import get_model_cache_env, get_user_cache_dir
+from rootstock.spawn import WORKER_WRAPPER, spawn_in_env
 
 # Runtime write-back caches that must NEVER point into the shared roots —
 # non-maintainers can only read there.
@@ -208,25 +204,26 @@ def test_resolve_cache_root_for_unknown_root_returns_root():
     assert resolve_cache_root(custom) == custom
 
 
-# ---------- EnvironmentManager wiring -------------------------------------
+# ---------- spawn_in_env wiring -------------------------------------------
 
 
-def test_environment_manager_passes_cache_root_through(tmp_path: Path):
-    (tmp_path / "envs" / "fake_env").mkdir(parents=True)
+def _make_fake_env(root: Path, name: str = "fake_env") -> None:
+    (root / "envs" / name / "bin").mkdir(parents=True)
+    (root / "envs" / name / "bin" / "python").touch()
+
+
+def test_spawn_in_env_passes_cache_root_through(tmp_path: Path):
+    _make_fake_env(tmp_path)
     cache_dir = tmp_path / "alt_cache"
-    mgr = EnvironmentManager(root=tmp_path, cache_root=cache_dir)
-    env_vars = mgr.get_environment_variables()
-    assert env_vars["XDG_CACHE_HOME"] == str(cache_dir / "cache")
-    assert env_vars["HOME"] == str(cache_dir / "home")
-    mgr.cleanup()
+    with spawn_in_env(tmp_path, "fake_env", WORKER_WRAPPER, {}, cache_root=cache_dir) as spec:
+        assert spec.env["XDG_CACHE_HOME"] == str(cache_dir / "cache")
+        assert spec.env["HOME"] == str(cache_dir / "home")
 
 
-def test_environment_manager_default_cache_root_uses_install_root(tmp_path: Path):
-    (tmp_path / "envs" / "fake_env").mkdir(parents=True)
-    mgr = EnvironmentManager(root=tmp_path)
-    env_vars = mgr.get_environment_variables()
-    assert env_vars["XDG_CACHE_HOME"] == str(tmp_path / "cache")
-    mgr.cleanup()
+def test_spawn_in_env_default_cache_root_uses_install_root(tmp_path: Path):
+    _make_fake_env(tmp_path)
+    with spawn_in_env(tmp_path, "fake_env", WORKER_WRAPPER, {}) as spec:
+        assert spec.env["XDG_CACHE_HOME"] == str(tmp_path / "cache")
 
 
 # ---------- RootstockCalculator wiring ------------------------------------
@@ -312,23 +309,15 @@ def test_calculator_with_root_and_explicit_cache_root(tmp_path: Path):
     assert calc.cache_root == cache
 
 
-# ---------- End-to-end: cache_root reaches the worker wrapper -------------
+# ---------- End-to-end: cache_root reaches the worker spawn ---------------
 
 
-def _extract_kwargs_path(wrapper_text: str) -> Path:
-    match = re.search(r'open\("([^"]+\.json)"\)', wrapper_text)
-    assert match
-    return Path(match.group(1))
-
-
-def test_environment_manager_get_environment_variables_reflects_split(tmp_path: Path):
+def test_spawn_in_env_env_vars_reflect_split(tmp_path: Path):
     """The env vars handed to the worker subprocess use the split cache_root."""
-    (tmp_path / "envs" / "fake_env").mkdir(parents=True)
+    _make_fake_env(tmp_path)
     cache_dir = tmp_path / "alt_cache"
-    mgr = EnvironmentManager(root=tmp_path, cache_root=cache_dir)
 
-    env_vars = mgr.get_environment_variables()
-    # All four cache-related vars must point under cache_dir, not tmp_path.
-    for key in ("HOME", "XDG_CACHE_HOME", "HF_HOME", "HF_HUB_CACHE"):
-        assert env_vars[key].startswith(str(cache_dir)), f"{key} = {env_vars[key]}"
-    mgr.cleanup()
+    with spawn_in_env(tmp_path, "fake_env", WORKER_WRAPPER, {}, cache_root=cache_dir) as spec:
+        # All four cache-related vars must point under cache_dir, not tmp_path.
+        for key in ("HOME", "XDG_CACHE_HOME", "HF_HOME", "HF_HUB_CACHE"):
+            assert spec.env[key].startswith(str(cache_dir)), f"{key} = {spec.env[key]}"

--- a/tests/server/test_pipe_deadlock.py
+++ b/tests/server/test_pipe_deadlock.py
@@ -86,7 +86,7 @@ def chatty_env_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     still ``import rootstock`` / ``ase`` — CPython resolves a symlinked
     interpreter's prefix from the *symlink* location, which has no
     site-packages, so the import would otherwise fail. The worker inherits this
-    env via ``os.environ.copy()`` in EnvironmentManager.get_environment_variables.
+    env via ``os.environ.copy()`` in spawn_in_env.
     """
     import ase
 

--- a/tests/worker/test_wrapper_kwargs.py
+++ b/tests/worker/test_wrapper_kwargs.py
@@ -1,42 +1,51 @@
-"""Tests for setup_kwargs plumbing through the wrapper script."""
+"""Tests for value plumbing through the spawn sidecar."""
 
 from __future__ import annotations
 
 import json
-import re
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
 
-from rootstock.environment import EnvironmentManager
-
-
-def _extract_kwargs_path(wrapper_text: str) -> Path:
-    match = re.search(r'open\("([^"]+)"\)', wrapper_text)
-    assert match, f"could not find kwargs_path in wrapper: {wrapper_text!r}"
-    return Path(match.group(1))
+from rootstock.spawn import WORKER_WRAPPER, spawn_in_env
 
 
 @pytest.fixture
-def env_manager(tmp_path: Path) -> EnvironmentManager:
-    # Pretend an env is "built" — generate_wrapper doesn't actually exec it.
-    (tmp_path / "envs" / "fake_env").mkdir(parents=True)
-    mgr = EnvironmentManager(root=tmp_path)
-    yield mgr
-    mgr.cleanup()
+def fake_root(tmp_path: Path) -> Path:
+    # Pretend an env is "built" — spawn_in_env stages files, it doesn't exec.
+    (tmp_path / "envs" / "fake_env" / "bin").mkdir(parents=True)
+    (tmp_path / "envs" / "fake_env" / "bin" / "python").touch()
+    return tmp_path
 
 
-def test_wrapper_writes_empty_kwargs_sidecar_when_none(env_manager):
-    wrapper = env_manager.generate_wrapper(
-        env_name="fake_env",
-        checkpoint="m",
-        device="cpu",
-        socket_path="/tmp/sock",
-    )
-    kwargs_path = _extract_kwargs_path(wrapper.read_text())
-    assert json.loads(kwargs_path.read_text()) == {}
+def _payload(**setup_kwargs) -> dict:
+    return {
+        "checkpoint": "m",
+        "device": "cpu",
+        "socket_path": "/tmp/sock",
+        "setup_kwargs": setup_kwargs,
+    }
+
+
+def test_wrapper_source_is_static(fake_root):
+    """No runtime value is ever interpolated into Python source — everything
+    travels through the sidecar."""
+    with spawn_in_env(fake_root, "fake_env", WORKER_WRAPPER, _payload(task="omol")) as spec:
+        env_python, wrapper, sidecar = spec.cmd
+        assert Path(wrapper).read_text() == WORKER_WRAPPER
+        spec_data = json.loads(Path(sidecar).read_text())
+        assert spec_data["checkpoint"] == "m"
+        assert spec_data["device"] == "cpu"
+        assert spec_data["socket_path"] == "/tmp/sock"
+        assert spec_data["env_dir"] == str(fake_root / "envs" / "fake_env")
+
+
+def test_empty_setup_kwargs_round_trip(fake_root):
+    with spawn_in_env(fake_root, "fake_env", WORKER_WRAPPER, _payload()) as spec:
+        spec_data = json.loads(Path(spec.cmd[2]).read_text())
+        assert spec_data["setup_kwargs"] == {}
 
 
 @pytest.mark.parametrize(
@@ -49,33 +58,32 @@ def test_wrapper_writes_empty_kwargs_sidecar_when_none(env_manager):
         {"unicode": "ωμα", "quote": 'has "quotes" inside'},
     ],
 )
-def test_wrapper_round_trips_kwargs_through_json_sidecar(env_manager, kwargs):
-    wrapper = env_manager.generate_wrapper(
-        env_name="fake_env",
-        checkpoint="m",
-        device="cpu",
-        socket_path="/tmp/sock",
-        setup_kwargs=kwargs,
-    )
-    kwargs_path = _extract_kwargs_path(wrapper.read_text())
-    assert json.loads(kwargs_path.read_text()) == kwargs
+def test_setup_kwargs_round_trip_through_json_sidecar(fake_root, kwargs):
+    with spawn_in_env(fake_root, "fake_env", WORKER_WRAPPER, _payload(**kwargs)) as spec:
+        spec_data = json.loads(Path(spec.cmd[2]).read_text())
+        assert spec_data["setup_kwargs"] == kwargs
 
 
-def test_wrapper_and_kwargs_files_cleaned_up(env_manager):
-    wrapper = env_manager.generate_wrapper(
-        env_name="fake_env",
-        checkpoint="m",
-        device="cpu",
-        socket_path="/tmp/sock",
-        setup_kwargs={"task": "omol"},
-    )
-    kwargs_path = _extract_kwargs_path(wrapper.read_text())
-    assert wrapper.exists()
-    assert kwargs_path.exists()
+def test_staged_files_removed_on_exit(fake_root):
+    with spawn_in_env(fake_root, "fake_env", WORKER_WRAPPER, _payload()) as spec:
+        wrapper, sidecar = Path(spec.cmd[1]), Path(spec.cmd[2])
+        assert wrapper.exists()
+        assert sidecar.exists()
+    assert not wrapper.parent.exists()
 
-    env_manager.cleanup()
-    assert not wrapper.exists()
-    assert not kwargs_path.exists()
+
+def test_staged_files_removed_on_exception(fake_root):
+    with pytest.raises(RuntimeError, match="boom"):
+        with spawn_in_env(fake_root, "fake_env", WORKER_WRAPPER, _payload()) as spec:
+            wrapper = Path(spec.cmd[1])
+            raise RuntimeError("boom")
+    assert not wrapper.parent.exists()
+
+
+def test_unbuilt_env_raises_before_staging(fake_root):
+    with pytest.raises(RuntimeError, match="not built"):
+        with spawn_in_env(fake_root, "missing_env", WORKER_WRAPPER, _payload()):
+            pass
 
 
 def test_run_worker_forwards_setup_kwargs(tmp_path: Path):


### PR DESCRIPTION
Closes #126.

Three parallel "run code in an env" mechanisms — the server's `WRAPPER_TEMPLATE` str.format wrapper, `operations._run_download`'s inline `python -c` script, and `serve.py`'s reuse of the wrapper — collapse into one context manager, `spawn_in_env`, in a new `rootstock/spawn.py`.

- **Static wrapper sources**: every runtime value (checkpoint, device, socket path, setup kwargs, env dir) travels through a JSON sidecar passed as `argv[1]` — nothing is interpolated into Python source anymore, so there's no repr()/escaping business.
- **One private tempdir, exception-safe cleanup**: wrapper + sidecar are staged together and removed when the context exits, replacing the `EnvironmentManager._temp_files`/`__del__` cleanup that leaked sidecars. (SIGKILL still leaks into TMPDIR — node-local and auto-cleaned, rather than shared state.)
- **cwd shadowing fix everywhere**: the `cwd=env_dir` fix that only `_run_download` had (a file like `environments/mace.py` in the caller's CWD shadowing the installed package) now applies to all three spawn paths.
- **EnvironmentManager deleted**: nothing was left of it — `get_env_python` survives as a module function, and the pruned-API `AttributeError` pointer now names `spawn_in_env` as the replacement. `RootstockServer` holds the spawn context open across `start()`/`stop()` via an `ExitStack`.

Verified beyond unit tests by `tests/server/test_pipe_deadlock.py`, which spawns a real worker through the new path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)