### PR TITLE
Lock manifest read-modify-write cycles

### DIFF
--- a/rootstock/commands/init.py
+++ b/rootstock/commands/init.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from ..clusters import CLUSTER_REGISTRY, get_cluster_for_root
 from ..config import DEFAULT_CONFIG_FILE, load_config, save_config
 from ..layout import write_layout_marker
-from ..manifest import create_manifest, save_manifest
+from ..manifest import create_manifest, manifest_lock, save_manifest
 from ..operations import refresh_manifest_environments
 from .common import ROOTSTOCK_ROOT_ENV
 
@@ -157,10 +157,11 @@ def cmd_init(args) -> int:
     # Initialize manifest if we have a cluster
     if cluster and not args.skip_manifest:
         print("\nInitializing manifest...")
-        manifest = create_manifest(root, cluster, config)
-        # Scan for existing built environments
-        manifest = refresh_manifest_environments(manifest, root)
-        save_manifest(manifest, root)
+        with manifest_lock(root):
+            manifest = create_manifest(root, cluster, config)
+            # Scan for existing built environments
+            manifest = refresh_manifest_environments(manifest, root)
+            save_manifest(manifest, root)
         print(f"  Created: {root}/manifest.json")
         if manifest.environments:
             print(f"  Found {len(manifest.environments)} existing environment(s)")

--- a/rootstock/commands/manifest.py
+++ b/rootstock/commands/manifest.py
@@ -7,7 +7,7 @@ import sys
 
 from ..client import RootstockClient
 from ..config import load_config
-from ..manifest import create_manifest, load_manifest, save_manifest
+from ..manifest import create_manifest, load_manifest, manifest_lock, save_manifest
 from ..operations import refresh_manifest_environments
 from .common import get_root_or_exit
 
@@ -110,9 +110,10 @@ def cmd_manifest_init(args) -> int:
         )
 
     # Create and save manifest
-    manifest = create_manifest(root, cluster, config)
-    manifest = refresh_manifest_environments(manifest, root)
-    save_manifest(manifest, root)
+    with manifest_lock(root):
+        manifest = create_manifest(root, cluster, config)
+        manifest = refresh_manifest_environments(manifest, root)
+        save_manifest(manifest, root)
 
     print(f"Manifest initialized: {root}/manifest.json")
     print(f"  Cluster: {cluster}")

--- a/rootstock/commands/smoke_test.py
+++ b/rootstock/commands/smoke_test.py
@@ -12,6 +12,7 @@ from ..manifest import (
     EnvironmentInfo,
     is_verified,
     load_manifest,
+    manifest_lock,
     now_iso,
     save_manifest,
 )
@@ -69,6 +70,13 @@ def cmd_smoke_test(args) -> int:
     n_failed = 0
     total_start = time.monotonic()
 
+    # Verification runs are long (minutes per checkpoint) and must not hold
+    # the manifest lock. Record outcomes here and apply them to a *freshly
+    # loaded* manifest in one locked cycle afterwards — mutating the manifest
+    # loaded before the loop and saving it at the end would silently revert
+    # anything a co-maintainer wrote in between.
+    outcomes: list[tuple[str, str, bool, str | None]] = []
+
     for env_name, ckpt_name, env, ckpt in selected:
         start = time.monotonic()
         ok, err = verify_checkpoint(
@@ -80,7 +88,10 @@ def cmd_smoke_test(args) -> int:
             cache_root=cache_root,
         )
         elapsed = time.monotonic() - start
+        outcomes.append((env_name, ckpt_name, ok, err))
 
+        # Mirror the outcome onto the working copy so verified_current in the
+        # report reflects this run.
         if ok:
             ckpt.verified_at = now_iso()
             ckpt.verified_device = device
@@ -111,7 +122,23 @@ def cmd_smoke_test(args) -> int:
                 line += f"  {err}"
             print(line)
 
