### PR TITLE
Add frontier to the cluster registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ predate the declaration. Most clusters use the same path for both.
 | `polaris` | `/eagle/Garden-Ai/rootstock` (shared with sophia) | (same as install root) |
 | `perlmutter` | `/global/cfs/cdirs/m4845/rootstock` | `/pscratch/sd/w/wengler/rootstock-cache` |
 | `delta` | `/work/hdd/data/rootstock` | (same as install root) |
+| `frontier` | `/sw/frontier/ums/ums047/rootstock` | `/lustre/orion/ums047/world-shared/rootstock-cache` |
 
 ## API
 

--- a/rootstock/clusters.py
+++ b/rootstock/clusters.py
@@ -49,10 +49,17 @@ CLUSTER_REGISTRY: dict[str, Cluster] = {
         root=Path("/global/cfs/cdirs/m4845/rootstock"),
         cache_root=Path("/pscratch/sd/w/wengler/rootstock-cache"),
     ),
-    "delta": Cluster(
-        root=Path("/work/hdd/data/rootstock")
-    )
+    "delta": Cluster(root=Path("/work/hdd/data/rootstock")),
+    # ORNL Frontier (AMD MI250X). The install root is a User-Managed Software
+    # area, which is read-only on compute nodes -- fine for serving, since
+    # workers only read their env. The cache is split onto Lustre because
+    # model libraries write weights there at runtime.
+    "frontier": Cluster(
+        root=Path("/sw/frontier/ums/ums047/rootstock"),
+        cache_root=Path("/lustre/orion/ums047/world-shared/rootstock-cache"),
+    ),
 }
+
 
 def get_cluster(cluster: str) -> Cluster:
     """Look up a known cluster by name."""

--- a/tests/cache/test_cache_root.py
+++ b/tests/cache/test_cache_root.py
@@ -159,6 +159,16 @@ def test_perlmutter_registered_with_split():
     assert "pscratch" in str(pm.cache_root).lower()
 
 
+def test_frontier_registered_with_split():
+    fr = get_cluster("frontier")
+    assert fr.cache_root is not None
+    assert fr.cache_root != fr.root
+    # UMS software area for code (read-only on compute nodes), Lustre for the
+    # cache, which model libraries write to at runtime.
+    assert "/sw/frontier/ums" in str(fr.root)
+    assert "lustre" in str(fr.cache_root).lower()
+
+
 def test_polaris_shares_sophia_eagle_root():
     """Both ALCF machines mount Eagle and share one install."""
     assert get_cluster("polaris").root == get_cluster("sophia").root


### PR DESCRIPTION
Registers ORNL Frontier, our first AMD (MI250X / ROCm) deployment, so users can say `cluster="frontier"` instead of carrying two paths around. Follows #91, which added the `amd_configs/` these envs will be built from.

```python
"frontier": Cluster(
    root=Path("/sw/frontier/ums/ums047/rootstock"),
    cache_root=Path("/lustre/orion/ums047/world-shared/rootstock-cache"),
),
```

## Why the root is split

Frontier's install root is a [User-Managed Software](https://docs.olcf.ornl.gov/software/UMS/index.html) area under `/sw` (project UMS047). Confirmed on the machine: **`/sw` is mounted read-only on compute nodes** (`dvs ro`) and read-write on login nodes.

Read-only is fine for the install itself — workers only ever read their env. But model libraries write weights at runtime through the `HOME`/`XDG_CACHE_HOME` redirect, so a read-only cache would break first-call weight fetching. Hence the split onto Lustre `world-shared`, mirroring what Perlmutter already does.

Choosing `/sw` for code and Lustre for cache (rather than putting everything on one) is deliberate: Lustre purges files not accessed in 90 days, so venvs live on the purge-immune filesystem while the cache — which is regenerable, and stays warm through access — lives on the writable one.

## On the `cache_root` field

`docs/cluster-setup.md` describes registry `cache_root` as a legacy fallback, since installs now self-declare in `layout.json`. It's included here anyway because Frontier has **no install yet**: this entry is what resolves the cache during the *first* install, before `layout.json` exists. Happy to drop it and pass `--cache-root` explicitly on the first run if maintainers prefer to keep the registry root-only.

## Verification

Paths and group match what's actually mounted (`login05`, compute node `frontier08633`, 2026-07-20). The AMD stack from #91 was confirmed on real hardware:

```
torch: 2.9.1+rocm6.4 | hip: 6.4.43484-123eb5128
is_available: True | count: 8
device: AMD Instinct MI250X | arch: gfx90a:sramecc+:xnack-
matmul finite: True
```

This closes the open question at the end of #91 ("someone with a Frontier allocation should confirm") for the torch layer — #91's `check_isa.py` bet that the official ROCm wheels are fat binaries carrying `gfx90a` holds on real MI250X hardware. Rootstock's own i-PI worker path on ROCm is still unexercised; that comes with the first `rootstock install`.

Also adds a registry test alongside the existing per-cluster ones, and updates the Known Clusters table in `CLAUDE.md`. `ruff format` collapsed the neighbouring `delta` entry — unrelated pre-existing drift this edit happened to trigger.

Full suite: 372 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
