### PR TITLE
Add --cache-root to init, and prompt for it

### DIFF
--- a/docs/cluster-setup.md
+++ b/docs/cluster-setup.md
@@ -30,7 +30,31 @@ Choose a location on a shared filesystem where other users have access:
 
 On most clusters a single shared filesystem hosts both the rootstock install (code, venvs, manifest) and the model-weight cache. Some clusters require these to live on different filesystems — typically because the recommended persistent project filesystem doesn't support `flock`, which the HuggingFace cache requires. NERSC Perlmutter is one such case: code lives on CFS, model weights on PSCRATCH.
 
-The install declares its own cache root in `{root}/layout.json` — `rootstock install` and `rootstock init` record it automatically. Every reader (CLI commands and `RootstockCalculator`, whether given `cluster=` or `root=`) resolves the cache root the same way: an explicit override wins, then the install's declaration, then — for legacy installs that predate the declaration — the cluster registry's entry, then the install root itself.
+The install declares its own cache root in `{root}/layout.json`. Every reader (CLI commands and `RootstockCalculator`, whether given `cluster=` or `root=`) resolves the cache root the same way: an explicit override wins, then the install's declaration, then — for legacy installs that predate the declaration — the cluster registry's entry, then the install root itself.
+
+**Setting it at install time.** `rootstock init` asks:
+
+```
+Model weights can live on a different filesystem than the install
+itself — some clusters require it (the project filesystem may not
+support flock, or weights may belong on scratch).
+Cache on a different filesystem? (y/n) [y]:
+  Cache root [/pscratch/sd/u/me/rootstock-cache]:
+```
+
+The suggestion is seeded from the cluster registry when the root belongs to a known cluster, but you can override it — don't accept a path just because it was pre-filled, since it reflects whatever registry *this client release* happened to ship. Pass `--cache-root` to skip the prompt entirely:
+
+```bash
+rootstock init --cache-root /pscratch/sd/u/me/rootstock-cache
+```
+
+Verify what an install actually declares with:
+
+```bash
+cat {root}/layout.json
+```
+
+**Changing it afterwards is deliberately awkward.** Only `init` sets the cache root; `rootstock install` records the declaration when one is missing but never changes an existing one, so no routine rebuild can re-point a deployment and scatter checkpoints across two filesystems. To move a populated install's cache: edit `cache_root` in `{root}/layout.json`, then move the `cache/` and `home/` directories to the new path (or re-run `rootstock add` to re-download into it). Don't re-run `rootstock init` on a populated root for this — it writes a fresh manifest and loses recorded environment state.
 
 The cluster registry (`rootstock/clusters.py`) is only a name → install-path bootstrap so users can say `cluster="perlmutter"` instead of remembering a path. Its per-cluster `cache_root` field remains solely as the legacy fallback above; new split-filesystem deployments don't need a registry entry at all, just a declaration in the install:
 

