### PR TITLE
Fix two AMD config regressions: torchvision routing and requires-python

### DIFF
--- a/sample_model_configurations/amd_configs/chgnet.py
+++ b/sample_model_configurations/amd_configs/chgnet.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.11"
 # dependencies = [
 #     "chgnet>=0.3.0",
 #     "ase>=3.22",

--- a/sample_model_configurations/amd_configs/mace.py
+++ b/sample_model_configurations/amd_configs/mace.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.11"
 # dependencies = [
 #     "mace-torch>=0.3.0",
 #     "ase>=3.22",

--- a/sample_model_configurations/amd_configs/mattersim.py
+++ b/sample_model_configurations/amd_configs/mattersim.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.11"
 # dependencies = [
 #     "mattersim>=1.1.0",
 #     "ase>=3.22",

--- a/sample_model_configurations/amd_configs/mattersim.py
+++ b/sample_model_configurations/amd_configs/mattersim.py
@@ -7,11 +7,22 @@
 #     # torch's ROCm wheels depend on this; it lives only on the ROCm
 #     # index, so it must be a direct dep for [tool.uv.sources] to route it.
 #     "pytorch-triton-rocm",
+#     # Not imported here. mattersim -> torchmetrics -> torchvision pulls it in
+#     # transitively, and torchvision ships compiled ops ABI-locked to one exact
+#     # torch build. An `explicit` index is only consulted for packages listed
+#     # in `dependencies`, so without this line torchvision silently resolves
+#     # from PyPI (a CUDA build!) against a different torch, and the mismatch
+#     # surfaces only at `import torchvision` as:
+#     #     RuntimeError: operator torchvision::nms does not exist
+#     # Leave it unpinned: the index hosts one build per torch release and uv
+#     # enforces the torch<->torchvision pairing.
+#     "torchvision",
 # ]
 #
 # [tool.uv.sources]
 # torch = { index = "pytorch-rocm" }
 # pytorch-triton-rocm = { index = "pytorch-rocm" }
+# torchvision = { index = "pytorch-rocm" }
 #
 # [[tool.uv.index]]
 # name = "pytorch-rocm"

--- a/sample_model_configurations/amd_configs/orb.py
+++ b/sample_model_configurations/amd_configs/orb.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.11"
 # dependencies = [
 #     "orb-models>=0.4.0",
 #     "ase>=3.22",

--- a/sample_model_configurations/nvidia_configs/mattersim.py
+++ b/sample_model_configurations/nvidia_configs/mattersim.py
@@ -4,10 +4,21 @@
 #     "mattersim>=1.1.0",
 #     "ase>=3.22",
 #     "torch>=2.0",
+#     # Not imported here. mattersim -> torchmetrics -> torchvision pulls it in
+#     # transitively, and torchvision ships compiled ops ABI-locked to one exact
+#     # torch build. An `explicit` index is only consulted for packages listed
+#     # in `dependencies`, so without this line torchvision silently resolves
+#     # from PyPI against a different torch and the mismatch surfaces only at
+#     # `import torchvision` as:
+#     #     RuntimeError: operator torchvision::nms does not exist
+#     # Leave it unpinned: the index hosts one build per torch release and uv
+#     # enforces the torch<->torchvision pairing.
+#     "torchvision",
 # ]
 #
 # [tool.uv.sources]
 # torch = { index = "pytorch-cu128" }
+# torchvision = { index = "pytorch-cu128" }
 #
 # [[tool.uv.index]]
 # name = "pytorch-cu128"


### PR DESCRIPTION
Two independent regressions in the AMD config ports, both found while staging the AMD envs for Frontier (#145). Each is one line of intent; both break the property #91 is built on — that an AMD config differs from its NVIDIA twin *only* in the dependency index.

---

## 1. torchvision resolves against the wrong torch (both AMD and NVIDIA)

`mattersim → torchmetrics → torchvision` pulls torchvision in **transitively**. torchvision ships compiled C++ ops ABI-locked to one exact torch build — and an `explicit = true` index is only consulted for packages that appear in `dependencies`. Since neither config listed torchvision, it resolved from PyPI while torch came from the pinned index.

Reproduced with `uv lock --script` on the NVIDIA config, before and after:

| | torch | torchvision |
|---|---|---|
| **before** | `2.11.0+cu128` (cu128 index) | `0.26.0` (**pypi.org**) |
| **after** | `2.11.0+cu128` (cu128 index) | `0.26.0+cu128` (cu128 index) |

**The version string is identical either way** — only the local build tag and the source index differ, which is why this is easy to miss in a lockfile review. Nothing warns at install time, and `import torch` succeeds. The mismatch surfaces later, on first `import torchvision`:

```
RuntimeError: operator torchvision::nms does not exist
```

The AMD config had the same gap, where the PyPI fallback is a **CUDA** build landing in a ROCm env. After the fix it resolves `torch 2.9.1+rocm6.4` with `torchvision 0.24.1+rocm6.4`, both from the ROCm index.

**Fix:** list torchvision as a direct dependency *and* map it in `[tool.uv.sources]` — the sources entry alone does nothing, the same trap `_agent/failure_modes.md` documents for `pytorch-triton-rocm`. Left unpinned deliberately: each index hosts one build per torch release and uv enforces the torch↔torchvision pairing.

---

## 2. AMD configs declared `requires-python >=3.10`

Every config in `nvidia_configs/` requires `>=3.11` (several pin `>=3.11,<3.12`; `orb_v3` wants `>=3.12`), but four of the five AMD ports declared `>=3.10`. `uma` was already correct.

rootstock builds each venv at the **minimum** `requires-python`, so an AMD env came up on 3.10 while its NVIDIA twin came up on 3.11 — different interpreter, different resolution, for configs that are supposed to be twins.

The looser floor also drags in backports that 3.11 makes unnecessary. Resolving `amd_configs/mattersim.py` both ways:

```
3.10: 167 packages     3.11: 163 packages
extra on 3.10: async-timeout, mongomock, smart-open, sshtunnel
```

Surfaced on Frontier, where the mace env had to be hand-edited before install to get a 3.11 interpreter.

---

## Deploying

Both are **dependency-affecting changes**, so deployed envs need `rootstock install --force` — editing `env_source.py` in place is not enough. Worth doing on the clusters where mattersim is currently listed broken. Verify the pair afterwards:

```bash
{root}/envs/mattersim/bin/python -c "import torch, torchvision; print(torch.__version__, torchvision.__version__)"
```

Both should carry the same `+cu128` / `+rocm6.4` tag.

Suite: 371 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
