### PR TITLE
setup-perms: assert mode bits after ACLs so setgid survives

### DIFF
--- a/docs/cluster-setup.md
+++ b/docs/cluster-setup.md
@@ -83,9 +83,11 @@ rootstock setup-perms /path/to/install/root \
   --group <group> --apply
 ```
 
-Omit `--apply` for a **dry run** (the default) that just prints the `chmod` / `chgrp` / `setfacl` commands — useful if you (or a cautious sysadmin) want to review them or paste them into a script before anything touches the filesystem. `--apply` runs them after a confirmation prompt, stopping at the first failure.
+Omit `--apply` for a **dry run** (the default) that just prints the `chmod` / `chgrp` / `setfacl` commands — useful if you (or a cautious sysadmin) want to review them or paste them into a script before anything touches the filesystem. `--apply` runs them after a confirmation prompt, stopping at the first failure, then re-runs the read-only check and reports anything the filesystem didn't actually honour.
 
-If the install or cache root **already has files in it** when you set this up (e.g., you're retrofitting a deployment that started out project-only), add `--retrofit` so the recipe also applies recursively and existing files become world-readable too:
+The order matters: the `chmod` comes **last**. Setting an ACL rewrites a path's mode bits, and on some filesystems (observed on NERSC CFS) that clears the setgid bit — so the mode is asserted after all the `setfacl` work, not before. If you hand-roll the recipe, keep that order.
+
+If the install or cache root **already has files in it** when you set this up (e.g., you're retrofitting a deployment that started out project-only), add `--retrofit` so the recipe also applies recursively — existing files become world-readable, and existing *subdirectories* get setgid so files created under them inherit the project group:
 
 ```bash
 rootstock setup-perms --cluster perlmutter --group m4845 --retrofit --apply

--- a/rootstock/cli.py
+++ b/rootstock/cli.py
@@ -317,6 +317,13 @@ def main():
         nargs="?",
         help="Install root path (omit when using --cluster)",
     )