--- a/rootstock/cli.py
+++ b/rootstock/cli.py
@@ -94,6 +94,15 @@ def main():
         description="Guided setup for root directory, maintainer info, and API credentials.",
     )
     init_parser.add_argument(
+        "--cache-root",
+        help=(
+            "Filesystem for model weights when it differs from the install root "
+            "(recorded in {root}/layout.json). Prompted for if omitted. This is "
+            "a deployment-time choice: changing it later means editing "
+            "layout.json and moving the weights."
+        ),
+    )
+    init_parser.add_argument(
         "--skip-dirs",
         action="store_true",
         help="Skip creating directory structure",

--- a/rootstock/commands/init.py
+++ b/rootstock/commands/init.py
@@ -41,6 +41,54 @@ def prompt_secret(prompt: str, existing: str | None = None) -> str | None:
     return value if value else None
 
 
+def resolve_init_cache_root(args, root: Path, cluster: str | None) -> Path:
+    """Decide where this install's model-weight cache lives.
+
+    Order: an explicit ``--cache-root`` wins; otherwise ask, seeding the
+    suggestion from the cluster registry. The prompt exists because the
+    registry is baked into the client — a maintainer running a pinned release
+    would otherwise silently inherit whatever cache path that release happened
+    to ship, which is exactly the coupling the layout.json declaration is
+    meant to break.
+
+    Paths are expanded but deliberately not ``resolve()``d: the answer is
+    written verbatim into layout.json and read by every other user's client,
+    so the canonical path the maintainer typed travels better than one node's
+    symlink-collapsed view of it.
+    """
+    explicit = getattr(args, "cache_root", None)
+    if explicit:
+        cache_root = Path(explicit).expanduser()
+        print(f"Cache root: {cache_root}")
+        return cache_root
+
+    if cluster:
+        from ..clusters import get_cluster
+
+        suggested = get_cluster(cluster).resolved_cache_root
+    else:
+        suggested = root
+
+    print("Model weights can live on a different filesystem than the install")
+    print("itself — some clusters require it (the project filesystem may not")
+    print("support flock, or weights may belong on scratch).")
+    split_default = "y" if suggested != root else "n"
+    answer = prompt_with_default("Cache on a different filesystem? (y/n)", split_default)
+    if answer.lower() not in ("y", "yes"):
+        print(f"  -> Cache root: {root} (same as install root)")
+        return root
+
+    default = str(suggested) if suggested != root else None
+    while True:
+        value = prompt_with_default("  Cache root", default)
+        if value:
+            return Path(value).expanduser()
+        print(
+            "  A cache root is required — answer 'n' to keep it under the install root.",
+            file=sys.stderr,
+        )
+
+
 def cmd_init(args) -> int:
     """
     Interactive initialization of rootstock configuration.
@@ -84,6 +132,13 @@ def cmd_init(args) -> int:
 
     print()
 
+    # Settled here, next to the root question it belongs with, but only when
+    # there is somewhere to record it — --skip-dirs writes no layout marker,
+    # so asking would discard the answer.
+    cache_root = resolve_init_cache_root(args, root, cluster) if not args.skip_dirs else None
+
+    print()
+
     # Ask if user is the maintainer
     print("Are you the maintainer of this rootstock installation?")
     print("Maintainers can configure API credentials to push manifests to the backend.")
@@ -121,12 +176,6 @@ def cmd_init(args) -> int:
     # path or different filesystems depending on the cluster.
     if not args.skip_dirs:
         print("\nCreating directory structure...")
-        from ..clusters import get_cluster
-
-        if cluster:
-            cache_root = get_cluster(cluster).resolved_cache_root
-        else:
-            cache_root = root
 
         dirs_to_create = [
             root / "environments",

--- a/rootstock/commands/install.py
+++ b/rootstock/commands/install.py
@@ -16,7 +16,7 @@ from ..operations import OperationError, install_environment
 from .common import get_root_or_exit, resolve_cache_root
 
 
-def _warn_on_permissions(root: Path) -> None:
+def _warn_on_permissions(root: Path, cache_root: Path) -> None:
     """Best-effort, bounded permission check run up front (warn-only).
 
     A shared install with the wrong perms "works for the maintainer, breaks for
@@ -26,7 +26,7 @@ def _warn_on_permissions(root: Path) -> None:
     """
     from ..perms import check_permissions
 
-    issues = check_permissions(root, resolve_cache_root(root))
+    issues = check_permissions(root, cache_root)
     if not issues:
         return
 
@@ -111,15 +111,24 @@ def cmd_install(args) -> int:
         )
         return 1
 
+    # Deliberately not overridable here. Where the weights live is a
+    # deployment-time decision (`rootstock init --cache-root`), not a
+    # per-build one: install runs once per environment and on every rebuild,
+    # so a flag here would let one stray invocation re-point the declaration
+    # and scatter checkpoints across two filesystems. Changing it on a
+    # populated install means editing {root}/layout.json and moving the
+    # weights, which should be deliberate.
+    cache_root = resolve_cache_root(root)
+
     # Surface permission problems before the (slow) build starts.
     if not getattr(args, "no_perm_check", False):
-        _warn_on_permissions(root)
+        _warn_on_permissions(root, cache_root)
 
     # Stamp (or backfill, for pre-marker installs) the layout version, and
     # make the install self-describing: declare its cache root. For legacy
     # roots without a declaration this persists the registry's answer, so
     # the install keeps working after pinned clients' registries go stale.
-    write_layout_marker(root, cache_root=resolve_cache_root(root))
+    write_layout_marker(root, cache_root=cache_root)
 
     # DIRECTORY MODE: install all *.py files
     if source_path.is_dir():

--- a/tests/cli/test_init_cache_root.py
+++ b/tests/cli/test_init_cache_root.py
@@ -1,0 +1,133 @@
+"""Tests for how ``rootstock init`` settles the model-weight cache root."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from rootstock.commands.init import resolve_init_cache_root
+
+
+def _args(**overrides):
+    base = dict(cache_root=None, skip_dirs=False, skip_manifest=True)
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _answers(monkeypatch, *responses):
+    """Feed successive replies to the prompts, failing on an unexpected one.
+
+    Returns the list the prompts land in — monkeypatching ``input`` means the
+    prompt text never reaches stdout, so assertions about defaults read here.
+    """
+    queue = list(responses)
+    prompts: list[str] = []
+
+    def fake_input(prompt=""):
+        prompts.append(prompt)
+        if not queue:
+            raise AssertionError(f"unexpected extra prompt: {prompt!r}")
+        return queue.pop(0)
+
+    monkeypatch.setattr("builtins.input", fake_input)
+    return prompts
+
+
+def test_explicit_flag_wins_without_prompting(monkeypatch):
+    _answers(monkeypatch)  # any prompt at all is a failure
+    got = resolve_init_cache_root(
+        _args(cache_root="/scratch/me/rs-cache"), Path("/install"), "perlmutter"
+    )
+    assert got == Path("/scratch/me/rs-cache")
+
+
+def test_explicit_flag_expands_user(monkeypatch):
+    _answers(monkeypatch)
+    got = resolve_init_cache_root(_args(cache_root="~/rs-cache"), Path("/install"), None)
+    assert got == Path.home() / "rs-cache"
+
+
+def test_explicit_flag_keeps_symlinks_uncollapsed(monkeypatch, tmp_path):
+    """The declaration is read by other users' clients, so keep it verbatim."""
+    real = tmp_path / "real-cache"
+    real.mkdir()
+    link = tmp_path / "link-cache"
+    link.symlink_to(real)
+
+    _answers(monkeypatch)
+    got = resolve_init_cache_root(_args(cache_root=str(link)), Path("/install"), None)
+    assert got == link
+
+
+def test_declining_the_split_uses_install_root(monkeypatch):
+    _answers(monkeypatch, "n")
+    assert resolve_init_cache_root(_args(), Path("/install"), None) == Path("/install")
+
+
+def test_accepting_the_split_takes_the_typed_path(monkeypatch):
+    _answers(monkeypatch, "y", "/scratch/me/rs-cache")
+    got = resolve_init_cache_root(_args(), Path("/install"), None)
+    assert got == Path("/scratch/me/rs-cache")
+
+
+def test_unknown_cluster_defaults_to_no_split(monkeypatch):
+    """With no registry hint the default answer is 'same filesystem'."""
+    prompts = _answers(monkeypatch, "")  # accept the default
+    assert resolve_init_cache_root(_args(), Path("/install"), None) == Path("/install")
+    assert "(y/n) [n]" in prompts[0]
+
+
+def test_registry_split_is_offered_as_the_default(monkeypatch):
+    """Perlmutter is registered split, so both prompts should pre-fill."""
+    from rootstock.clusters import get_cluster
+
+    expected = get_cluster("perlmutter").resolved_cache_root
+    prompts = _answers(monkeypatch, "", "")  # accept both defaults
+    got = resolve_init_cache_root(_args(), get_cluster("perlmutter").root, "perlmutter")
+    assert got == expected
+
+    assert "(y/n) [y]" in prompts[0]
+    assert str(expected) in prompts[1]
+
+
+def test_registry_suggestion_is_overridable(monkeypatch):
+    """The whole point: a stale baked-in registry must not bind the install."""
+    from rootstock.clusters import get_cluster
+
+    _answers(monkeypatch, "y", "/pscratch/somewhere/else")
+    got = resolve_init_cache_root(_args(), get_cluster("perlmutter").root, "perlmutter")
+    assert got == Path("/pscratch/somewhere/else")
+
+
+def test_registry_split_can_be_declined(monkeypatch):
+    from rootstock.clusters import get_cluster
+
+    root = get_cluster("perlmutter").root
+    _answers(monkeypatch, "n")
+    assert resolve_init_cache_root(_args(), root, "perlmutter") == root
+
+
+def test_empty_answer_without_a_default_reprompts(monkeypatch, capsys):
+    _answers(monkeypatch, "y", "", "/scratch/me/rs-cache")
+    got = resolve_init_cache_root(_args(), Path("/install"), None)
+    assert got == Path("/scratch/me/rs-cache")
+    assert "A cache root is required" in capsys.readouterr().err
+
+
+def test_skip_dirs_asks_nothing(monkeypatch, tmp_path):
+    """No layout marker gets written, so there is nothing to ask about."""
+    from rootstock.commands.init import cmd_init
+
+    _answers(monkeypatch, str(tmp_path), "n")  # root, then maintainer? -> n
+    monkeypatch.setattr("rootstock.commands.init.save_config", lambda config: None)
+    rc = cmd_init(_args(skip_dirs=True))
+    assert rc == 0
+    assert not (tmp_path / "layout.json").exists()
+
+
+@pytest.mark.parametrize("reply", ["y", "Y", "yes", "YES"])
+def test_yes_spellings(monkeypatch, reply):
+    _answers(monkeypatch, reply, "/scratch/c")
+    assert resolve_init_cache_root(_args(), Path("/install"), None) == Path("/scratch/c")

--- a/tests/cli/test_install_cache_root.py
+++ b/tests/cli/test_install_cache_root.py
@@ -1,0 +1,94 @@
+"""How ``rootstock install`` treats the declared model-weight cache root.
+
+Where the cache lives is a deployment-time decision made by ``rootstock
+init``; install only backfills the declaration when it is missing. These
+tests pin that boundary — a rebuild must never re-point a deployment.
+The build itself is stubbed out.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from rootstock.commands.install import cmd_install
+from rootstock.layout import read_declared_cache_root, write_layout_marker
+
+
+def _args(root, **overrides):
+    base = dict(
+        source="mace",
+        root=str(root),
+        models=None,
+        force=False,
+        upgrade=False,
+        verbose=False,
+        no_push=True,
+        no_perm_check=True,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+@pytest.fixture
+def stub_build(monkeypatch):
+    """Neutralize everything except the cache-root bookkeeping."""
+    monkeypatch.setattr("rootstock.environment.check_uv_available", lambda: True)
+    monkeypatch.setattr(
+        "rootstock.commands.install.install_environment",
+        lambda *a, **kw: None,
+    )
+
+
+def test_backfills_the_install_root_when_undeclared(tmp_path, stub_build):
+    assert cmd_install(_args(tmp_path)) == 0
+    assert read_declared_cache_root(tmp_path) == tmp_path
+
+
+def test_existing_declaration_is_preserved(tmp_path, stub_build):
+    write_layout_marker(tmp_path, cache_root="/declared/cache")
+    assert cmd_install(_args(tmp_path)) == 0
+    assert read_declared_cache_root(tmp_path) == Path("/declared/cache")
+
+
+def test_repeated_installs_do_not_drift(tmp_path, stub_build):
+    write_layout_marker(tmp_path, cache_root="/declared/cache")
+    for _ in range(3):
+        assert cmd_install(_args(tmp_path)) == 0
+    assert read_declared_cache_root(tmp_path) == Path("/declared/cache")
+
+
+def test_install_rejects_a_cache_root_flag():
+    """Regression guard: the cache location is not a per-build override.
+
+    `init` owns it. If this starts passing, a rebuild can silently re-point a
+    deployment's weights — see the comment in cmd_install.
+    """
+    import subprocess
+
+    out = subprocess.run(
+        ["uv", "run", "rootstock", "install", "mace", "--cache-root", "/tmp/x"],
+        capture_output=True,
+        text=True,
+    )
+    assert out.returncode == 2
+    assert "unrecognized arguments: --cache-root" in out.stderr
+
+
+def test_permission_check_uses_the_declared_cache_root(tmp_path, monkeypatch, stub_build):
+    """The pre-build warning must stat the split cache root, not the install root."""
+    write_layout_marker(tmp_path, cache_root="/declared/cache")
+    seen = {}
+
+    def fake_check(install_root, cache_root=None, **kwargs):
+        seen["install"] = install_root
+        seen["cache"] = cache_root
+        return []
+
+    monkeypatch.setattr("rootstock.perms.check_permissions", fake_check)
+
+    cmd_install(_args(tmp_path, no_perm_check=False))
+    assert seen["install"] == tmp_path
+    assert seen["cache"] == Path("/declared/cache")


### PR DESCRIPTION
## Why

The model-weight cache root was only ever settable through the cluster registry, which is baked into each client release. A maintainer running a pinned client bakes *that release's* cache path into `{root}/layout.json` — and since the declaration then outranks the registry for every later reader, one stale client permanently mis-points a fresh deployment. That's exactly the coupling `layout.json` was introduced to break.

Concretely, this bit us on Perlmutter: the deployment is moving to `/pscratch/sd/o/oprice/rootstock-cache` (#148), but `rootstock init` from PyPI `v1.0.0` would happily create `cache/` and `home/` under the *old* maintainer's pscratch and declare it, because that's what the v1.0.0 registry says. There was no flag to say otherwise.

## What

`rootstock init` takes `--cache-root`, and **asks** when the flag is omitted:

```
Model weights can live on a different filesystem than the install
itself — some clusters require it (the project filesystem may not
support flock, or weights may belong on scratch).
Cache on a different filesystem? (y/n) [y]:
  Cache root [/pscratch/sd/w/wengler/rootstock-cache]:
```

The suggestion is seeded from the registry when the root belongs to a known cluster, so the common case is still two Enters — but it's now a visible hint the maintainer can override, rather than a silent default. The question is asked next to the root prompt it belongs with, and skipped under `--skip-dirs` (which writes no layout marker, so the answer would be discarded).

## `install` deliberately does not take the flag

An earlier revision of this PR added `--cache-root` to `install` too. That was wrong: where the weights live is a deployment-time decision, not a per-build one. `install` runs once per environment and again on every rebuild, so an override there lets a single stray invocation re-point the declaration and scatter checkpoints across two filesystems — when the whole point is that checkpoints live together.

`install`'s behavior is therefore **unchanged**: it still backfills the declaration when one is absent and preserves an existing one. The only edits to it here are a resolve-once tidy-up and a comment recording why the flag is absent, plus tests pinning that boundary.

Changing the cache root on a *populated* install means editing `cache_root` in `{root}/layout.json` and moving `cache/` + `home/` (or re-running `rootstock add` to re-download). Deliberately awkward. Note that re-running `rootstock init` is **not** a substitute — it calls `create_manifest` and saves a fresh manifest, losing recorded environment state; the docs now say so.

## Other notes

Paths are `expanduser()`'d but deliberately **not** `resolve()`'d. The value is written verbatim into `layout.json` and read by every other user's client, so the canonical path the maintainer typed travels better than one node's symlink-collapsed view. (`init` still resolves the *install* root, as before — unchanged.)

## Test plan

- [x] 20 new tests across `tests/cli/test_init_cache_root.py` and `tests/cli/test_install_cache_root.py` — flag-wins-without-prompting, prompt defaults for known/unknown clusters, overriding a registry suggestion, declining the split, re-prompt on empty input, `--skip-dirs` asks nothing; and on the install side: backfill when undeclared, existing declaration preserved, no drift across repeated installs, the permission check targeting the declared cache root, and a regression guard that `install --cache-root` is still rejected.
- [x] Full suite: 396 passed, 2 skipped.
- [x] Exercised the real CLI end to end under a redirected `HOME` — declining the split, accepting it, and `--cache-root` — confirming `layout.json` records the right path and `cache/` + `home/` land under the cache root while `environments/`, `envs/`, `.python/` stay under the install root.

`ruff check` reports 5 pre-existing errors on `main` (unrelated files); the files touched here are clean.

## Note for reviewers

Stacked conceptually on #148 but branched from `main` and independent of it — either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
