### PR TITLE
CLI tidies: benchmark forwarding via parse_known_args, direct manifest dispatch

### DIFF
--- a/rootstock/cli.py
+++ b/rootstock/cli.py
@@ -59,7 +59,9 @@ from .commands import (
     cmd_init,
     cmd_install,
     cmd_list,
-    cmd_manifest,
+    cmd_manifest_init,
+    cmd_manifest_push,
+    cmd_manifest_show,
     cmd_new_env,
     cmd_resolve,
     cmd_serve,
@@ -73,13 +75,6 @@ from .manifest import ManifestError
 
 
 def main():
-    # `rootstock benchmark ...` forwards everything after the subcommand to the
-    # benchmark's own argument parser. Intercept it before the main parser runs,
-    # since argparse can't cleanly pass arbitrary flags through a subparser.
-    argv = sys.argv[1:]
-    if argv and argv[0] == "benchmark":
-        sys.exit(cmd_benchmark(argv[1:]))
-
     parser = argparse.ArgumentParser(
         prog="rootstock",
         description="Rootstock MLIP environment manager",
@@ -422,10 +417,11 @@ def main():
     )
     serve_parser.set_defaults(func=cmd_serve)
 
-    # benchmark command. Registered only so it appears in `rootstock --help`;
-    # the actual dispatch happens in the early intercept at the top of main(),
-    # which forwards all following args to the benchmark's own parser. (argparse
-    # REMAINDER can't reliably capture leading options, so we bypass it.)
+    # benchmark command. Everything after the subcommand is forwarded to the
+    # benchmark's own parser via the parse_known_args leftovers at the bottom
+    # of main() — argparse.REMAINDER cannot capture leading options (--list as
+    # the first forwarded arg errors), so the subparser declares no arguments
+    # and add_help=False lets --help through to the benchmark parser.
     subparsers.add_parser(
         "benchmark",
         help="Measure i-PI IPC overhead vs. in-env direct calls",
@@ -459,7 +455,7 @@ def main():
         help=f"Root directory (default: ${ROOTSTOCK_ROOT_ENV})",
     )
     manifest_show_parser.add_argument("--json", action="store_true", help="Output as JSON")
-    manifest_show_parser.set_defaults(func=cmd_manifest)
+    manifest_show_parser.set_defaults(func=cmd_manifest_show)
 
     # manifest push
     manifest_push_parser = manifest_subparsers.add_parser(
@@ -471,7 +467,7 @@ def main():
         default=os.environ.get(ROOTSTOCK_ROOT_ENV),
         help=f"Root directory (default: ${ROOTSTOCK_ROOT_ENV})",
     )
-    manifest_push_parser.set_defaults(func=cmd_manifest)
+    manifest_push_parser.set_defaults(func=cmd_manifest_push)
 
     # manifest init
     manifest_init_parser = manifest_subparsers.add_parser(
@@ -498,9 +494,16 @@ def main():
         action="store_true",
         help="Don't push manifest to backend (useful during development)",
     )
-    manifest_init_parser.set_defaults(func=cmd_manifest)
+    manifest_init_parser.set_defaults(func=cmd_manifest_init)
 
-    args = parser.parse_args()
+    # parse_known_args instead of parse_args so `rootstock benchmark ...` can
+    # forward arbitrary flags to the benchmark's own parser. Every other
+    # command keeps strict parsing via the explicit error below.
+    args, extra = parser.parse_known_args()
+    if args.command == "benchmark":
+        sys.exit(cmd_benchmark(extra))
+    if extra:
+        parser.error(f"unrecognized arguments: {' '.join(extra)}")
     try:
         sys.exit(args.func(args))
     except ManifestError as exc:

--- a/rootstock/commands/__init__.py
+++ b/rootstock/commands/__init__.py
@@ -6,7 +6,7 @@ from .check_perms import cmd_check_perms
 from .create import cmd_new_env
 from .init import cmd_init
 from .install import cmd_install
-from .manifest import cmd_manifest
+from .manifest import cmd_manifest_init, cmd_manifest_push, cmd_manifest_show
 from .resolve import cmd_resolve
 from .serve import cmd_serve
 from .setup_perms import cmd_setup_perms
@@ -20,7 +20,9 @@ __all__ = [
     "cmd_init",
     "cmd_install",
     "cmd_list",
-    "cmd_manifest",
+    "cmd_manifest_init",
+    "cmd_manifest_push",
+    "cmd_manifest_show",
     "cmd_new_env",
     "cmd_resolve",
     "cmd_serve",

--- a/rootstock/commands/manifest.py
+++ b/rootstock/commands/manifest.py
@@ -12,17 +12,6 @@ from ..operations import refresh_manifest_environments
 from .common import get_root_or_exit
 
 
-def cmd_manifest(args) -> int:
-    """Handle manifest subcommands."""
-    if args.manifest_action == "show":
-        return cmd_manifest_show(args)
-    elif args.manifest_action == "push":
-        return cmd_manifest_push(args)
-    elif args.manifest_action == "init":
-        return cmd_manifest_init(args)
-    return 0
-
-
 def cmd_manifest_show(args) -> int:
     """Show current manifest."""
     root = get_root_or_exit(args)

--- a/tests/cli/test_dispatch.py
+++ b/tests/cli/test_dispatch.py
@@ -1,0 +1,53 @@
+"""Tests for main()'s argument dispatch: benchmark forwarding and strictness."""
+
+from __future__ import annotations
+
+import pytest
+
+from rootstock import cli
+
+
+def _run_main(monkeypatch, argv: list[str]) -> int:
+    monkeypatch.setattr("sys.argv", ["rootstock", *argv])
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main()
+    return excinfo.value.code
+
+
+def test_benchmark_forwards_leading_options(monkeypatch):
+    """argparse.REMAINDER chokes on a leading option like --list; the
+    parse_known_args forwarding must pass it through untouched."""
+    seen = {}
+
+    def fake_benchmark(argv):
+        seen["argv"] = argv
+        return 0
+
+    monkeypatch.setattr(cli, "cmd_benchmark", fake_benchmark)
+    assert _run_main(monkeypatch, ["benchmark", "--list"]) == 0
+    assert seen["argv"] == ["--list"]
+
+
+def test_benchmark_forwards_multiple_args_in_order(monkeypatch):
+    seen = {}
+
+    def fake_benchmark(argv):
+        seen["argv"] = argv
+        return 0
+
+    monkeypatch.setattr(cli, "cmd_benchmark", fake_benchmark)
+    _run_main(monkeypatch, ["benchmark", "--devices", "cuda", "cpu", "--calls", "5"])
+    assert seen["argv"] == ["--devices", "cuda", "cpu", "--calls", "5"]
+
+
+def test_non_benchmark_commands_reject_unknown_args(monkeypatch):
+    """Forwarding leftovers to benchmark must not loosen any other command."""
+    assert _run_main(monkeypatch, ["list", "--bogus"]) == 2
+
+
+def test_manifest_subcommands_dispatch_directly(monkeypatch):
+    """Each manifest subparser binds its own func — no re-dispatch layer."""
+    called = []
+    monkeypatch.setattr(cli, "cmd_manifest_show", lambda args: called.append("show") or 0)
+    assert _run_main(monkeypatch, ["manifest", "show", "--root", "/nowhere"]) == 0
+    assert called == ["show"]


### PR DESCRIPTION
Closes #132.

- **Benchmark forwarding**: the pre-parser `sys.argv` intercept and the dummy help-only subparser become ordinary parse flow — `parse_known_args` collects everything after `benchmark` as leftovers and forwards them to the benchmark's own parser. `argparse.REMAINDER` genuinely can't do this (a leading option like `--list` errors before REMAINDER captures it — verified empirically; the old comment was right). All other commands keep strict parsing via an explicit unrecognized-arguments error, pinned by a new test.
- **Manifest dispatch**: `manifest show/push/init` each bind their own `func` via `set_defaults`, deleting the `cmd_manifest` re-dispatch layer.
- **umask**: stays in `cmd_add`/`cmd_install`, per the option the audit note sanctioned — post-#121 the operations layer documents that callers own process-wide concerns, and `test_add_overrides_restrictive_umask` pins `cmd_add` setting it. Moving it to `main()` would change that contract for no benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)