+    # --root is how every other command spells it; accept both rather than
+    # failing with "unrecognized arguments" on the obvious guess.
+    setup_perms_parser.add_argument(
+        "--root",
+        dest="root_flag",
+        help="Install root path (same as the positional argument)",
+    )
     setup_perms_parser.add_argument(
         "--cache-root",
         help="Cache root path, when on a separate filesystem from the install root",
@@ -359,6 +366,11 @@ def main():
         nargs="?",
         default=os.environ.get(ROOTSTOCK_ROOT_ENV),
         help=f"Install root path (default: ${ROOTSTOCK_ROOT_ENV}; or use --cluster)",
+    )
+    check_perms_parser.add_argument(
+        "--root",
+        dest="root_flag",
+        help="Install root path (same as the positional argument)",
     )
     check_perms_parser.add_argument(
         "--cache-root",

--- a/rootstock/commands/check_perms.py
+++ b/rootstock/commands/check_perms.py
@@ -15,8 +15,8 @@ from .common import ROOTSTOCK_ROOT_ENV, resolve_cache_root
 def _resolve_roots(args) -> tuple[Path, Path | None] | None:
     """Resolve (install_root, cache_root) to check.
 
-    Priority: --cluster, then the positional root (whose argparse default is
-    $ROOTSTOCK_ROOT), then the config file. When the root isn't given via
+    Priority: --cluster, then --root or the positional root (whose argparse
+    default is $ROOTSTOCK_ROOT), then the config file. When the root isn't given via
     --cluster, the cache root comes from --cache-root or a reverse lookup in
     the cluster registry. Returns None (after printing an error) on bad input.
     """
@@ -28,7 +28,7 @@ def _resolve_roots(args) -> tuple[Path, Path | None] | None:
             return None
         return cluster.root, cluster.cache_root
 
-    root = args.root or load_config().root
+    root = getattr(args, "root_flag", None) or args.root or load_config().root
     if not root:
         print(
             f"Error: provide an install root path, --cluster <name>, or set {ROOTSTOCK_ROOT_ENV}.",

--- a/rootstock/commands/setup_perms.py
+++ b/rootstock/commands/setup_perms.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 
 from ..clusters import get_cluster
-from ..perms import format_command, render_commands
+from ..perms import check_permissions, format_command, render_commands
 
 
 def _resolve_roots(args) -> tuple[Path, Path | None] | None:
@@ -26,14 +26,15 @@ def _resolve_roots(args) -> tuple[Path, Path | None] | None:
         cache_root = cluster.cache_root  # None when same as install root
         return install_root, cache_root
 
-    if not args.root:
+    root = getattr(args, "root_flag", None) or args.root
+    if not root:
         print(
             "Error: provide an install root path or --cluster <name>.",
             file=sys.stderr,
         )
         return None
 
-    install_root = Path(args.root)
+    install_root = Path(root)
     cache_root = Path(args.cache_root) if args.cache_root else None
     return install_root, cache_root
 
@@ -80,6 +81,22 @@ def cmd_setup_perms(args) -> int:
             if result.stderr:
                 print(result.stderr.rstrip(), file=sys.stderr)
             return 1
+
+    # Re-check rather than trust: every command can exit 0 and still leave the
+    # roots wrong (a filesystem that silently drops setgid, an ACL the fs maps
+    # differently). Better to say so here than to have the maintainer discover
+    # it from a later check-perms.
+    issues = check_permissions(install_root, cache_root, group=args.group)
+    if issues:
+        print("Permissions applied, but the roots still look wrong:", file=sys.stderr)
+        for issue in issues:
+            print(f"  - {issue.path}: {issue.problem}", file=sys.stderr)
+        print(
+            "\nThis filesystem may not support part of the recipe; "
+            "run 'rootstock check-perms' for the full check.",
+            file=sys.stderr,
+        )
+        return 1
 
     print("Permissions applied.")
     return 0

--- a/rootstock/perms.py
+++ b/rootstock/perms.py
@@ -23,7 +23,12 @@ The recipe:
   handles group-ownership inheritance. No named-group ACL (maintainer-only-write
   on the cache is the accepted default).
 * ``--retrofit`` — recursive ``setfacl -R`` variants so an install that already
-  has files in it becomes world-readable, not just future files.
+  has files in it becomes world-readable, not just future files, plus a
+  ``find -type d ... chmod g+s`` so existing subdirectories inherit too.
+
+The ``chmod`` comes *last* in the rendered order: setting an ACL rewrites a
+path's mode bits, which can clear setgid, so the mode is asserted after all the
+``setfacl`` work rather than before it.
 """
 
 from __future__ import annotations
@@ -59,7 +64,6 @@ def render_commands(
     """
     install_root = Path(install_root)
     cmds: list[list[str]] = [
-        ["chmod", INSTALL_ROOT_MODE, str(install_root)],
         ["chgrp", group, str(install_root)],
         ["setfacl", "-m", f"g:{group}:rwx", str(install_root)],
         ["setfacl", "-dm", f"g:{group}:rwx", str(install_root)],
@@ -68,10 +72,7 @@ def render_commands(
     separate_cache = cache_root is not None and Path(cache_root) != install_root
     if separate_cache:
         cache_root = Path(cache_root)
-        cmds += [
-            ["chmod", CACHE_ROOT_MODE, str(cache_root)],
-            ["chgrp", group, str(cache_root)],
-        ]
+        cmds += [["chgrp", group, str(cache_root)]]
 
     if retrofit:
         # Existing files: make the named-group ACL and world r-x apply to what's
@@ -89,8 +90,30 @@ def render_commands(
                 ["setfacl", "-R", "-m", "o::r-X", str(cache_root)],
                 ["setfacl", "-R", "-dm", "o::r-X", str(cache_root)],
             ]
+        # setgid has to hold on every *existing* directory too, not just the
+        # root: a subdirectory without it hands new files the creator's primary
+        # group. ``-exec ... +`` batches, so this is one chmod per few thousand
+        # dirs rather than one per dir.
+        cmds += [_setgid_dirs(install_root)]
+        if separate_cache:
+            cmds += [_setgid_dirs(cache_root)]
+
+    # Mode bits go *last*, deliberately. Setting an ACL rewrites the file mode
+    # (the ACL's owner/mask/other entries are the mode bits), and on some
+    # filesystems that drops the setgid bit — observed on NERSC CFS in 2026-07,
+    # where a chmod-first recipe left the root at 0775 and check-perms flagged
+    # it immediately after a successful setup-perms --apply. Re-asserting the
+    # mode after every setfacl is cheap and makes the recipe order-independent.
+    cmds += [["chmod", INSTALL_ROOT_MODE, str(install_root)]]
+    if separate_cache:
+        cmds += [["chmod", CACHE_ROOT_MODE, str(cache_root)]]
 
     return cmds
+
+
+def _setgid_dirs(root: Path) -> list[str]:
+    """``find``-based recursive setgid for directories under ``root``."""
+    return ["find", str(root), "-type", "d", "-exec", "chmod", "g+s", "{}", "+"]
 
 
 def format_command(argv: list[str]) -> str:

--- a/tests/cli/test_setup_perms.py
+++ b/tests/cli/test_setup_perms.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
 from rootstock.commands.setup_perms import cmd_setup_perms
+from rootstock.perms import PermIssue
 
 
 def _args(**overrides):
     base = dict(
         root=None,
+        root_flag=None,
         cache_root=None,
         cluster=None,
         group="m4845",
@@ -84,12 +87,47 @@ def test_apply_runs_commands_after_confirmation(monkeypatch, capsys):
         return SimpleNamespace(returncode=0, stderr="")
 
     monkeypatch.setattr("rootstock.commands.setup_perms.subprocess.run", fake_run)
+    monkeypatch.setattr("rootstock.commands.setup_perms.check_permissions", lambda *a, **k: [])
     monkeypatch.setattr("builtins.input", lambda _prompt: "y")
 
     rc = cmd_setup_perms(_args(root="/install/root", apply=True))
     assert rc == 0
-    assert ["chmod", "2775", "/install/root"] in calls
+    # The mode bits are asserted last, after the ACL work that can clear setgid.
+    assert calls[-1] == ["chmod", "2775", "/install/root"]
     assert "Permissions applied." in capsys.readouterr().out
+
+
+def test_apply_reports_issues_that_survive(monkeypatch, capsys):
+    """Every command exiting 0 doesn't mean the roots ended up correct."""
+    monkeypatch.setattr(
+        "rootstock.commands.setup_perms.subprocess.run",
+        lambda argv, capture_output=False, text=False: SimpleNamespace(returncode=0, stderr=""),
+    )
+    monkeypatch.setattr(
+        "rootstock.commands.setup_perms.check_permissions",
+        lambda *a, **k: [PermIssue(Path("/install/root"), "setgid bit not set")],
+    )
+    monkeypatch.setattr("builtins.input", lambda _prompt: "y")
+
+    rc = cmd_setup_perms(_args(root="/install/root", apply=True))
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "still look wrong" in err
+    assert "setgid bit not set" in err
+
+
+def test_apply_accepts_root_flag(monkeypatch, capsys):
+    """--root is accepted alongside the positional form."""
+    monkeypatch.setattr(
+        "rootstock.commands.setup_perms.subprocess.run",
+        lambda argv, capture_output=False, text=False: SimpleNamespace(returncode=0, stderr=""),
+    )
+    monkeypatch.setattr("rootstock.commands.setup_perms.check_permissions", lambda *a, **k: [])
+    monkeypatch.setattr("builtins.input", lambda _prompt: "y")
+
+    rc = cmd_setup_perms(_args(root=None, root_flag="/install/root", apply=True))
+    assert rc == 0
+    assert "/install/root" in capsys.readouterr().out
 
 
 def test_apply_aborts_without_confirmation(monkeypatch, capsys):
@@ -109,7 +147,7 @@ def test_apply_bails_on_first_failure(monkeypatch, capsys):
 
     def fake_run(argv, capture_output=False, text=False):
         calls.append(argv)
-        # Fail on the second command (chgrp).
+        # Fail on the first command (chgrp).
         if argv[0] == "chgrp":
             return SimpleNamespace(returncode=1, stderr="chgrp: invalid group")
         return SimpleNamespace(returncode=0, stderr="")

--- a/tests/test_perms.py
+++ b/tests/test_perms.py
@@ -21,11 +21,12 @@ from rootstock.perms import (
 def test_render_single_filesystem():
     cmds = render_commands("/install/root", group="m4845")
     lines = [format_command(c) for c in cmds]
+    # chmod goes last: setting an ACL rewrites the mode and can drop setgid.
     assert lines == [
-        "chmod 2775 /install/root",
         "chgrp m4845 /install/root",
         "setfacl -m g:m4845:rwx /install/root",
         "setfacl -dm g:m4845:rwx /install/root",
+        "chmod 2775 /install/root",
     ]
 
 
@@ -46,6 +47,26 @@ def test_render_cache_root_same_as_install_emits_nothing_extra():
     assert len(cmds) == 4
 
 
+def test_render_chmod_follows_every_setfacl():
+    """Every path's chmod must come after the last setfacl touching that path.
+
+    A setfacl can rewrite the mode bits (and drop setgid on some filesystems),
+    so a chmod-first recipe leaves the root without setgid — the NERSC CFS bug.
+    """
+    for retrofit in (False, True):
+        cmds = render_commands(
+            "/install/root", cache_root="/cache/root", group="m4845", retrofit=retrofit
+        )
+        for root in ("/install/root", "/cache/root"):
+            touching = [i for i, c in enumerate(cmds) if root in c]
+            chmods = [i for i in touching if cmds[i][0] == "chmod"]
+            setfacls = [i for i in touching if cmds[i][0] == "setfacl"]
+            assert chmods, f"no chmod for {root} (retrofit={retrofit})"
+            assert all(i < min(chmods) for i in setfacls), (
+                f"setfacl runs after chmod for {root} (retrofit={retrofit})"
+            )
+
+
 def test_render_retrofit_adds_recursive_variants():
     cmds = render_commands("/install/root", cache_root="/cache/root", group="m4845", retrofit=True)
     lines = [format_command(c) for c in cmds]
@@ -59,6 +80,16 @@ def test_render_retrofit_adds_recursive_variants():
     assert "setfacl -R -dm o::r-X /cache/root" in lines
     # ...but no recursive named-group ACL on the cache root.
     assert "setfacl -R -m g:m4845:rwX /cache/root" not in lines
+
+
+def test_render_retrofit_sets_setgid_on_existing_dirs():
+    cmds = render_commands("/install/root", cache_root="/cache/root", group="m4845", retrofit=True)
+    lines = [format_command(c) for c in cmds]
+    assert "find /install/root -type d -exec chmod g+s '{}' +" in lines
+    assert "find /cache/root -type d -exec chmod g+s '{}' +" in lines
+    # Without --retrofit only the root itself is touched.
+    plain = [format_command(c) for c in render_commands("/install/root", group="m4845")]
+    assert not any(line.startswith("find ") for line in plain)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## The bug

Running the recipe on NERSC CFS (Perlmutter, `/global/cfs/cdirs/m5268/rootstock`) left the install root without setgid, even though every command exited 0:

```
$ rootstock setup-perms --group m5268 --apply --retrofit /global/cfs/cdirs/m5268/rootstock
...
Permissions applied.

$ rootstock check-perms
Found 1 issue(s):
  - /global/cfs/cdirs/m5268/rootstock: setgid bit not set; new files won't inherit the project group
```

`render_commands` emitted `chmod 2775` **first** and every `setfacl` after it. Setting a POSIX ACL rewrites the path's mode bits (the ACL's owner/mask/other entries *are* the mode bits), and on that filesystem it drops setgid — so the chmod was silently undone by the ACL calls that followed. `setfacl(1)` documents this clearing only for `--restore`; with `-m` it's kernel/filesystem behaviour, so the fix is to stop depending on the order being safe either way.

## Changes

- **`chmod` renders last**, after every `setfacl` touching that path. A test asserts the invariant for both roots, with and without `--retrofit`.
- **`--retrofit` sets setgid on existing subdirectories** (`find <root> -type d -exec chmod g+s {} +`). Independent gap found while here: only the root ever got a `chmod`, so even a clean retrofit left every subdirectory handing new files the creator's primary group. `check-perms` never caught it because it deliberately doesn't recurse.
- **`--apply` verifies instead of asserting.** It now re-runs `check_permissions` and reports what didn't stick, rather than printing "Permissions applied." on exit codes alone — that's what would have surfaced this in one command instead of two.
- **`--root` accepted on `setup-perms` and `check-perms`.** Both took the root positionally while every other command spells it `--root`, so the obvious guess failed with `unrecognized arguments: --root`.

Docs updated in `docs/cluster-setup.md` (the ordering constraint matters for anyone hand-rolling the recipe).

## Testing

- `uv run pytest` — 375 passed, 2 skipped.
- `uv run ruff check` / `format --check` clean on the touched files.
- Rendering verified by hand; the on-cluster rerun against CFS is still to be done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)