-    save_manifest(manifest, root)
+    with manifest_lock(root):
+        fresh = load_manifest(root)
+        if fresh is not None:
+            for env_name, ckpt_name, ok, err in outcomes:
+                env_record = fresh.environments.get(env_name)
+                ckpt_record = env_record.checkpoints.get(ckpt_name) if env_record else None
+                if ckpt_record is None:
+                    continue  # env/checkpoint removed while we were testing
+                if ok:
+                    ckpt_record.verified_at = now_iso()
+                    ckpt_record.verified_device = device
+                    ckpt_record.last_error = None
+                else:
+                    ckpt_record.verified_at = None
+                    ckpt_record.verified_device = None
+                    ckpt_record.last_error = f"smoke-test: {err}"
+            save_manifest(fresh, root)
     update_and_push_manifest(root, quiet=True, push=not no_push)
 
     total_elapsed = time.monotonic() - total_start

--- a/rootstock/manifest.py
+++ b/rootstock/manifest.py
@@ -15,9 +15,12 @@ import hashlib
 import json
 import os
 import shutil
+import socket
 import subprocess
 import sys
 import tempfile
+import time
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -27,12 +30,26 @@ from .exceptions import RootstockError
 
 SCHEMA_VERSION = 4
 
+# manifest_lock defaults. The lock is only held across a load → mutate → save
+# cycle (plus the env refresh, which shells out to `uv pip list` per env), so
+# holds are seconds, not minutes; the stale threshold is deliberately far
+# beyond any legitimate hold.
+LOCK_TIMEOUT = 120.0
+LOCK_STALE_AFTER = 600.0
+_LOCK_POLL_INTERVAL = 0.5
+
 
 class ManifestError(RootstockError, RuntimeError):
     """The manifest exists but cannot be used: corrupt JSON, missing required
     fields, or a schema this client has no path to. Deliberately NOT treated
     as "no manifest" — a silent fresh start would let the next save overwrite
     all fetch/verify history."""
+
+
+class ManifestLockTimeout(ManifestError):
+    """Could not acquire the manifest lock within the timeout. Subclasses
+    ManifestError so the CLI reports it as a clean diagnosis, not a
+    traceback."""
 
 
 def _migrate_v1_to_v2(data: dict) -> tuple[dict, str | None]:
@@ -414,6 +431,97 @@ def built_at_estimate(env_path: Path) -> str:
     """
     ts = env_path.stat().st_mtime
     return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+
+
+def _try_create_lock(lock_path: Path) -> bool:
+    """One atomic O_EXCL attempt; the lock file records who holds it."""
+    try:
+        fd = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    except FileExistsError:
+        return False
+    with os.fdopen(fd, "w") as f:
+        json.dump(
+            {"pid": os.getpid(), "host": socket.gethostname(), "created": now_iso()},
+            f,
+        )
+    return True
+
+
+def _describe_lock(lock_path: Path) -> str:
+    try:
+        holder = json.loads(lock_path.read_text())
+        return (
+            f"held by pid {holder.get('pid')} on {holder.get('host')} "
+            f"since {holder.get('created')}"
+        )
+    except (OSError, json.JSONDecodeError):
+        return "holder unknown (lock file unreadable)"
+
+
+@contextmanager
+def manifest_lock(
+    root: Path,
+    timeout: float = LOCK_TIMEOUT,
+    stale_after: float = LOCK_STALE_AFTER,
+):
+    """Hold ``{root}/manifest.json.lock`` for a read-modify-write cycle.
+
+    Every writer must load the manifest fresh *inside* this lock, mutate, and
+    save before releasing — holding a manifest object across the lock
+    boundary reintroduces the lost-update race this exists to prevent
+    (nightly smoke-test vs. a co-maintainer's add).
+
+    Deliberately NOT fcntl/flock: the manifest lives on the install root,
+    which can be a filesystem without working POSIX locks (Perlmutter CFS is
+    why the cache_root split exists at all). An O_EXCL create is atomic on
+    the filesystems we care about.
+
+    A lock older than ``stale_after`` (far beyond any legitimate hold) is
+    presumed abandoned by a killed process and broken: unlinked and
+    re-contested. The mtime comes from the fileserver's clock, so
+    ``stale_after`` is generous rather than tight.
+
+    Raises:
+        ManifestLockTimeout: not acquired within ``timeout`` seconds.
+    """
+    root = Path(root)
+    root.mkdir(parents=True, exist_ok=True)
+    lock_path = root / "manifest.json.lock"
+
+    deadline = time.monotonic() + timeout
+    while not _try_create_lock(lock_path):
+        try:
+            seen = lock_path.stat()
+        except FileNotFoundError:
+            continue  # released between attempts — retry immediately
+
+        if time.time() - seen.st_mtime > stale_after:
+            # Presumed abandoned. Re-stat before unlinking so we only break
+            # the lock we judged stale, not one freshly taken since (the
+            # unlink itself can still race another breaker — the loser of
+            # the subsequent O_EXCL just keeps waiting).
+            try:
+                if lock_path.stat().st_mtime == seen.st_mtime:
+                    lock_path.unlink()
+            except FileNotFoundError:
+                pass
+            continue
+
+        if time.monotonic() >= deadline:
+            raise ManifestLockTimeout(
+                f"could not lock {root / 'manifest.json'} after {timeout:.0f}s; "
+                f"lock file {lock_path} is {_describe_lock(lock_path)}. "
+                f"If that process is dead, remove the lock file and retry."
+            )
+        time.sleep(_LOCK_POLL_INTERVAL)
+
+    try:
+        yield
+    finally:
+        # If we exceeded stale_after ourselves, another process may have
+        # broken our lock and taken its own; this unlink would then release
+        # theirs early. Tolerated: stale_after is far above any real hold.
+        lock_path.unlink(missing_ok=True)
 
 
 def load_manifest(root: Path) -> Manifest | None:

--- a/rootstock/manifest.py
+++ b/rootstock/manifest.py
@@ -343,11 +343,13 @@ def get_installed_versions(
     def normalize(name: str) -> str:
         return name.lower().replace("-", "_").replace(".", "_")
 
-    filter_set = (
-        {normalize(p.split("==")[0].split(">")[0].split("<")[0].split("~")[0].split("[")[0].strip()) for p in only_packages}
-        if only_packages
-        else None
-    )
+    def base_name(spec: str) -> str:
+        # Strip version specifiers and extras: "torch>=2.0" / "mace[dev]" -> package name
+        for sep in ("==", ">", "<", "~", "["):
+            spec = spec.split(sep)[0]
+        return spec.strip()
+
+    filter_set = {normalize(base_name(p)) for p in only_packages} if only_packages else None
 
     packages_data = []
 

--- a/rootstock/operations.py
+++ b/rootstock/operations.py
@@ -25,6 +25,7 @@ import subprocess
 import sys
 import tempfile
 from collections.abc import Callable
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -42,6 +43,7 @@ from .manifest import (
     create_manifest,
     get_installed_versions,
     load_manifest,
+    manifest_lock,
     now_iso,
     save_manifest,
 )
@@ -232,35 +234,39 @@ def update_and_push_manifest(
     """
     config = load_config()
 
-    # Load existing manifest first
-    manifest = load_manifest(root)
+    # The whole load → refresh → save cycle runs under the manifest lock so a
+    # concurrent writer (nightly smoke-test vs. a co-maintainer's add) can't
+    # be silently overwritten. The push happens after release — no reason to
+    # hold the lock across a network call.
+    with manifest_lock(root):
+        manifest = load_manifest(root)
 
-    # Determine cluster: provided > existing manifest > detect from path
-    if cluster is None:
-        if manifest is not None:
-            cluster = manifest.cluster
-        else:
-            cluster = get_cluster_for_root(root)
+        # Determine cluster: provided > existing manifest > detect from path
+        if cluster is None:
+            if manifest is not None:
+                cluster = manifest.cluster
+            else:
+                cluster = get_cluster_for_root(root)
 
-    if cluster is None:
-        if not quiet:
-            print(
-                "Warning: Cannot update manifest - cluster not specified and "
-                "root doesn't match any known cluster. "
-                "Run 'rootstock manifest init --cluster <name>' first.",
-                file=sys.stderr,
-            )
-        return False
+        if cluster is None:
+            if not quiet:
+                print(
+                    "Warning: Cannot update manifest - cluster not specified and "
+                    "root doesn't match any known cluster. "
+                    "Run 'rootstock manifest init --cluster <name>' first.",
+                    file=sys.stderr,
+                )
+            return False
 
-    # Create manifest if it doesn't exist
-    if manifest is None:
-        manifest = create_manifest(root, cluster, config)
+        # Create manifest if it doesn't exist
+        if manifest is None:
+            manifest = create_manifest(root, cluster, config)
 
-    # Refresh environment info from current state
-    manifest = refresh_manifest_environments(manifest, root, built_env=built_env)
+        # Refresh environment info from current state
+        manifest = refresh_manifest_environments(manifest, root, built_env=built_env)
 
-    # Save locally
-    save_manifest(manifest, root)
+        # Save locally
+        save_manifest(manifest, root)
 
     # Skip push if explicitly disabled
     if not push:
@@ -870,19 +876,33 @@ def _run_download(
     return True, None
 
 
+@contextmanager
+def _manifest_transaction(root: Path, cluster_hint: str | None = None):
+    """Lock → load-fresh (or create) → yield → save-once → unlock.
+
+    The single sanctioned way to mutate the manifest. Long-running work
+    (downloads, verification subprocesses) must happen *outside* the
+    transaction; the body should only apply its results. On an exception in
+    the body nothing is saved.
+    """
+    with manifest_lock(root):
+        manifest = load_manifest(root)
+        if manifest is None:
+            config = load_config()
+            manifest = create_manifest(root, cluster_hint or "unknown", config)
+        yield manifest
+        save_manifest(manifest, root)
+
+
 def _ensure_manifest_entry(
+    manifest: Manifest,
     root: Path,
-    cluster_hint: str | None,
     env_name: str,
     checkpoint: str,
-) -> tuple[Manifest, EnvironmentInfo, CheckpointInfo]:
-    """Load (or create) the manifest and return the env+checkpoint records."""
-    manifest = load_manifest(root)
-    if manifest is None:
-        config = load_config()
-        cluster = cluster_hint or "unknown"
-        manifest = create_manifest(root, cluster, config)
-
+) -> tuple[EnvironmentInfo, CheckpointInfo]:
+    """Return the env+checkpoint records, refreshing from disk if the env is
+    missing from the manifest. Mutates ``manifest`` in place — call inside a
+    transaction."""
     env = manifest.environments.get(env_name)
     if env is None:
         # The manifest hasn't been refreshed since this env was built. Refresh
@@ -906,7 +926,7 @@ def _ensure_manifest_entry(
 
     if checkpoint not in env.checkpoints:
         env.checkpoints[checkpoint] = CheckpointInfo()
-    return manifest, env, env.checkpoints[checkpoint]
+    return env, env.checkpoints[checkpoint]
 
 
 def add_checkpoint(
@@ -938,25 +958,46 @@ def add_checkpoint(
 
     env_name, _ = find_env_for_checkpoint(root, checkpoint)
 
-    manifest, env, ckpt = _ensure_manifest_entry(root, None, env_name, checkpoint)
+    # Fail fast before any long-running work (checked again inside each
+    # transaction by _ensure_manifest_entry, whose refresh needs it too).
+    env_dir = root / "envs" / env_name
+    if not (env_dir / "bin" / "python").exists():
+        raise OperationError(
+            f"environment '{env_name}' is not built at {env_dir}.\n"
+            f"Run: rootstock install <path-to-{env_name}.py> --root {root}"
+        )
 
-    # ---- Download phase ------------------------------------------------
-    already_fetched = ckpt.fetched_at is not None
+    # Unlocked peek for idempotence; every write below loads fresh inside
+    # its own transaction, so a racing writer costs at most a redundant
+    # (idempotent) download, never a lost update.
+    peek = load_manifest(root)
+    peek_env = peek.environments.get(env_name) if peek else None
+    peek_ckpt = peek_env.checkpoints.get(checkpoint) if peek_env else None
+    already_fetched = peek_ckpt is not None and peek_ckpt.fetched_at is not None
+
+    fetched_at = peek_ckpt.fetched_at if peek_ckpt else None
+    verified_at: str | None = None
+    verified_device: str | None = None
+
+    # ---- Download phase (runs outside the lock) ------------------------
     if not already_fetched:
         _say(progress, f"Downloading {env_name}/{checkpoint} on CPU...")
         ok, err = _run_download(root, env_name, checkpoint, setup_kwargs, cache_root=cache_root)
+        with _manifest_transaction(root) as manifest:
+            _, ckpt = _ensure_manifest_entry(manifest, root, env_name, checkpoint)
+            if ok:
+                ckpt.fetched_at = now_iso()
+                ckpt.last_error = None
+                fetched_at = ckpt.fetched_at
+            else:
+                ckpt.last_error = f"download: {err}"
         if not ok:
-            ckpt.last_error = f"download: {err}"
-            save_manifest(manifest, root)
             raise OperationError(f"download failed: {err}")
-        ckpt.fetched_at = now_iso()
-        ckpt.last_error = None
-        save_manifest(manifest, root)
-        _say(progress, f"  fetched_at = {ckpt.fetched_at}")
+        _say(progress, f"  fetched_at = {fetched_at}")
     else:
-        _say(progress, f"{env_name}/{checkpoint} already fetched at {ckpt.fetched_at}")
+        _say(progress, f"{env_name}/{checkpoint} already fetched at {fetched_at}")
 
-    # ---- Verify phase --------------------------------------------------
+    # ---- Verify phase (runs outside the lock) --------------------------
     if not verify:
         _say(progress, "(skipping verify per --no-verify)")
     else:
@@ -964,26 +1005,30 @@ def add_checkpoint(
         ok, err = verify_checkpoint(
             root, env_name, checkpoint, device, setup_kwargs, cache_root=cache_root
         )
+        with _manifest_transaction(root) as manifest:
+            _, ckpt = _ensure_manifest_entry(manifest, root, env_name, checkpoint)
+            if ok:
+                ckpt.verified_at = now_iso()
+                ckpt.verified_device = device
+                ckpt.last_error = None
+                verified_at = ckpt.verified_at
+                verified_device = ckpt.verified_device
+            else:
+                ckpt.verified_at = None
+                ckpt.verified_device = None
+                ckpt.last_error = f"verify: {err}"
         if not ok:
-            ckpt.verified_at = None
-            ckpt.verified_device = None
-            ckpt.last_error = f"verify: {err}"
-            save_manifest(manifest, root)
             raise OperationError(f"verify failed: {err}")
-        ckpt.verified_at = now_iso()
-        ckpt.verified_device = device
-        ckpt.last_error = None
-        save_manifest(manifest, root)
-        _say(progress, f"  verified_at = {ckpt.verified_at} ({device})")
+        _say(progress, f"  verified_at = {verified_at} ({device})")
 
-    # Refresh + push
+    # Refresh + push (takes the lock for its own load -> refresh -> save)
     update_and_push_manifest(root, quiet=True, push=push)
 
     return AddResult(
         env_name=env_name,
         checkpoint=checkpoint,
-        fetched_at=ckpt.fetched_at,
+        fetched_at=fetched_at,
         already_fetched=already_fetched,
-        verified_at=ckpt.verified_at if verify else None,
-        verified_device=ckpt.verified_device if verify else None,
+        verified_at=verified_at if verify else None,
+        verified_device=verified_device if verify else None,
     )

--- a/tests/manifest/test_built_at.py
+++ b/tests/manifest/test_built_at.py
@@ -101,7 +101,7 @@ def test_add_backfills_real_env_info_from_disk(tmp_path):
     synthesizing a placeholder with source_hash='' and built_at=now."""
     env_dir = _make_built_env(tmp_path)
 
-    manifest, env, _ = _ensure_manifest_entry(tmp_path, "test", "mace", "some-ckpt")
+    env, _ = _ensure_manifest_entry(_manifest(tmp_path), tmp_path, "mace", "some-ckpt")
 
     assert env.source_hash.startswith("sha256:")
     assert env.source == ENV_SOURCE
@@ -111,7 +111,7 @@ def test_add_backfills_real_env_info_from_disk(tmp_path):
 
 def test_add_errors_on_unbuilt_env(tmp_path):
     with pytest.raises(RuntimeError, match="not built"):
-        _ensure_manifest_entry(tmp_path, "test", "mace", "some-ckpt")
+        _ensure_manifest_entry(_manifest(tmp_path), tmp_path, "mace", "some-ckpt")
 
 
 def test_add_errors_on_env_missing_source(tmp_path):
@@ -120,4 +120,4 @@ def test_add_errors_on_env_missing_source(tmp_path):
     (env_dir / "bin" / "python").touch()
 
     with pytest.raises(RuntimeError, match="no env_source.py"):
-        _ensure_manifest_entry(tmp_path, "test", "mace", "some-ckpt")
+        _ensure_manifest_entry(_manifest(tmp_path), tmp_path, "mace", "some-ckpt")

--- a/tests/manifest/test_locking.py
+++ b/tests/manifest/test_locking.py
@@ -1,0 +1,111 @@
+"""Tests for the manifest write lock (O_EXCL lock file — never flock; see #125)."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from rootstock.manifest import ManifestError, ManifestLockTimeout, manifest_lock
+
+
+def test_lock_file_created_and_removed(tmp_path: Path):
+    lock = tmp_path / "manifest.json.lock"
+    with manifest_lock(tmp_path):
+        assert lock.exists()
+        assert json.loads(lock.read_text())["pid"] == os.getpid()
+    assert not lock.exists()
+
+
+def test_lock_removed_on_exception(tmp_path: Path):
+    with pytest.raises(RuntimeError, match="boom"):
+        with manifest_lock(tmp_path):
+            raise RuntimeError("boom")
+    assert not (tmp_path / "manifest.json.lock").exists()
+
+
+def test_lock_creates_missing_root(tmp_path: Path):
+    root = tmp_path / "not" / "yet" / "there"
+    with manifest_lock(root):
+        pass
+    assert root.is_dir()
+
+
+def test_contended_lock_times_out_cleanly(tmp_path: Path):
+    with manifest_lock(tmp_path):
+        with pytest.raises(ManifestLockTimeout, match="manifest.json"):
+            with manifest_lock(tmp_path, timeout=1.0):
+                pass
+    # The loser must not have removed the winner's lock on its way out —
+    # but the winner's own exit above does, so re-check the release worked.
+    assert not (tmp_path / "manifest.json.lock").exists()
+
+
+def test_lock_timeout_is_a_manifest_error():
+    """The CLI catches ManifestError for a clean diagnosis — lock timeouts
+    must ride that path, not escape as tracebacks."""
+    assert issubclass(ManifestLockTimeout, ManifestError)
+
+
+def test_timeout_message_names_the_holder(tmp_path: Path):
+    lock = tmp_path / "manifest.json.lock"
+    lock.write_text('{"pid": 4242, "host": "nid001", "created": "2026-07-17T00:00:00Z"}')
+    with pytest.raises(ManifestLockTimeout, match="4242"):
+        with manifest_lock(tmp_path, timeout=0.6):
+            pass
+    assert lock.exists()  # a fresh foreign lock is respected, not broken
+
+
+def test_stale_lock_is_broken(tmp_path: Path):
+    lock = tmp_path / "manifest.json.lock"
+    lock.write_text('{"pid": 999999, "host": "dead-node", "created": "old"}')
+    hour_ago = time.time() - 3600
+    os.utime(lock, (hour_ago, hour_ago))
+
+    with manifest_lock(tmp_path, timeout=5.0, stale_after=600.0):
+        # We hold our own lock now, not the corpse.
+        assert json.loads(lock.read_text())["pid"] == os.getpid()
+    assert not lock.exists()
+
+
+def test_transactions_load_fresh_and_do_not_lose_updates(tmp_path: Path):
+    """Two sequential read-modify-write cycles each see the other's writes —
+    the lost-update mode was mutating a long-held manifest object and saving
+    it over someone else's interleaved save."""
+    from rootstock.manifest import CheckpointInfo, EnvironmentInfo, load_manifest
+    from rootstock.operations import _manifest_transaction
+
+    def env_record() -> EnvironmentInfo:
+        return EnvironmentInfo(
+            built_at="2026-01-01T00:00:00Z",
+            source_hash="sha256:abc",
+            source="",
+            python_requires=">=3.11",
+            dependencies={},
+            checkpoints={"ck": CheckpointInfo()},
+        )
+
+    with _manifest_transaction(tmp_path, cluster_hint="test") as manifest:
+        manifest.environments["a"] = env_record()
+
+    with _manifest_transaction(tmp_path, cluster_hint="test") as manifest:
+        # Loaded fresh: writer A's env is visible, not clobbered.
+        assert "a" in manifest.environments
+        manifest.environments["b"] = env_record()
+
+    final = load_manifest(tmp_path)
+    assert set(final.environments) == {"a", "b"}
+
+
+def test_transaction_does_not_save_on_exception(tmp_path: Path):
+    from rootstock.manifest import load_manifest
+    from rootstock.operations import _manifest_transaction
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with _manifest_transaction(tmp_path, cluster_hint="test"):
+            raise RuntimeError("boom")
+    assert load_manifest(tmp_path) is None
+    assert not (tmp_path / "manifest.json.lock").exists()


### PR DESCRIPTION
Closes #125.

Concurrent writers — a nightly smoke-test overlapping a co-maintainer's `add`, or two maintainers at once — could silently lose updates: commands held a manifest loaded at start, mutated it across minutes of downloads/verification, and saved over whatever landed in between. Lost updates propagate to the public Almanac.

**The lock**: `manifest_lock()` holds `{root}/manifest.json.lock` across each load → mutate → save cycle.
- Deliberately an **atomic O_EXCL lock file, not fcntl/flock** — the manifest lives on the install root, which can be a filesystem without working POSIX locks (Perlmutter CFS is why the cache_root split exists at all).
- The lock file records pid/host/time. A lock far older than any legitimate hold (default 10 min; holds are seconds) is presumed abandoned by a killed process and broken, with a re-stat guard so only the lock judged stale gets unlinked.
- Timeouts raise `ManifestLockTimeout`, a `ManifestError` subclass, so the CLI prints a clean diagnosis naming the holder instead of a traceback.

**Writers restructured** so long-running work never holds the lock:
- `add_checkpoint`: download and verify run unlocked; each outcome is applied through a new `_manifest_transaction` (lock → load-fresh → mutate → save-once) instead of three saves of one long-held object. `_ensure_manifest_entry` now operates on the transaction's manifest.
- `smoke-test`: the verification loop records outcomes, then applies them to a freshly loaded manifest in one locked cycle (entries removed mid-run are skipped, not resurrected).
- `update_and_push_manifest`: load → refresh → save under the lock; the backend push happens after release.
- `manifest init` / `rootstock init`: create+refresh+save under the lock.

Follow-up note: once this and #139 both land, `ManifestLockTimeout` inherits `RootstockError` transitively — no extra change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)