### PR TITLE
Fix fairchem-1.x and sevennet envs against dependency drift

### DIFF
--- a/sample_model_configurations/nvidia_configs/dimenet.py
+++ b/sample_model_configurations/nvidia_configs/dimenet.py
@@ -4,6 +4,9 @@
 #     "torch>=2.4.0",
 #     "fairchem-core>=1.0.0,<2.0.0",
 #     "ase>=3.22",
+#     # scipy.special.sph_harm was removed in scipy 1.17 and fairchem-core 1.x
+#     # still imports it — an uncapped rebuild breaks at import (Delta, 2026-07-18).
+#     "scipy<1.17",
 #     "torch-geometric",
 #     "torch-scatter",
 #     "torch-sparse",

--- a/sample_model_configurations/nvidia_configs/equiformer.py
+++ b/sample_model_configurations/nvidia_configs/equiformer.py
@@ -4,6 +4,9 @@
 #     "torch>=2.4.0",
 #     "fairchem-core>=1.0.0,<2.0.0",
 #     "ase>=3.22",
+#     # scipy.special.sph_harm was removed in scipy 1.17 and fairchem-core 1.x
+#     # still imports it — an uncapped rebuild breaks at import (Delta, 2026-07-18).
+#     "scipy<1.17",
 #     "torch-geometric",
 #     "torch-scatter",
 #     "torch-sparse",

--- a/sample_model_configurations/nvidia_configs/escn.py
+++ b/sample_model_configurations/nvidia_configs/escn.py
@@ -4,6 +4,9 @@
 #     "torch>=2.4.0",
 #     "fairchem-core>=1.0.0,<2.0.0",
 #     "ase>=3.22",
+#     # scipy.special.sph_harm was removed in scipy 1.17 and fairchem-core 1.x
+#     # still imports it — an uncapped rebuild breaks at import (Delta, 2026-07-18).
+#     "scipy<1.17",
 #     "torch-geometric",
 #     "torch-scatter",
 #     "torch-sparse",

--- a/sample_model_configurations/nvidia_configs/painn.py
+++ b/sample_model_configurations/nvidia_configs/painn.py
@@ -4,6 +4,9 @@
 #     "torch>=2.4.0",
 #     "fairchem-core>=1.0.0,<2.0.0",
 #     "ase>=3.22",
+#     # scipy.special.sph_harm was removed in scipy 1.17 and fairchem-core 1.x
+#     # still imports it — an uncapped rebuild breaks at import (Delta, 2026-07-18).
+#     "scipy<1.17",
 #     "torch-geometric",
 #     "torch-scatter",
 #     "torch-sparse",

--- a/sample_model_configurations/nvidia_configs/scn.py
+++ b/sample_model_configurations/nvidia_configs/scn.py
@@ -4,6 +4,9 @@
 #     "torch>=2.4.0",
 #     "fairchem-core>=1.0.0,<2.0.0",
 #     "ase>=3.22",
+#     # scipy.special.sph_harm was removed in scipy 1.17 and fairchem-core 1.x
+#     # still imports it — an uncapped rebuild breaks at import (Delta, 2026-07-18).
+#     "scipy<1.17",
 #     "torch-geometric",
 #     "torch-scatter",
 #     "torch-sparse",

--- a/sample_model_configurations/nvidia_configs/sevennet.py
+++ b/sample_model_configurations/nvidia_configs/sevennet.py
@@ -19,11 +19,15 @@
 SevenNet (SCalable EquiVariance-Enabled Neural Network) ships several
 pretrained models, loaded by keyword through ``SevenNetCalculator``.
 
-Multi-fidelity models (``7net-omni``, ``7net-mf-ompa``) require a ``modal``
-argument selecting the training fidelity (e.g. ``"mpa"`` or ``"omat24"``).
-Pass it at runtime via ``setup_kwargs={"modal": ...}`` on RootstockCalculator
-(or ``--kwarg modal=...`` for ``rootstock add``); single-fidelity models
-ignore it.
+Multi-fidelity models (``7net-omni``, ``7net-mf-ompa``) take a ``modal``
+argument selecting the training fidelity (e.g. ``"mpa"`` or ``"omat24"``),
+and sevenn releases after mid-2026 make it mandatory (older ones defaulted
+silently). When not given, setup() defaults them to ``"mpa"`` — the
+MPtrj+sAlex fidelity, consistent with the lineage of the other checkpoints
+here — so no-kwarg paths (smoke-test, plain ``rootstock add``) keep working.
+Override at runtime via ``setup_kwargs={"modal": ...}`` on
+RootstockCalculator (or ``--kwarg modal=...`` for ``rootstock add``);
+single-fidelity models ignore it.
 """
 
 CHECKPOINTS = {
@@ -35,6 +39,13 @@ CHECKPOINTS = {
 }
 
 
+# Multi-fidelity models and the fidelity used when modal isn't specified.
+MULTI_FIDELITY_DEFAULT_MODAL = {
+    "sevennet-mf-ompa": "mpa",
+    "sevennet-omni": "mpa",
+}
+
+
 def setup(checkpoint: str, device: str = "cuda", modal: str | None = None):
     """
     Load a SevenNet calculator.
@@ -43,12 +54,15 @@ def setup(checkpoint: str, device: str = "cuda", modal: str | None = None):
         checkpoint: Canonical checkpoint id, must be a key of CHECKPOINTS.
         device: PyTorch device string (e.g., "cuda", "cuda:0", "cpu").
         modal: Fidelity selector for multi-fidelity models (e.g. "mpa",
-            "omat24"). Required for 7net-omni / 7net-mf-ompa; ignored otherwise.
+            "omat24"). Defaults to "mpa" for 7net-omni / 7net-mf-ompa;
+            ignored by the single-fidelity models.
 
     Returns:
         ASE-compatible calculator.
     """
     from sevenn.calculator import SevenNetCalculator
 
+    if modal is None:
+        modal = MULTI_FIDELITY_DEFAULT_MODAL.get(checkpoint)
     kwargs = {"modal": modal} if modal is not None else {}
     return SevenNetCalculator(model=CHECKPOINTS[checkpoint], device=device, **kwargs)


### PR DESCRIPTION
Found by the 2026-07-17 Delta wipe-and-rebuild — the first from-scratch deployment on 1.0.

- **scipy 1.17 removed `scipy.special.sph_harm`**, which fairchem-core 1.x still imports. The five fairchem-1.x envs (dimenet, equiformer, escn, painn, scn) are exactly the envs that **cannot lock** (PyG find-links defeats universal resolution, `lock_hash: null`), so a rebuild re-resolves scipy fresh and breaks at import — the unlocked-rebuild drift the lockfile work can't cover. Capped `scipy<1.17`.
- **Newer sevenn requires `modal`** for the multi-fidelity models (`7net-mf-ompa`, `7net-omni`); older releases defaulted it silently, which is how these verified pre-rebuild. `setup()` now defaults them to `modal="mpa"` (MPtrj+sAlex fidelity, matching the lineage of the other sevennet checkpoints), keeping the no-kwarg paths (nightly smoke-test, plain `add`) green while `setup_kwargs={"modal": ...}` still overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)