### PR TITLE
Local checkpoints: bring your own weights via rootstock add-local

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,14 @@ rootstock install <env_source.py> [--root <path>] [--force] [--upgrade]
 # Download + verify a checkpoint by canonical id (idempotent). Use --no-verify on login nodes.
 rootstock add <checkpoint-id> [--kwarg key=val ...] [--device cuda] [--no-verify]
 
-# Re-verify all fetched checkpoints (suitable for nightly cron)
+# Register/remove a user-supplied weights file as a checkpoint (per-user
+# registry at ~/.config/rootstock/local-checkpoints.json; no shared-root
+# writes). The env must declare setup_from_path().
+rootstock add-local <weights-path> --env <env> --id <id> [--kwarg key=val ...] [--no-verify]
+rootstock remove-local <id>
+
+# Re-verify all fetched checkpoints plus the user's local checkpoints
+# (suitable for nightly cron)
 rootstock smoke-test [--env ENV] [--checkpoint CKPT] [--device cuda] [--json]
 
 # Show status (per-checkpoint verified/stale grid; --json for machine-readable)
@@ -137,6 +144,12 @@ with RootstockCalculator(
     checkpoint="uma-s-1p1",
     setup_kwargs={"task": "omol"},
 ) as calc:
+    ...
+
+# Local checkpoints (registered via `rootstock add-local`) resolve the same
+# way — canonical ids are checked first, then the per-user registry. The
+# worker then loads via the env's setup_from_path() instead of setup().
+with RootstockCalculator(cluster="delta", checkpoint="my-uma-ft") as calc:
     ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,15 @@ rootstock add uma-s-1p1 --kwarg task=omat
 
 `rootstock status` shows a per-checkpoint grid of fetched/verified/stale state. See the [dashboard](https://garden-ai-prod--rootstock-admin-dashboard.modal.run/) for environment files that are known to work.
 
+Users can also bring their own weights (e.g. a fine-tuned UMA model) without any write access to the shared install — `rootstock add-local` registers a local file under a checkpoint id that then works everywhere a canonical id does:
+
+```bash
+rootstock add-local /scratch/me/my-uma-ft.pt --env uma --id my-uma-ft --kwarg task=omol
+rootstock remove-local my-uma-ft   # delete the registration (never the file)
+```
+
+The registration lives in the per-user registry (`~/.config/rootstock/local-checkpoints.json`); the hosting env must declare a `setup_from_path()` function (see [docs/environments.md](docs/environments.md)).
+
 ### 5. Register with the dashboard (optional)
 
 If you configured API credentials during `rootstock init`, the manifest is pushed automatically when you install or update environments. If the push failed (e.g., due to network issues), you can retry:

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,12 +27,12 @@ with RootstockCalculator(
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `checkpoint` | `str` | Yes | Canonical checkpoint id (e.g., `"mace-mp-0-medium"`, `"uma-s-1p1"`). The hosting env is resolved automatically by walking the installed envs and matching against each env's `CHECKPOINTS` table |
+| `checkpoint` | `str` | Yes | Checkpoint id — either a canonical id (e.g., `"mace-mp-0-medium"`, `"uma-s-1p1"`) or one you registered with `rootstock add-local`. The hosting env is resolved automatically: installed envs' `CHECKPOINTS` tables first, then your local-checkpoint registry |
 | `cluster` | `str` | Yes* | Cluster name (e.g., `"delta"`, `"perlmutter"`) |
 | `root` | `str` | Yes* | Custom install-root path instead of a known cluster |
 | `cache_root` | `str` | No | Override path for the model-weight cache and redirected `HOME`. When omitted, the install's own declaration (`{root}/layout.json`) decides, falling back to the cluster registry for legacy roots, then to `root` |
 | `device` | `str` | No | `"cuda"` (default) or `"cpu"` |
-| `setup_kwargs` | `dict` | No | Extra keyword arguments forwarded to the env's `setup()` function (e.g., `{"task": "omol"}`). Cannot contain `checkpoint` or `device` |
+| `setup_kwargs` | `dict` | No | Extra keyword arguments forwarded to the env's `setup()` function (e.g., `{"task": "omol"}`). Cannot contain `checkpoint` or `device`. For a local checkpoint, these merge over the kwargs recorded at `add-local` time (per-call wins) and go to `setup_from_path()` instead |
 | `timeout` | `float` | No | Socket timeout in seconds for worker operations (default 600, matching checkpoint verification — so the first real force call, which may pay for `torch.compile` or large neighbor lists, runs under the envelope verification exercised) |
 
 *`cluster` and `root` are mutually exclusive. When neither is given, the calculator falls back to the `ROOTSTOCK_ROOT` environment variable and then the `root` in `~/.config/rootstock/config.toml` — the same resolution the CLI uses — so on a configured machine `RootstockCalculator(checkpoint=...)` alone works.
@@ -110,6 +110,32 @@ rootstock status
 
 This command displays installed environments, their checkpoints, and cache sizes.
 
+### Local checkpoints (bring your own weights)
+
+A fine-tuned or otherwise user-supplied weights file can be registered under
+a checkpoint id of your choosing, bound to an installed env that declares the
+`setup_from_path` hook (see [Adding Models](environments.md)):
+
+```bash
+rootstock add-local /scratch/me/my-uma-ft.pt --env uma --id my-uma-ft --kwarg task=omol
+```
+
+Registration hashes the file, records it in your per-user registry
+(`~/.config/rootstock/local-checkpoints.json`), and runs the same
+verification as `rootstock add`. Nothing is written to the shared install —
+this works against a read-only shared root. The id then behaves like any
+canonical id:
+
+```python
+RootstockCalculator(cluster="sophia", checkpoint="my-uma-ft", device="cuda")
+```
+
+`rootstock status` shows your local checkpoints (verification state, file
+presence, staleness after env rebuilds), `rootstock smoke-test` re-verifies
+them (after re-hashing, so a swapped file is caught), and
+`rootstock remove-local <id>` deletes the registration — never the weights
+file.
+
 ## CLI reference
 
 The Rootstock CLI provides commands for both administrators (setting up clusters) and users (querying available environments).
@@ -144,6 +170,28 @@ rootstock resolve --cluster delta
 
 # JSON output
 rootstock resolve --cluster delta --json
+```
+
+#### `rootstock add-local`
+
+Register your own weights file (e.g. a fine-tune) as a checkpoint. Per-user;
+requires no write access to the shared install. The target env must declare
+`setup_from_path` (registration errors otherwise, listing the envs that do).
+
+```bash
+rootstock add-local /scratch/me/my-uma-ft.pt --env uma --id my-uma-ft --kwarg task=omol
+
+# On a login node without a GPU: register now, verify later via smoke-test
+rootstock add-local /scratch/me/my-uma-ft.pt --env uma --id my-uma-ft --no-verify
+```
+
+#### `rootstock remove-local`
+
+Delete a local checkpoint's registry entry. The weights file is never
+touched.
+
+```bash
+rootstock remove-local my-uma-ft
 ```
 
 ### Administrator commands

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -129,6 +129,43 @@ Signature: `setup(checkpoint: str, device: str = "cuda", **extra)`.
 
 Return: an ASE-compatible calculator.
 
+### `setup_from_path()` function (optional — enables local checkpoints)
+
+Declaring a module-level `setup_from_path` opts the env into **local
+checkpoints**: user-supplied weights files (e.g. fine-tunes) registered with
+`rootstock add-local`. Envs without it don't support them, and registration
+fails with a clear error. Like `CHECKPOINTS`, presence is detected by parsing
+the source — the module is not executed.
+
+Signature: `setup_from_path(path: str, device: str = "cuda", **extra)`.
+
+- `path`: Absolute filesystem path to the weights file. Loading a file is
+  usually a *different* upstream call than loading a registry name — e.g.
+  FAIRChem's `load_predict_unit(path)` vs `get_predict_unit(name)` — which is
+  why this is a separate function rather than a path-shaped `checkpoint`.
+- `device`, extra kwargs: as for `setup()`. Give extras defaults where
+  possible; a fine-tune needing a required kwarg still works (the kwarg is
+  recorded at `rootstock add-local --kwarg ...` time), but defaults make
+  registration friendlier.
+
+Return: an ASE-compatible calculator.
+
+```python
+def setup_from_path(path: str, device: str = "cuda", task: str = "omat"):
+    from fairchem.core import FAIRChemCalculator
+    from fairchem.core.units.mlip_unit import load_predict_unit
+
+    predictor = load_predict_unit(path, device=device)
+    return FAIRChemCalculator(predictor, task_name=task)
+```
+
+One rebuild hazard to know about: registration checks the env source at
+registration time. If the env is later rebuilt (`rootstock install --force`)
+from a source that dropped `setup_from_path`, existing registrations break at
+worker startup. `rootstock status` flags registered checkpoints as stale
+after any env rebuild, and `rootstock smoke-test` re-verifies them — that's
+the detection path.
+
 ## Examples
 
 ### MACE (MP-0 and OFF23 in one env)

--- a/docs/nightly-smoke-testing.md
+++ b/docs/nightly-smoke-testing.md
@@ -9,6 +9,13 @@ automated smoke-test rotation.
 pass each) and pushes the refreshed `manifest.json` to the backend. Running it
 on a schedule keeps each cluster's manifest honest about checkpoint health.
 
+It also covers the running user's **local checkpoints** (`rootstock
+add-local`): each is re-hashed against its registered sha256 (a swapped file
+fails without being verified) and then verified with its registered kwargs;
+those outcomes are written to the per-user registry, not the shared manifest.
+A run that tests only local checkpoints never writes the manifest at all, so
+non-maintainers can schedule their own re-verification too.
+
 The mechanism is a **self-scheduling batch job**: a single GPU job that first
 re-queues its own next run, then runs the smoke-test. The only state that
 persists between runs is "a job is queued for next time," which the job

--- a/rootstock/benchmark.py
+++ b/rootstock/benchmark.py
@@ -184,7 +184,6 @@ def run_worker_mode(args) -> int:
     Emits one JSON line to stdout: ``RESULT <json>``.
     """
     sys.path.insert(0, args.env_dir)
-    from env_source import setup  # type: ignore
 
     data = np.load(args.worker_data)
     from ase import Atoms
@@ -202,8 +201,17 @@ def run_worker_mode(args) -> int:
 
     setup_kwargs = json.loads(args.setup_kwargs) if args.setup_kwargs else {}
 
+    # Mirror the real worker wrapper's branch: local checkpoints load through
+    # the env's setup_from_path hook, canonical ids through setup().
     t0 = time.perf_counter()
-    calc = setup(args.checkpoint, args.device, **setup_kwargs)
+    if getattr(args, "checkpoint_path", None):
+        from env_source import setup_from_path  # type: ignore
+
+        calc = setup_from_path(args.checkpoint_path, args.device, **setup_kwargs)
+    else:
+        from env_source import setup  # type: ignore
+
+        calc = setup(args.checkpoint, args.device, **setup_kwargs)
     load_s = time.perf_counter() - t0
 
     result = time_force_loop(atoms, calc, data["frames"], int(data["n_warmup"]))
@@ -219,7 +227,7 @@ def run_worker_mode(args) -> int:
 
 def run_in_env_arm(root: Path, cache_root: Path | None, env_name: str, env_dir: Path,
                    checkpoint: str, device: str, setup_kwargs: dict,
-                   npz_path: Path) -> dict:
+                   npz_path: Path, checkpoint_path: str | None = None) -> dict:
     """Spawn the env's python in worker mode and parse its JSON result.
 
     Reproduces Rootstock's own subprocess environment (the HOME/cache redirect
@@ -246,6 +254,8 @@ def run_in_env_arm(root: Path, cache_root: Path | None, env_name: str, env_dir: 
         "--worker-data", str(npz_path),
         "--setup-kwargs", json.dumps(setup_kwargs),
     ]
+    if checkpoint_path:
+        cmd += ["--checkpoint-path", checkpoint_path]
     proc = subprocess.run(cmd, env=env, capture_output=True, text=True)
     if proc.returncode != 0:
         raise RuntimeError(
@@ -280,10 +290,15 @@ def run_rootstock_arm(root: Path, cache_root: Path | None, cluster: str | None,
 def benchmark_one(checkpoint: str, device: str, root: Path, cache_root: Path | None,
                   cluster: str | None, atoms, frames: np.ndarray, n_warmup: int,
                   setup_kwargs: dict, work_dir: Path) -> dict:
-    from rootstock.environment import find_env_for_checkpoint
+    from rootstock.local_checkpoints import resolve_checkpoint
 
-    env_name, _ = find_env_for_checkpoint(root, checkpoint)
+    resolved = resolve_checkpoint(root, checkpoint)
+    env_name = resolved.env_name
     env_dir = root / "envs" / env_name
+    # Registered defaults for a local checkpoint; explicit --setup-kwargs
+    # wins. Both arms get the identical merged dict (the managed arm's
+    # calculator re-merges, with the same precedence, to the same result).
+    setup_kwargs = {**resolved.setup_kwargs, **setup_kwargs}
 
     # Serialize the system + identical trajectory once; both arms read it.
     npz_path = work_dir / f"frames_{checkpoint.replace('/', '_')}_{device}.npz"
@@ -298,14 +313,17 @@ def benchmark_one(checkpoint: str, device: str, root: Path, cache_root: Path | N
 
     print(f"  [in-env]    {checkpoint} on {device} via {env_name} ...", flush=True)
     direct = run_in_env_arm(root, cache_root, env_name, env_dir, checkpoint,
-                            device, setup_kwargs, npz_path)
+                            device, setup_kwargs, npz_path,
+                            checkpoint_path=resolved.path)
 
     print(f"  [rootstock] {checkpoint} on {device} (IPC) ...", flush=True)
     rs = run_rootstock_arm(root, cache_root, cluster, checkpoint, device,
                            setup_kwargs, atoms, frames, n_warmup)
 
     overhead_ms = rs["median_ms"] - direct["median_ms"]
-    overhead_pct = 100.0 * overhead_ms / direct["median_ms"] if direct["median_ms"] else float("nan")
+    overhead_pct = (
+        100.0 * overhead_ms / direct["median_ms"] if direct["median_ms"] else float("nan")
+    )
 
     return {
         "checkpoint": checkpoint,
@@ -342,6 +360,7 @@ def print_table(results: list[dict]) -> None:
 
 def list_available(root: Path) -> int:
     from rootstock.environment import list_declared_checkpoints
+    from rootstock.local_checkpoints import LocalCheckpointError, local_checkpoints_for_root
 
     declared = list_declared_checkpoints(root)
     if not declared:
@@ -351,6 +370,13 @@ def list_available(root: Path) -> int:
     for env, ckpts in declared.items():
         ids = ", ".join(ckpts) if ckpts else "(none)"
         print(f"  {env:<16} {ids}")
+    try:
+        local = local_checkpoints_for_root(root)
+    except LocalCheckpointError:
+        local = {}
+    if local:
+        ids = ", ".join(sorted(local))
+        print(f"  {'(local)':<16} {ids}")
     print("\nPass a few of these to --checkpoints.")
     return 0
 
@@ -376,7 +402,8 @@ def main(argv=None) -> int:
                    help="Per-step Gaussian displacement (A) for the replay trajectory.")
     p.add_argument("--seed", type=int, default=42)
     p.add_argument("--setup-kwargs", default="",
-                   help="JSON forwarded to setup() for every checkpoint (e.g. '{\"task\":\"omat\"}').")
+                   help='JSON forwarded to setup() for every checkpoint '
+                        '(e.g. \'{"task":"omat"}\').')
     p.add_argument("--out", help="Write full results JSON here.")
     p.add_argument("--list", action="store_true", help="List installed checkpoints and exit.")
 
@@ -384,6 +411,7 @@ def main(argv=None) -> int:
     p.add_argument("--worker-mode", action="store_true", help=argparse.SUPPRESS)
     p.add_argument("--env-dir", help=argparse.SUPPRESS)
     p.add_argument("--checkpoint", help=argparse.SUPPRESS)
+    p.add_argument("--checkpoint-path", help=argparse.SUPPRESS)
     p.add_argument("--device", help=argparse.SUPPRESS)
     p.add_argument("--worker-data", help=argparse.SUPPRESS)
 

--- a/rootstock/benchmark.py
+++ b/rootstock/benchmark.py
@@ -293,6 +293,15 @@ def benchmark_one(checkpoint: str, device: str, root: Path, cache_root: Path | N
     from rootstock.local_checkpoints import resolve_checkpoint
 
     resolved = resolve_checkpoint(root, checkpoint)
+    if resolved.is_local and not Path(resolved.path).exists():
+        # Same guard as the calculator — fail before either arm spawns,
+        # not as a raw subprocess traceback from the in-env worker.
+        raise RuntimeError(
+            f"local checkpoint '{checkpoint}' points at {resolved.path}, "
+            f"which no longer exists. Re-register it with `rootstock "
+            f"add-local` or remove it with `rootstock remove-local "
+            f"{checkpoint}`."
+        )
     env_name = resolved.env_name
     env_dir = root / "envs" / env_name
     # Registered defaults for a local checkpoint; explicit --setup-kwargs
@@ -372,7 +381,8 @@ def list_available(root: Path) -> int:
         print(f"  {env:<16} {ids}")
     try:
         local = local_checkpoints_for_root(root)
-    except LocalCheckpointError:
+    except LocalCheckpointError as exc:
+        print(f"Warning: ignoring local-checkpoint registry: {exc}", file=sys.stderr)
         local = {}
     if local:
         ids = ", ".join(sorted(local))

--- a/rootstock/calculator.py
+++ b/rootstock/calculator.py
@@ -171,6 +171,14 @@ class RootstockCalculator(Calculator):
         # Registration already rejected reserved keys in the defaults.
         self.setup_kwargs = {**resolved.setup_kwargs, **setup_kwargs}
 
+        if resolved.is_local and "path" in setup_kwargs:
+            # setup_from_path's first parameter — fail here, not as a
+            # TypeError inside the worker.
+            raise TypeError(
+                "setup_kwargs cannot contain 'path' for a local checkpoint; "
+                "the registered weights path is passed at the top level."
+            )
+
         if resolved.is_local and not Path(resolved.path).exists():
             # Fail at construction, not as a WorkerDiedError post-mortem
             # minutes into a batch job.

--- a/rootstock/calculator.py
+++ b/rootstock/calculator.py
@@ -15,8 +15,8 @@ from ase.stress import full_3x3_to_voigt_6_stress
 
 from .clusters import get_cluster
 from .config import resolve_default_root
-from .environment import find_env_for_checkpoint
 from .layout import ensure_layout_compatible, resolve_cache_root
+from .local_checkpoints import LocalCheckpointError, resolve_checkpoint
 from .server import RootstockServer, WorkerDiedError
 
 
@@ -56,7 +56,9 @@ class RootstockCalculator(Calculator):
     Note:
         Environments must be pre-built with `rootstock install` before use.
         The hosting env is resolved automatically by walking the installed envs
-        and matching the checkpoint id against each env file's `CHECKPOINTS`.
+        and matching the checkpoint id against each env file's `CHECKPOINTS`,
+        then against the user's local-checkpoint registry (weights files
+        registered with `rootstock add-local`).
     """
 
     implemented_properties = ["energy", "free_energy", "forces", "stress"]
@@ -129,7 +131,6 @@ class RootstockCalculator(Calculator):
 
         self.checkpoint = checkpoint
         self.device = device
-        self.setup_kwargs = setup_kwargs
         self.timeout = timeout
 
         # Resolve the install root: the cluster name is only a name -> path
@@ -160,10 +161,25 @@ class RootstockCalculator(Calculator):
         # misleading resolution error.
         ensure_layout_compatible(self.root)
 
-        # Resolve env name from the canonical checkpoint id by walking the
-        # installed envs at self.root. Raises CheckpointNotFoundError with a
-        # helpful listing if no env declares this id.
-        self.env_name, _ = find_env_for_checkpoint(self.root, checkpoint)
+        # Resolve the checkpoint id: env-declared canonical ids first, then
+        # the user's local-checkpoint registry. Raises CheckpointNotFoundError
+        # with a listing of both namespaces if nothing matches.
+        resolved = resolve_checkpoint(self.root, checkpoint)
+        self.env_name = resolved.env_name
+        self.checkpoint_path = resolved.path
+        # Registered defaults for a local checkpoint; per-call kwargs win.
+        # Registration already rejected reserved keys in the defaults.
+        self.setup_kwargs = {**resolved.setup_kwargs, **setup_kwargs}
+
+        if resolved.is_local and not Path(resolved.path).exists():
+            # Fail at construction, not as a WorkerDiedError post-mortem
+            # minutes into a batch job.
+            raise LocalCheckpointError(
+                f"local checkpoint '{checkpoint}' points at {resolved.path}, "
+                f"which no longer exists. Re-register it with `rootstock "
+                f"add-local` or remove it with `rootstock remove-local "
+                f"{checkpoint}`."
+            )
 
         # Generate unique socket name to avoid conflicts
         self._socket_name = f"rootstock_{uuid.uuid4().hex[:8]}"
@@ -181,6 +197,7 @@ class RootstockCalculator(Calculator):
                 cache_root=self.cache_root,
                 setup_kwargs=self.setup_kwargs,
                 timeout=self.timeout,
+                checkpoint_path=self.checkpoint_path,
             )
             self._server.start()
 

--- a/rootstock/cli.py
+++ b/rootstock/cli.py
@@ -54,6 +54,7 @@ import sys
 from . import __version__
 from .commands import (
     cmd_add,
+    cmd_add_local,
     cmd_benchmark,
     cmd_check_perms,
     cmd_init,
@@ -63,6 +64,7 @@ from .commands import (
     cmd_manifest_push,
     cmd_manifest_show,
     cmd_new_env,
+    cmd_remove_local,
     cmd_resolve,
     cmd_serve,
     cmd_setup_perms,
@@ -235,14 +237,85 @@ def main():
     )
     add_parser.set_defaults(func=cmd_add)
 
+    # add-local command
+    add_local_parser = subparsers.add_parser(
+        "add-local",
+        help="Register a local weights file (e.g. a fine-tune) as a checkpoint",
+        description=(
+            "Register a user-supplied weights file under a checkpoint id, "
+            "bound to an installed env. The env must declare a "
+            "setup_from_path(path, device, **kwargs) function (opt-in; see "
+            "docs/environments.md). Nothing is written to the shared install "
+            "— the registration lives in the per-user registry "
+            "(~/.config/rootstock/local-checkpoints.json) and the weights "
+            "file stays where it is. The id then works everywhere a "
+            "canonical id does."
+        ),
+    )
+    add_local_parser.add_argument("path", help="Path to the weights file")
+    add_local_parser.add_argument(
+        "--env",
+        required=True,
+        help="Installed env that hosts this checkpoint (must declare setup_from_path)",
+    )
+    add_local_parser.add_argument(
+        "--id",
+        required=True,
+        help="Checkpoint id to register (must not collide with a canonical id)",
+    )
+    add_local_parser.add_argument(
+        "--kwarg",
+        action="append",
+        metavar="KEY=VAL",
+        help=(
+            "Default kwarg passed to setup_from_path() whenever this "
+            "checkpoint is used (repeatable). Value is JSON-decoded first, "
+            "then falls back to a string. E.g., --kwarg task=omol"
+        ),
+    )
+    add_local_parser.add_argument(
+        "--device", default="cuda", help="Device for verify (default: cuda)"
+    )
+    add_local_parser.add_argument(
+        "--no-verify",
+        action="store_true",
+        help="Skip the verify phase. Login-node escape hatch.",
+    )
+    add_local_parser.add_argument(
+        "--root",
+        default=os.environ.get(ROOTSTOCK_ROOT_ENV),
+        help=f"Root directory (default: ${ROOTSTOCK_ROOT_ENV})",
+    )
+    add_local_parser.set_defaults(func=cmd_add_local)
+
+    # remove-local command
+    remove_local_parser = subparsers.add_parser(
+        "remove-local",
+        help="Remove a locally-registered checkpoint (never deletes weights)",
+        description=(
+            "Delete a local checkpoint's registry entry. The weights file is "
+            "never touched — the registry records it, it doesn't own it."
+        ),
+    )
+    remove_local_parser.add_argument("checkpoint", help="Registered checkpoint id")
+    remove_local_parser.add_argument(
+        "--root",
+        default=os.environ.get(ROOTSTOCK_ROOT_ENV),
+        help=f"Root directory (default: ${ROOTSTOCK_ROOT_ENV})",
+    )
+    remove_local_parser.set_defaults(func=cmd_remove_local)
+
     # smoke-test command
     smoke_parser = subparsers.add_parser(
         "smoke-test",
         help="Re-verify checkpoints already registered in the manifest",
         description=(
             "Re-verify checkpoints by running a forward pass on each. Never downloads. "
-            "Always uses setup_kwargs={} — checkpoints requiring non-default kwargs "
-            "may show as failing here even if they work in practice."
+            "Canonical checkpoints always use setup_kwargs={} — checkpoints requiring "
+            "non-default kwargs may show as failing here even if they work in practice. "
+            "The user's local checkpoints (rootstock add-local) are also tested: "
+            "re-hashed against their registered sha256, then verified with their "
+            "registered kwargs; outcomes go to the per-user registry, not the manifest."
         ),
     )
     smoke_parser.add_argument("--env", help="Filter to a single environment")

--- a/rootstock/commands/__init__.py
+++ b/rootstock/commands/__init__.py
@@ -6,6 +6,7 @@ from .check_perms import cmd_check_perms
 from .create import cmd_new_env
 from .init import cmd_init
 from .install import cmd_install
+from .local import cmd_add_local, cmd_remove_local
 from .manifest import cmd_manifest_init, cmd_manifest_push, cmd_manifest_show
 from .resolve import cmd_resolve
 from .serve import cmd_serve
@@ -15,6 +16,7 @@ from .status import cmd_list, cmd_status
 
 __all__ = [
     "cmd_add",
+    "cmd_add_local",
     "cmd_benchmark",
     "cmd_check_perms",
     "cmd_init",
@@ -24,6 +26,7 @@ __all__ = [
     "cmd_manifest_push",
     "cmd_manifest_show",
     "cmd_new_env",
+    "cmd_remove_local",
     "cmd_resolve",
     "cmd_serve",
     "cmd_setup_perms",

--- a/rootstock/commands/add.py
+++ b/rootstock/commands/add.py
@@ -89,8 +89,8 @@ def cmd_add(args) -> int:
             progress=print,
         )
     except (CheckpointNotFoundError, OperationError) as exc:
-        if isinstance(exc, CheckpointNotFoundError) and args.checkpoint in (
-            _local_checkpoints_or_empty(root)
+        if isinstance(exc, CheckpointNotFoundError) and (
+            args.checkpoint in _local_checkpoints_or_empty(root)
         ):
             print(
                 f"Error: '{args.checkpoint}' is a locally-registered "

--- a/rootstock/commands/add.py
+++ b/rootstock/commands/add.py
@@ -10,13 +10,25 @@ import sys
 from pathlib import Path
 
 from ..environment import CheckpointNotFoundError, list_declared_checkpoints
+from ..local_checkpoints import LocalCheckpointError, local_checkpoints_for_root
 from ..operations import OperationError, add_checkpoint, parse_setup_kwargs
 from .common import get_root_or_exit
 
 
+def _local_checkpoints_or_empty(root: Path) -> dict:
+    """The user's local checkpoints for this root; a corrupt registry warns
+    instead of breaking a read-only listing."""
+    try:
+        return local_checkpoints_for_root(root)
+    except LocalCheckpointError as exc:
+        print(f"Warning: ignoring local-checkpoint registry: {exc}", file=sys.stderr)
+        return {}
+
+
 def _print_checkpoint_catalog(root: Path) -> int:
     """Print every canonical checkpoint id ``rootstock add`` accepts, grouped
-    by hosting env. Returns a process exit code."""
+    by hosting env, plus the user's registered local checkpoints. Returns a
+    process exit code."""
     declared = list_declared_checkpoints(root)
     if not declared:
         print(
@@ -33,6 +45,12 @@ def _print_checkpoint_catalog(root: Path) -> int:
             continue
         for ckpt_id in ckpts:
             print(f"    {ckpt_id}")
+
+    local = _local_checkpoints_or_empty(root)
+    if local:
+        print("  local (this user — already registered, no add needed):")
+        for ckpt_id, entry in sorted(local.items()):
+            print(f"    {ckpt_id}  (env: {entry.env})")
     return 0
 
 
@@ -71,7 +89,17 @@ def cmd_add(args) -> int:
             progress=print,
         )
     except (CheckpointNotFoundError, OperationError) as exc:
-        print(f"Error: {exc}", file=sys.stderr)
+        if isinstance(exc, CheckpointNotFoundError) and args.checkpoint in (
+            _local_checkpoints_or_empty(root)
+        ):
+            print(
+                f"Error: '{args.checkpoint}' is a locally-registered "
+                f"checkpoint — it needs no `rootstock add`. Use it directly, "
+                f"or re-verify it with `rootstock smoke-test`.",
+                file=sys.stderr,
+            )
+        else:
+            print(f"Error: {exc}", file=sys.stderr)
         return 1
 
     return 0

--- a/rootstock/commands/local.py
+++ b/rootstock/commands/local.py
@@ -1,0 +1,103 @@
+"""``rootstock add-local`` / ``rootstock remove-local`` — per-user local
+checkpoints (user-supplied weights files).
+
+Unlike ``add``, nothing here touches the shared install: the weights stay
+wherever the user put them, and the registration lives in the per-user
+registry (see rootstock.local_checkpoints). That's what makes this usable
+by non-maintainers against a read-only shared root.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from ..local_checkpoints import (
+    LocalCheckpointError,
+    record_local_verification,
+    register_local_checkpoint,
+    remove_local_checkpoint,
+)
+from ..operations import parse_setup_kwargs
+from ..verify import verify_checkpoint
+from .common import get_root_or_exit, resolve_cache_root
+
+
+def cmd_add_local(args) -> int:
+    # Deliberately no umask(0o002) here (contrast cmd_add): the registry is a
+    # private per-user file and the weights file already exists — no shared
+    # writes happen.
+    root = get_root_or_exit(args)
+    cache_root = resolve_cache_root(root)
+    weights_path = Path(args.path).expanduser().resolve()
+
+    try:
+        setup_kwargs = parse_setup_kwargs(args.kwarg)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+    print(f"Hashing {weights_path} ...")
+    try:
+        entry = register_local_checkpoint(
+            root,
+            args.id,
+            args.env,
+            weights_path,
+            setup_kwargs=setup_kwargs,
+        )
+    except LocalCheckpointError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Registered '{args.id}' -> {entry.path}")
+    print(f"  env: {entry.env}")
+    print(f"  {entry.sha256} ({entry.size} bytes)")
+
+    if args.no_verify:
+        print(
+            "Skipped verification (--no-verify). Run `rootstock smoke-test` "
+            "on a node with the target device to verify."
+        )
+        return 0
+
+    print(f"Verifying {entry.env}/{args.id} on {args.device}...")
+    ok, err = verify_checkpoint(
+        root,
+        entry.env,
+        args.id,
+        args.device,
+        setup_kwargs=entry.setup_kwargs,
+        cache_root=cache_root,
+        checkpoint_path=entry.path,
+    )
+    record_local_verification(
+        root,
+        args.id,
+        ok=ok,
+        device=args.device,
+        error=None if ok else f"verify: {err}",
+    )
+    if not ok:
+        # The registration is kept (with last_error recorded) so the user can
+        # fix the cause and re-verify via smoke-test — same recoverable
+        # semantics as `rootstock add`.
+        print(f"Error: verification failed: {err}", file=sys.stderr)
+        return 1
+
+    print(
+        f'Verified. Use it like any checkpoint id: RootstockCalculator(checkpoint="{args.id}", ...)'
+    )
+    return 0
+
+
+def cmd_remove_local(args) -> int:
+    root = get_root_or_exit(args)
+    try:
+        entry = remove_local_checkpoint(root, args.checkpoint)
+    except LocalCheckpointError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Removed registry entry '{args.checkpoint}' (weights file untouched: {entry.path})")
+    return 0

--- a/rootstock/commands/serve.py
+++ b/rootstock/commands/serve.py
@@ -49,6 +49,16 @@ def cmd_serve(args) -> int:
     # Registered defaults for a local checkpoint; explicit --kwarg wins.
     setup_kwargs = {**resolved.setup_kwargs, **cli_kwargs}
 
+    if resolved.is_local and "path" in cli_kwargs:
+        # setup_from_path's first parameter — fail here, not as a TypeError
+        # inside the worker.
+        print(
+            "Error: --kwarg path=... is reserved for local checkpoints; the "
+            "registered weights path is passed automatically.",
+            file=sys.stderr,
+        )
+        return 2
+
     # Validate environment exists before printing the startup banner
     try:
         get_env_python(root, env_name)

--- a/rootstock/commands/serve.py
+++ b/rootstock/commands/serve.py
@@ -20,11 +20,10 @@ def cmd_serve(args) -> int:
         0: Clean shutdown
         1: Error
     """
-    from ..environment import (
-        CheckpointNotFoundError,
-        find_env_for_checkpoint,
-        get_env_python,
-    )
+    from pathlib import Path
+
+    from ..environment import CheckpointNotFoundError, get_env_python
+    from ..local_checkpoints import resolve_checkpoint
     from ..operations import parse_setup_kwargs
     from ..spawn import WORKER_WRAPPER, spawn_in_env
     from .common import resolve_cache_root
@@ -36,16 +35,19 @@ def cmd_serve(args) -> int:
     device = args.device
 
     try:
-        setup_kwargs = parse_setup_kwargs(getattr(args, "kwarg", None))
+        cli_kwargs = parse_setup_kwargs(getattr(args, "kwarg", None))
     except ValueError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 2
 
     try:
-        env_name, _ = find_env_for_checkpoint(root, checkpoint)
+        resolved = resolve_checkpoint(root, checkpoint)
     except CheckpointNotFoundError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
+    env_name = resolved.env_name
+    # Registered defaults for a local checkpoint; explicit --kwarg wins.
+    setup_kwargs = {**resolved.setup_kwargs, **cli_kwargs}
 
     # Validate environment exists before printing the startup banner
     try:
@@ -54,9 +56,22 @@ def cmd_serve(args) -> int:
         print(f"Error: {e}", file=sys.stderr)
         return 1
 
+    if resolved.is_local and not Path(resolved.path).exists():
+        print(
+            f"Error: local checkpoint '{checkpoint}' points at "
+            f"{resolved.path}, which no longer exists. Re-register it with "
+            f"`rootstock add-local` or remove it with "
+            f"`rootstock remove-local {checkpoint}`.",
+            file=sys.stderr,
+        )
+        return 1
+
     print("Starting rootstock worker:")
     print(f"  Env: {env_name}")
-    print(f"  Checkpoint: {checkpoint}")
+    if resolved.is_local:
+        print(f"  Checkpoint: {checkpoint} (local: {resolved.path})")
+    else:
+        print(f"  Checkpoint: {checkpoint}")
     print(f"  Device: {device}")
     print(f"  Socket: {socket_path}")
 
@@ -68,6 +83,7 @@ def cmd_serve(args) -> int:
         WORKER_WRAPPER,
         {
             "checkpoint": checkpoint,
+            "checkpoint_path": resolved.path,
             "device": device,
             "socket_path": socket_path,
             "setup_kwargs": setup_kwargs,

--- a/rootstock/commands/smoke_test.py
+++ b/rootstock/commands/smoke_test.py
@@ -72,7 +72,12 @@ def _check_local_weights(entry: LocalCheckpointEntry) -> str | None:
     path = Path(entry.path)
     if not path.exists():
         return f"weights file missing: {entry.path}"
-    sha256, size = hash_weights_file(path)
+    try:
+        sha256, size = hash_weights_file(path)
+    except OSError as exc:
+        # Revoked permissions, stale NFS handles, etc. — a per-file failure
+        # must not abort the run (canonical outcomes are recorded after this).
+        return f"weights file unreadable: {exc}"
     if sha256 != entry.sha256 or size != entry.size:
         return (
             "weights file changed on disk (sha256 mismatch); "

--- a/rootstock/commands/smoke_test.py
+++ b/rootstock/commands/smoke_test.py
@@ -7,6 +7,13 @@ import sys
 import time
 from pathlib import Path
 
+from ..local_checkpoints import (
+    LocalCheckpointEntry,
+    LocalCheckpointError,
+    hash_weights_file,
+    local_checkpoints_for_root,
+    record_local_verification,
+)
 from ..manifest import (
     CheckpointInfo,
     EnvironmentInfo,
@@ -39,6 +46,41 @@ def _select(
     return selected
 
 
+def _select_local(
+    root: Path, env_filter: str | None, checkpoint_filter: str | None
+) -> list[tuple[str, LocalCheckpointEntry]]:
+    """Pick which of the user's local checkpoints to test (same filter
+    semantics as the manifest selection; --env matches the hosting env)."""
+    try:
+        local = local_checkpoints_for_root(root)
+    except LocalCheckpointError as exc:
+        print(f"Warning: ignoring local-checkpoint registry: {exc}", file=sys.stderr)
+        return []
+    selected = []
+    for ckpt_id, entry in sorted(local.items()):
+        if env_filter is not None and entry.env != env_filter:
+            continue
+        if checkpoint_filter is not None and ckpt_id != checkpoint_filter:
+            continue
+        selected.append((ckpt_id, entry))
+    return selected
+
+
+def _check_local_weights(entry: LocalCheckpointEntry) -> str | None:
+    """Pre-verify integrity check: the file must still exist and hash to what
+    was registered — a silently swapped file must never be blessed."""
+    path = Path(entry.path)
+    if not path.exists():
+        return f"weights file missing: {entry.path}"
+    sha256, size = hash_weights_file(path)
+    if sha256 != entry.sha256 or size != entry.size:
+        return (
+            "weights file changed on disk (sha256 mismatch); "
+            "re-register with `rootstock add-local`"
+        )
+    return None
+
+
 def cmd_smoke_test(args) -> int:
     root: Path = get_root_or_exit(args)
     cache_root = resolve_cache_root(root)
@@ -52,13 +94,15 @@ def cmd_smoke_test(args) -> int:
         print("Error: --checkpoint requires --env", file=sys.stderr)
         return 2
 
+    local_selected = _select_local(root, env_filter, ckpt_filter)
+
     manifest = load_manifest(root)
-    if manifest is None:
+    if manifest is None and not local_selected:
         print(f"Error: no manifest at {root}/manifest.json", file=sys.stderr)
         return 1
 
-    selected = _select(manifest, env_filter, ckpt_filter)
-    if not selected:
+    selected = _select(manifest, env_filter, ckpt_filter) if manifest is not None else []
+    if not selected and not local_selected:
         if json_out:
             print(json.dumps({"results": [], "passed": 0, "failed": 0}, indent=2))
         else:
@@ -122,24 +166,93 @@ def cmd_smoke_test(args) -> int:
                 line += f"  {err}"
             print(line)
 
-    with manifest_lock(root):
-        fresh = load_manifest(root)
-        if fresh is not None:
-            for env_name, ckpt_name, ok, err in outcomes:
-                env_record = fresh.environments.get(env_name)
-                ckpt_record = env_record.checkpoints.get(ckpt_name) if env_record else None
-                if ckpt_record is None:
-                    continue  # env/checkpoint removed while we were testing
-                if ok:
-                    ckpt_record.verified_at = now_iso()
-                    ckpt_record.verified_device = device
-                    ckpt_record.last_error = None
-                else:
-                    ckpt_record.verified_at = None
-                    ckpt_record.verified_device = None
-                    ckpt_record.last_error = f"smoke-test: {err}"
-            save_manifest(fresh, root)
-    update_and_push_manifest(root, quiet=True, push=not no_push)
+    # Local checkpoints: re-hash first (a swapped file must not be blessed),
+    # then verify with the *registered* kwargs — unlike canonical smoke-tests
+    # they are part of the registration contract, and they're what add-local
+    # verified. Outcomes go to the per-user registry, never the manifest.
+    local_outcomes: list[tuple[str, bool, str | None]] = []
+    for ckpt_id, entry in local_selected:
+        start = time.monotonic()
+        err = _check_local_weights(entry)
+        if err is None:
+            ok, err = verify_checkpoint(
+                root=root,
+                env_name=entry.env,
+                checkpoint=ckpt_id,
+                device=device,
+                setup_kwargs=entry.setup_kwargs,
+                cache_root=cache_root,
+                checkpoint_path=entry.path,
+            )
+        else:
+            ok = False
+        elapsed = time.monotonic() - start
+        local_outcomes.append((ckpt_id, ok, err))
+
+        if ok:
+            n_passed += 1
+        else:
+            n_failed += 1
+
+        env_record = manifest.environments.get(entry.env) if manifest is not None else None
+        results.append(
+            {
+                "env": entry.env,
+                "checkpoint": ckpt_id,
+                "device": device,
+                "passed": ok,
+                "elapsed_s": round(elapsed, 2),
+                "error": err,
+                "local": True,
+                "verified_current": bool(
+                    ok and env_record is not None and now_iso() > env_record.built_at
+                ),
+            }
+        )
+
+        if not json_out:
+            verdict = "PASS" if ok else "FAIL"
+            line = (
+                f"{entry.env}/{ckpt_id:<24} [{verdict}]  {device}  "
+                f"{elapsed:5.1f}s  [local]"
+            )
+            if not ok:
+                line += f"  {err}"
+            print(line)
+
+    for ckpt_id, ok, err in local_outcomes:
+        # record_local_verification loads fresh and skips ids removed while
+        # we were testing; the shared manifest is never touched for locals.
+        record_local_verification(
+            root,
+            ckpt_id,
+            ok=ok,
+            device=device,
+            error=None if ok else f"smoke-test: {err}",
+        )
+
+    # Only touch the shared manifest when canonical checkpoints were tested.
+    # A local-only run (the common case for non-maintainers, who cannot write
+    # the shared root at all) must not take the manifest lock or push.
+    if outcomes:
+        with manifest_lock(root):
+            fresh = load_manifest(root)
+            if fresh is not None:
+                for env_name, ckpt_name, ok, err in outcomes:
+                    env_record = fresh.environments.get(env_name)
+                    ckpt_record = env_record.checkpoints.get(ckpt_name) if env_record else None
+                    if ckpt_record is None:
+                        continue  # env/checkpoint removed while we were testing
+                    if ok:
+                        ckpt_record.verified_at = now_iso()
+                        ckpt_record.verified_device = device
+                        ckpt_record.last_error = None
+                    else:
+                        ckpt_record.verified_at = None
+                        ckpt_record.verified_device = None
+                        ckpt_record.last_error = f"smoke-test: {err}"
+                save_manifest(fresh, root)
+        update_and_push_manifest(root, quiet=True, push=not no_push)
 
     total_elapsed = time.monotonic() - total_start
 

--- a/rootstock/commands/status.py
+++ b/rootstock/commands/status.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from ..config import DEFAULT_CONFIG_FILE
 from ..install_state import InstallState, read_install_state
+from ..local_checkpoints import LocalCheckpointError, local_checkpoints_for_root
 from ..manifest import is_verified
 from .common import get_root_or_exit, resolve_cache_root
 
@@ -38,6 +40,73 @@ def _checkpoint_line(env, ckpt_name: str, ckpt) -> str:
     line = f"    {ckpt_name:<24}  {fetched}  {verified}  {marker}".rstrip()
     if ckpt.last_error:
         line += f"\n      last error: {ckpt.last_error}"
+    return line
+
+
+def _local_state(state: InstallState, ckpt_id: str, entry) -> dict:
+    """Derived flags for one local checkpoint: file presence, staleness
+    against the hosting env's manifest built_at, and canonical shadowing."""
+    env = state.envs.get(entry.env)
+    record = env.record if env is not None else None
+
+    shadowed_by = None
+    for env_name, env_state in state.envs.items():
+        if env_state.declared_checkpoints and ckpt_id in env_state.declared_checkpoints:
+            shadowed_by = env_name
+            break
+
+    if entry.verified_at is None:
+        verified_current = False
+    elif record is None:
+        verified_current = False
+    else:
+        # Same lexical-ISO comparison as manifest.is_verified.
+        verified_current = entry.verified_at > record.built_at
+
+    return {
+        "exists": Path(entry.path).exists(),
+        "env_built": env is not None,
+        "env_built_at": record.built_at if record else None,
+        "verified_current": verified_current,
+        "shadowed_by": shadowed_by,
+    }
+
+
+def _local_checkpoint_line(state: InstallState, ckpt_id: str, entry) -> str:
+    derived = _local_state(state, ckpt_id, entry)
+
+    if entry.verified_at is None:
+        verified = "not verified"
+        marker = "⚠"
+    elif derived["verified_current"]:
+        verified = f"verified {_short_date(entry.verified_at)} ({entry.verified_device})"
+        marker = "✓"
+    elif derived["env_built_at"] is not None:
+        verified = (
+            f"verified {_short_date(entry.verified_at)} ({entry.verified_device})  "
+            f"⚠ stale (env rebuilt {_short_date(derived['env_built_at'])})"
+        )
+        marker = ""
+    else:
+        verified = (
+            f"verified {_short_date(entry.verified_at)} ({entry.verified_device})  "
+            f"⚠ env not in manifest"
+        )
+        marker = ""
+
+    line = f"    {ckpt_id:<24}  env: {entry.env:<12}  {verified}  {marker}".rstrip()
+    line += f"\n      {entry.path}"
+    if not derived["exists"]:
+        line += "  ⚠ file missing"
+    if not derived["env_built"]:
+        line += f"\n      ⚠ env '{entry.env}' is not built"
+    if derived["shadowed_by"]:
+        line += (
+            f"\n      ⚠ shadowed by a canonical id in env "
+            f"'{derived['shadowed_by']}' — the canonical checkpoint wins"
+        )
+    if entry.last_error:
+        line += f"\n      last error: {entry.last_error}"
     return line
 
 
@@ -87,6 +156,20 @@ def cmd_status(args) -> int:
         # Records the manifest still carries for envs that are gone from disk.
         for name in sorted(state.manifest_only_envs):
             print(f"  {name:<20} [manifest only — not on disk]")
+
+    # The user's own registered local checkpoints (per-user registry; never
+    # part of the shared manifest).
+    try:
+        local = local_checkpoints_for_root(root)
+        local_error = None
+    except LocalCheckpointError as exc:
+        local, local_error = {}, str(exc)
+    if local or local_error:
+        print("\nLocal checkpoints (this user):")
+        if local_error:
+            print(f"  (unreadable: {local_error})")
+        for ckpt_id, entry in sorted(local.items()):
+            print(_local_checkpoint_line(state, ckpt_id, entry))
 
     # Show the cache location; computing sizes is opt-in. Cache may live
     # under the install root or under a separate declared cache_root. Some
@@ -157,6 +240,16 @@ def _cmd_status_json(state: InstallState) -> int:
             "checkpoints": checkpoints,
         }
 
+    local_checkpoints = {}
+    try:
+        for ckpt_id, entry in sorted(local_checkpoints_for_root(state.root).items()):
+            local_checkpoints[ckpt_id] = {
+                **entry.to_dict(),
+                **_local_state(state, ckpt_id, entry),
+            }
+    except LocalCheckpointError:
+        pass  # per-user registry problems must not break machine-readable status
+
     manifest = state.manifest
     payload = {
         "root": str(state.root),
@@ -167,6 +260,7 @@ def _cmd_status_json(state: InstallState) -> int:
         "sources": [name for name, _ in state.sources],
         "environments": environments,
         "manifest_only_environments": sorted(state.manifest_only_envs),
+        "local_checkpoints": local_checkpoints,
     }
     print(json.dumps(payload, indent=2))
     return 0

--- a/rootstock/environment.py
+++ b/rootstock/environment.py
@@ -215,6 +215,23 @@ def parse_checkpoints_dict(env_source_path: Path) -> dict[str, str]:
     )
 
 
+def declares_setup_from_path(env_source_path: Path) -> bool:
+    """
+    Return True when the env source declares a module-level ``setup_from_path``.
+
+    ``setup_from_path(path, device="cuda", **kwargs)`` is the opt-in hook that
+    lets an env load user-supplied weights files (local checkpoints). Presence
+    is all that's checked — the signature is trusted the same way ``setup``'s
+    is.
+    """
+    tree = ast.parse(env_source_path.read_text(), filename=str(env_source_path))
+    return any(
+        isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == "setup_from_path"
+        for node in tree.body
+    )
+
+
 def list_declared_checkpoints(root: Path | str) -> dict[str, dict[str, str]]:
     """
     Walk ``{root}/envs/*/env_source.py`` and return ``{env_name: CHECKPOINTS}``

--- a/rootstock/integrations/mlipx.py
+++ b/rootstock/integrations/mlipx.py
@@ -17,8 +17,10 @@ Usage inside an MLIPx recipe's ``models.py``::
     from rootstock.integrations.mlipx import RootstockMLIPxModel
 
     MODELS = {
-        "mace":  RootstockMLIPxModel(checkpoint="mace-mp-0-medium", cluster="sophia", device="cuda"),
-        "uma":   RootstockMLIPxModel(checkpoint="uma-s-1p1",        cluster="sophia", device="cuda"),
+        "mace": RootstockMLIPxModel(
+            checkpoint="mace-mp-0-medium", cluster="sophia", device="cuda"
+        ),
+        "uma": RootstockMLIPxModel(checkpoint="uma-s-1p1", cluster="sophia", device="cuda"),
     }
 
 Locally (no cluster), point at an install root instead::
@@ -100,12 +102,11 @@ class RootstockMLIPxModel(zntrack.Node):
         }
         try:
             from ..clusters import get_root_for_cluster
-            from ..environment import find_env_for_checkpoint
+            from ..local_checkpoints import resolve_checkpoint
 
             root = get_root_for_cluster(self.cluster) if self.cluster else self.root
             if root is not None:
-                env_name, _ = find_env_for_checkpoint(root, self.checkpoint)
-                metadata["env"] = env_name
+                metadata["env"] = resolve_checkpoint(root, self.checkpoint).env_name
         except Exception:
             pass
 

--- a/rootstock/local_checkpoints.py
+++ b/rootstock/local_checkpoints.py
@@ -1,0 +1,410 @@
+"""
+Per-user registry of local checkpoints (user-supplied weights files).
+
+A shared install is world-readable but maintainer-writable, so a user who
+fine-tunes a model cannot register the weights in the install's manifest or
+env sources. Instead, local checkpoints live in a per-user JSON registry
+(``~/.config/rootstock/local-checkpoints.json``) keyed by install root. Each
+entry binds a user-chosen checkpoint id to an installed env that declares the
+``setup_from_path`` hook, plus the weights path, its hash, and verification
+state.
+
+Resolution (:func:`resolve_checkpoint`) consults the env-declared canonical
+ids first, then this registry — so a registered id works everywhere a
+canonical id does (calculator, serve, benchmark) without any shared-root
+writes.
+
+Locking: none, deliberately. The registry is a private per-user file; the
+only plausible concurrent writers are the same user's own processes (an
+``add-local`` racing a nightly ``smoke-test``). Atomic replace prevents
+corruption, and a lost update costs at most one re-verification, not shared
+state. Every mutator loads fresh, mutates, and saves immediately — no
+registry object is held across long-running work.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+import tempfile
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+from .config import DEFAULT_CONFIG_DIR
+from .environment import (
+    CheckpointNotFoundError,
+    declares_setup_from_path,
+    find_env_for_checkpoint,
+    list_declared_checkpoints,
+)
+from .exceptions import RootstockError
+from .manifest import now_iso
+
+LOCAL_REGISTRY_SCHEMA_VERSION = 1
+DEFAULT_LOCAL_REGISTRY_FILE = DEFAULT_CONFIG_DIR / "local-checkpoints.json"
+
+# Keys setup_from_path receives positionally / at the top level. "path" is
+# reserved too: it's setup_from_path's first parameter, so a registered
+# path= kwarg would TypeError with "multiple values for argument".
+RESERVED_SETUP_KWARGS = frozenset({"checkpoint", "device", "path"})
+
+_HASH_CHUNK_SIZE = 1024 * 1024  # weights files are GBs; read in 1 MiB chunks
+
+
+class LocalCheckpointError(RootstockError, RuntimeError):
+    """A local-checkpoint registry operation failed. Messages are
+    user-presentable diagnoses, not tracebacks."""
+
+
+@dataclass
+class LocalCheckpointEntry:
+    """One registered local checkpoint, bound to an install root."""
+
+    env: str
+    path: str  # absolute path to the weights file (user's own storage)
+    sha256: str  # "sha256:<hex>", matching the manifest's source_hash style
+    size: int  # st_size at registration; cheap staleness signal
+    setup_kwargs: dict = field(default_factory=dict)
+    registered_at: str = ""  # ISO 8601
+    verified_at: str | None = None
+    verified_device: str | None = None
+    last_error: str | None = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> LocalCheckpointEntry:
+        return cls(
+            env=data["env"],
+            path=data["path"],
+            sha256=data["sha256"],
+            size=data["size"],
+            setup_kwargs=data.get("setup_kwargs") or {},
+            registered_at=data.get("registered_at", ""),
+            verified_at=data.get("verified_at"),
+            verified_device=data.get("verified_device"),
+            last_error=data.get("last_error"),
+        )
+
+
+@dataclass(frozen=True)
+class ResolvedCheckpoint:
+    """Where a checkpoint id points: hosting env, plus the weights path and
+    registered default setup kwargs when the id is a local checkpoint."""
+
+    checkpoint: str
+    env_name: str
+    path: str | None = None  # None => canonical id
+    setup_kwargs: dict = field(default_factory=dict)
+
+    @property
+    def is_local(self) -> bool:
+        return self.path is not None
+
+
+def _root_key(root: Path | str) -> str:
+    """Registry key for an install root. Resolved so the same install reached
+    via symlinks or relative paths lands on one entry set."""
+    return str(Path(root).resolve())
+
+
+def _registry_path(registry_path: Path | str | None) -> Path:
+    # Resolved at call time (not bound as a default) so tests can point the
+    # module-level default somewhere else.
+    if registry_path is not None:
+        return Path(registry_path)
+    return DEFAULT_LOCAL_REGISTRY_FILE
+
+
+def hash_weights_file(path: Path) -> tuple[str, int]:
+    """Chunked sha256 of a weights file. Returns ("sha256:<hex>", size)."""
+    digest = hashlib.sha256()
+    size = 0
+    with open(path, "rb") as f:
+        while chunk := f.read(_HASH_CHUNK_SIZE):
+            digest.update(chunk)
+            size += len(chunk)
+    return f"sha256:{digest.hexdigest()}", size
+
+
+def load_local_registry(
+    registry_path: Path | str | None = None,
+) -> dict[str, dict[str, LocalCheckpointEntry]]:
+    """
+    Load the registry as ``{root_key: {checkpoint_id: entry}}``.
+
+    A missing file is an empty registry. A file that exists but can't be
+    parsed raises — unlike the manifest, the recovery hint is cheap because
+    only this user's registrations are at stake.
+    """
+    path = _registry_path(registry_path)
+    if not path.exists():
+        return {}
+
+    try:
+        data = json.loads(path.read_text())
+        version = data.get("schema_version")
+        if not isinstance(version, int):
+            raise ValueError(f"invalid schema_version={version!r}")
+        if version > LOCAL_REGISTRY_SCHEMA_VERSION:
+            raise LocalCheckpointError(
+                f"local-checkpoint registry at {path} is schema_version="
+                f"{version}, but this rootstock only understands up to "
+                f"{LOCAL_REGISTRY_SCHEMA_VERSION}. It was written by a newer "
+                f"rootstock — upgrade this client."
+            )
+        return {
+            root_key: {
+                ckpt_id: LocalCheckpointEntry.from_dict(entry) for ckpt_id, entry in entries.items()
+            }
+            for root_key, entries in data.get("roots", {}).items()
+        }
+    except LocalCheckpointError:
+        raise
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError, AttributeError) as exc:
+        raise LocalCheckpointError(
+            f"local-checkpoint registry at {path} is corrupted "
+            f"({type(exc).__name__}: {exc}). Fix the file, or delete it to "
+            f"start fresh — it only holds your own registrations; weights "
+            f"files are never stored in it."
+        ) from exc
+
+
+def save_local_registry(
+    roots: dict[str, dict[str, LocalCheckpointEntry]],
+    registry_path: Path | str | None = None,
+) -> None:
+    """Atomic write (temp + rename). mkstemp's 0600 is correct here — this is
+    a private per-user file, unlike the shared manifest."""
+    path = _registry_path(registry_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    data = {
+        "schema_version": LOCAL_REGISTRY_SCHEMA_VERSION,
+        "roots": {
+            root_key: {ckpt_id: entry.to_dict() for ckpt_id, entry in entries.items()}
+            for root_key, entries in roots.items()
+        },
+    }
+
+    fd, temp_path = tempfile.mkstemp(dir=path.parent, suffix=".json")
+    try:
+        with open(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        Path(temp_path).rename(path)
+    except Exception:
+        try:
+            Path(temp_path).unlink()
+        except OSError:
+            pass
+        raise
+
+
+def local_checkpoints_for_root(
+    root: Path | str,
+    registry_path: Path | str | None = None,
+) -> dict[str, LocalCheckpointEntry]:
+    """Registered local checkpoints for one install root (empty dict if none)."""
+    return load_local_registry(registry_path).get(_root_key(root), {})
+
+
+def register_local_checkpoint(
+    root: Path | str,
+    checkpoint_id: str,
+    env_name: str,
+    weights_path: Path | str,
+    setup_kwargs: dict | None = None,
+    registry_path: Path | str | None = None,
+) -> LocalCheckpointEntry:
+    """
+    Validate and record a local checkpoint. Idempotent: re-registering an
+    existing id overwrites the entry and resets its verification state.
+
+    Raises LocalCheckpointError for every validation failure; the messages
+    name the fix.
+    """
+    root = Path(root)
+    weights_path = Path(weights_path).expanduser().resolve()
+    setup_kwargs = dict(setup_kwargs or {})
+
+    if not weights_path.is_file():
+        raise LocalCheckpointError(
+            f"weights file not found (or not a regular file): {weights_path}"
+        )
+    if not os.access(weights_path, os.R_OK):
+        raise LocalCheckpointError(f"weights file is not readable: {weights_path}")
+
+    env_dir = root / "envs" / env_name
+    env_source = env_dir / "env_source.py"
+    if not (env_dir / "bin" / "python").exists() or not env_source.exists():
+        built = (
+            sorted(
+                p.name
+                for p in (root / "envs").iterdir()
+                if p.is_dir() and (p / "bin" / "python").exists()
+            )
+            if (root / "envs").exists()
+            else []
+        )
+        raise LocalCheckpointError(
+            f"env '{env_name}' is not built at {root}. "
+            f"Built envs: {', '.join(built) if built else '(none)'}."
+        )
+
+    if not declares_setup_from_path(env_source):
+        supporting = sorted(
+            env_dir.name
+            for env_dir in (root / "envs").iterdir()
+            if (env_dir / "env_source.py").exists()
+            and declares_setup_from_path(env_dir / "env_source.py")
+        )
+        raise LocalCheckpointError(
+            f"env '{env_name}' does not declare setup_from_path(path, device, "
+            f"**kwargs), which is required to load local checkpoints. "
+            f"Envs at {root} that support local checkpoints: "
+            f"{', '.join(supporting) if supporting else '(none)'}. "
+            f"Ask the install maintainer to add setup_from_path to the env "
+            f"source — see docs/environments.md."
+        )
+
+    for owner_env, declared in list_declared_checkpoints(root).items():
+        if checkpoint_id in declared:
+            raise LocalCheckpointError(
+                f"id '{checkpoint_id}' is already a canonical checkpoint of "
+                f"env '{owner_env}' at {root}; choose a different --id."
+            )
+
+    reserved = RESERVED_SETUP_KWARGS & setup_kwargs.keys()
+    if reserved:
+        raise LocalCheckpointError(
+            f"setup_kwargs cannot contain reserved keys {sorted(reserved)}; "
+            f"they are passed to setup_from_path at the top level."
+        )
+
+    sha256, size = hash_weights_file(weights_path)
+    entry = LocalCheckpointEntry(
+        env=env_name,
+        path=str(weights_path),
+        sha256=sha256,
+        size=size,
+        setup_kwargs=setup_kwargs,
+        registered_at=now_iso(),
+    )
+
+    roots = load_local_registry(registry_path)
+    roots.setdefault(_root_key(root), {})[checkpoint_id] = entry
+    save_local_registry(roots, registry_path)
+    return entry
+
+
+def remove_local_checkpoint(
+    root: Path | str,
+    checkpoint_id: str,
+    registry_path: Path | str | None = None,
+) -> LocalCheckpointEntry:
+    """
+    Delete a registry entry and return it. Never touches the weights file —
+    the registry records it, it doesn't own it.
+    """
+    roots = load_local_registry(registry_path)
+    key = _root_key(root)
+    entries = roots.get(key, {})
+    if checkpoint_id not in entries:
+        if entries:
+            listing = ", ".join(sorted(entries))
+            detail = f"Registered local checkpoints for {key}: {listing}."
+        else:
+            detail = f"No local checkpoints are registered for {key}."
+        raise LocalCheckpointError(f"no local checkpoint '{checkpoint_id}' is registered. {detail}")
+
+    entry = entries.pop(checkpoint_id)
+    if not entries:
+        del roots[key]
+    save_local_registry(roots, registry_path)
+    return entry
+
+
+def record_local_verification(
+    root: Path | str,
+    checkpoint_id: str,
+    *,
+    ok: bool,
+    device: str,
+    error: str | None = None,
+    registry_path: Path | str | None = None,
+) -> None:
+    """Write a verification outcome back to the registry. A checkpoint
+    removed since the caller last looked is skipped silently — the outcome
+    has nothing to attach to."""
+    roots = load_local_registry(registry_path)
+    entry = roots.get(_root_key(root), {}).get(checkpoint_id)
+    if entry is None:
+        return
+    if ok:
+        entry.verified_at = now_iso()
+        entry.verified_device = device
+        entry.last_error = None
+    else:
+        entry.last_error = error
+    save_local_registry(roots, registry_path)
+
+
+def resolve_checkpoint(
+    root: Path | str,
+    checkpoint_id: str,
+    registry_path: Path | str | None = None,
+) -> ResolvedCheckpoint:
+    """
+    Resolve a checkpoint id to its hosting env, checking env-declared
+    canonical ids first, then the user's local-checkpoint registry.
+
+    Canonical ids win: registration rejects collisions in the other
+    direction, but an env installed *after* a local registration can
+    introduce one — the canonical id is authoritative and `status` surfaces
+    the shadowing.
+
+    Deliberately does not check that the env is built or the weights file
+    still exists — resolution is also used for metadata lookups; callers
+    that spawn a worker check before spawning.
+
+    Raises CheckpointNotFoundError when neither namespace has the id.
+    """
+    for env_name, ckpts in list_declared_checkpoints(root).items():
+        if checkpoint_id in ckpts:
+            return ResolvedCheckpoint(checkpoint=checkpoint_id, env_name=env_name)
+
+    try:
+        local = local_checkpoints_for_root(root, registry_path)
+    except LocalCheckpointError as exc:
+        # A broken per-user file must not brick canonical resolution; the
+        # mutating commands (add-local/remove-local) still fail loudly.
+        print(f"Warning: ignoring local-checkpoint registry: {exc}", file=sys.stderr)
+        local = {}
+
+    entry = local.get(checkpoint_id)
+    if entry is not None:
+        return ResolvedCheckpoint(
+            checkpoint=checkpoint_id,
+            env_name=entry.env,
+            path=entry.path,
+            setup_kwargs=dict(entry.setup_kwargs),
+        )
+
+    # Reuse find_env_for_checkpoint's rich canonical listing, appending the
+    # local dimension so the error names both namespaces.
+    try:
+        find_env_for_checkpoint(root, checkpoint_id)
+    except CheckpointNotFoundError as exc:
+        extra = ""
+        if local:
+            extra = f"\nYour registered local checkpoints: {', '.join(sorted(local))}."
+        raise CheckpointNotFoundError(
+            f"{exc}{extra}\nLocal weights files can be registered with "
+            f"`rootstock add-local <path> --env <env> --id <id>`."
+        ) from None
+    # find_env_for_checkpoint succeeding here is impossible (we already
+    # walked the same declarations), but never mask it if it happens.
+    raise AssertionError("resolve_checkpoint: inconsistent declared-checkpoint walk")

--- a/rootstock/local_checkpoints.py
+++ b/rootstock/local_checkpoints.py
@@ -348,6 +348,10 @@ def record_local_verification(
         entry.verified_device = device
         entry.last_error = None
     else:
+        # Same semantics as the manifest's smoke-test path: a failure revokes
+        # verified state, so `status` can never show ✓ alongside last_error.
+        entry.verified_at = None
+        entry.verified_device = None
         entry.last_error = error
     save_local_registry(roots, registry_path)
 

--- a/rootstock/server.py
+++ b/rootstock/server.py
@@ -94,6 +94,7 @@ class RootstockServer:
         cache_root: Path | None = None,
         timeout: float = 600.0,
         setup_kwargs: dict | None = None,
+        checkpoint_path: str | None = None,
     ):
         """
         Initialize the server.
@@ -117,6 +118,9 @@ class RootstockServer:
                 torch.compile or large neighbor lists — runs under the
                 same envelope verification exercised.
             setup_kwargs: Extra keyword arguments forwarded to setup()
+            checkpoint_path: Path to a local (user-registered) weights file.
+                When set, the worker loads via the env's setup_from_path()
+                hook instead of setup(); ``checkpoint`` is then only a label.
         """
         if root is None:
             raise ValueError("root is required for pre-built environments")
@@ -130,6 +134,7 @@ class RootstockServer:
 
         self.env_name = env_name
         self.checkpoint = checkpoint
+        self.checkpoint_path = checkpoint_path
         self.device = device
         self.root = Path(root)
         self.cache_root = Path(cache_root) if cache_root is not None else None
@@ -192,6 +197,7 @@ class RootstockServer:
                 WORKER_WRAPPER,
                 {
                     "checkpoint": self.checkpoint,
+                    "checkpoint_path": self.checkpoint_path,
                     "device": self.device,
                     "socket_path": self.socket_path,
                     "setup_kwargs": self.setup_kwargs,

--- a/rootstock/spawn.py
+++ b/rootstock/spawn.py
@@ -39,12 +39,22 @@ with open(sys.argv[1]) as f:
     spec = json.load(f)
 
 sys.path.insert(0, spec["env_dir"])
-from env_source import setup
 from rootstock.worker import run_worker
 
+# Local checkpoints (user-supplied weights) load through the env's opt-in
+# setup_from_path hook; the path travels through run_worker's existing
+# checkpoint parameter, so workers frozen inside built envs need no change.
+# The imports are one-sided: canonical mode must not require the hook.
+if spec.get("checkpoint_path"):
+    from env_source import setup_from_path as setup_fn
+    target = spec["checkpoint_path"]
+else:
+    from env_source import setup as setup_fn
+    target = spec["checkpoint"]
+
 run_worker(
-    setup_fn=setup,
-    checkpoint=spec["checkpoint"],
+    setup_fn=setup_fn,
+    checkpoint=target,
     device=spec["device"],
     socket_path=spec["socket_path"],
     setup_kwargs=spec["setup_kwargs"],

--- a/rootstock/verify.py
+++ b/rootstock/verify.py
@@ -58,6 +58,7 @@ def verify_checkpoint(
     device: str,
     setup_kwargs: dict | None = None,
     cache_root: Path | None = None,
+    checkpoint_path: str | None = None,
 ) -> tuple[bool, str | None]:
     """
     Run a single forward pass to verify a checkpoint loads and computes.
@@ -70,6 +71,8 @@ def verify_checkpoint(
         setup_kwargs: Extra keyword arguments forwarded to setup().
         cache_root: Optional separate root for the model-weight cache and
                     redirected HOME. Defaults to ``root``.
+        checkpoint_path: Path to a local (user-registered) weights file; the
+                    worker then loads via setup_from_path() instead of setup().
 
     Returns:
         (success, error_message). On success, error_message is None.
@@ -91,6 +94,7 @@ def verify_checkpoint(
         cache_root=Path(cache_root) if cache_root is not None else None,
         setup_kwargs=setup_kwargs,
         timeout=600.0,
+        checkpoint_path=checkpoint_path,
     )
 
     try:

--- a/tests/calculator/test_calculator_local.py
+++ b/tests/calculator/test_calculator_local.py
@@ -1,0 +1,126 @@
+"""Tests for RootstockCalculator with local (user-registered) checkpoints."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rootstock import local_checkpoints
+from rootstock.calculator import RootstockCalculator
+from rootstock.environment import CheckpointNotFoundError
+from rootstock.local_checkpoints import LocalCheckpointError, register_local_checkpoint
+
+_UMA_ENV_SOURCE = '''\
+"""UMA env."""
+
+CHECKPOINTS = {
+    "uma-s-1p1": "uma-s-1p1",
+}
+
+
+def setup(checkpoint, device="cuda", task="omat"):
+    return None
+
+
+def setup_from_path(path, device="cuda", task="omat"):
+    return None
+'''
+
+
+@pytest.fixture
+def fake_root(tmp_path: Path) -> Path:
+    env_dir = tmp_path / "root" / "envs" / "uma"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+    (env_dir / "env_source.py").write_text(_UMA_ENV_SOURCE)
+    return tmp_path / "root"
+
+
+@pytest.fixture
+def registry(tmp_path: Path, monkeypatch) -> Path:
+    # The calculator resolves against the module default; point it into tmp
+    # so tests never touch (or depend on) the developer's real registry.
+    path = tmp_path / "registry.json"
+    monkeypatch.setattr(local_checkpoints, "DEFAULT_LOCAL_REGISTRY_FILE", path)
+    return path
+
+
+@pytest.fixture
+def weights(tmp_path: Path) -> Path:
+    path = tmp_path / "ft.pt"
+    path.write_bytes(b"weights")
+    return path
+
+
+@pytest.fixture
+def registered(fake_root, weights, registry) -> str:
+    register_local_checkpoint(
+        fake_root, "my-uma-ft", "uma", weights, setup_kwargs={"task": "omol"}
+    )
+    return "my-uma-ft"
+
+
+class _RecordingServer:
+    ctor_kwargs: dict = {}
+
+    def __init__(self, **kwargs):
+        _RecordingServer.ctor_kwargs = kwargs
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+
+@pytest.fixture
+def recording_server(monkeypatch):
+    _RecordingServer.ctor_kwargs = {}
+    monkeypatch.setattr("rootstock.calculator.RootstockServer", _RecordingServer)
+    return _RecordingServer
+
+
+def test_local_id_resolves_env_and_path(fake_root, registered, weights):
+    calc = RootstockCalculator(checkpoint=registered, root=fake_root)
+    assert calc.env_name == "uma"
+    assert calc.checkpoint_path == str(weights.resolve())
+    assert calc.setup_kwargs == {"task": "omol"}
+
+
+def test_per_call_kwargs_override_registered(fake_root, registered):
+    calc = RootstockCalculator(
+        checkpoint=registered, root=fake_root, setup_kwargs={"task": "omc"}
+    )
+    assert calc.setup_kwargs == {"task": "omc"}
+
+
+def test_server_receives_checkpoint_path(fake_root, registered, weights, recording_server):
+    calc = RootstockCalculator(checkpoint=registered, root=fake_root, device="cpu")
+    calc._ensure_server()
+    kwargs = recording_server.ctor_kwargs
+    assert kwargs["checkpoint_path"] == str(weights.resolve())
+    assert kwargs["checkpoint"] == registered
+    assert kwargs["setup_kwargs"] == {"task": "omol"}
+
+
+def test_canonical_id_has_no_checkpoint_path(fake_root, registry, recording_server):
+    calc = RootstockCalculator(checkpoint="uma-s-1p1", root=fake_root, device="cpu")
+    assert calc.checkpoint_path is None
+    calc._ensure_server()
+    assert recording_server.ctor_kwargs["checkpoint_path"] is None
+
+
+def test_missing_weights_file_raises_at_construction(
+    fake_root, registered, weights, recording_server
+):
+    weights.unlink()
+    with pytest.raises(LocalCheckpointError, match="no longer exists"):
+        RootstockCalculator(checkpoint=registered, root=fake_root)
+    # Never got as far as building a server.
+    assert recording_server.ctor_kwargs == {}
+
+
+def test_unknown_id_mentions_add_local(fake_root, registry):
+    with pytest.raises(CheckpointNotFoundError, match="add-local"):
+        RootstockCalculator(checkpoint="not-a-real-id", root=fake_root)

--- a/tests/calculator/test_calculator_local.py
+++ b/tests/calculator/test_calculator_local.py
@@ -111,6 +111,15 @@ def test_canonical_id_has_no_checkpoint_path(fake_root, registry, recording_serv
     assert recording_server.ctor_kwargs["checkpoint_path"] is None
 
 
+def test_per_call_path_kwarg_rejected_for_local(fake_root, registered):
+    # "path" is setup_from_path's first parameter; fail at construction, not
+    # as a TypeError inside the worker.
+    with pytest.raises(TypeError, match="path"):
+        RootstockCalculator(
+            checkpoint=registered, root=fake_root, setup_kwargs={"path": "/x"}
+        )
+
+
 def test_missing_weights_file_raises_at_construction(
     fake_root, registered, weights, recording_server
 ):

--- a/tests/cli/test_add.py
+++ b/tests/cli/test_add.py
@@ -289,3 +289,42 @@ def test_add_without_checkpoint_or_list_returns_2(fake_root):
     """Omitting both the checkpoint and --list is a usage error."""
     rc = cmd_add(_make_args(fake_root, checkpoint=None))
     assert rc == 2
+
+
+# ---------- local checkpoints in cmd_add ------------------------------------
+
+
+@pytest.fixture
+def local_registered(fake_root, tmp_path, monkeypatch) -> str:
+    """A local checkpoint registered for fake_root, in an isolated registry."""
+    from rootstock import local_checkpoints
+    from rootstock.local_checkpoints import LocalCheckpointEntry, save_local_registry
+
+    registry = tmp_path / "registry.json"
+    monkeypatch.setattr(local_checkpoints, "DEFAULT_LOCAL_REGISTRY_FILE", registry)
+    entry = LocalCheckpointEntry(
+        env="mace",
+        path=str(tmp_path / "ft.pt"),
+        sha256="sha256:abc",
+        size=1,
+        registered_at="2026-07-21T00:00:00+00:00",
+    )
+    save_local_registry({str(fake_root.resolve()): {"my-ft": entry}})
+    return "my-ft"
+
+
+def test_add_list_includes_local_section(fake_root, local_registered, capsys):
+    rc = cmd_add(_make_args(fake_root, list=True, checkpoint=None))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "local (this user" in out
+    assert "my-ft" in out
+
+
+def test_add_of_local_id_explains_no_add_needed(fake_root, local_registered, capsys):
+    """`rootstock add <local-id>` is a category error — point at direct use."""
+    rc = cmd_add(_make_args(fake_root, checkpoint="my-ft"))
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "locally-registered" in err
+    assert "smoke-test" in err

--- a/tests/cli/test_add_local.py
+++ b/tests/cli/test_add_local.py
@@ -1,0 +1,178 @@
+"""Tests for ``rootstock add-local``."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from rootstock import local_checkpoints
+from rootstock.commands import local as local_cmd
+from rootstock.commands.local import cmd_add_local
+from rootstock.local_checkpoints import local_checkpoints_for_root
+
+_UMA_ENV_SOURCE = '''\
+"""UMA env with the local-checkpoint hook."""
+
+CHECKPOINTS = {
+    "uma-s-1p1": "uma-s-1p1",
+}
+
+
+def setup(checkpoint, device="cuda", task="omat"):
+    return None
+
+
+def setup_from_path(path, device="cuda", task="omat"):
+    return None
+'''
+
+_MACE_ENV_SOURCE = '''\
+"""MACE env without the hook."""
+
+CHECKPOINTS = {
+    "mace-mp-0-medium": "medium",
+}
+
+
+def setup(checkpoint, device="cuda"):
+    return None
+'''
+
+
+@pytest.fixture
+def fake_root(tmp_path: Path) -> Path:
+    root = tmp_path / "root"
+    for name, source in (("uma", _UMA_ENV_SOURCE), ("mace", _MACE_ENV_SOURCE)):
+        env_dir = root / "envs" / name
+        (env_dir / "bin").mkdir(parents=True)
+        (env_dir / "bin" / "python").touch()
+        (env_dir / "env_source.py").write_text(source)
+    return root
+
+
+@pytest.fixture
+def registry(tmp_path: Path, monkeypatch) -> Path:
+    path = tmp_path / "registry.json"
+    monkeypatch.setattr(local_checkpoints, "DEFAULT_LOCAL_REGISTRY_FILE", path)
+    return path
+
+
+@pytest.fixture
+def weights(tmp_path: Path) -> Path:
+    path = tmp_path / "ft.pt"
+    path.write_bytes(b"fine-tuned weights")
+    return path
+
+
+@pytest.fixture
+def verify_calls(monkeypatch) -> list:
+    """Stub verify_checkpoint where cmd_add_local binds it; record calls."""
+    calls = []
+
+    def fake_verify(root, env, checkpoint, device, **kwargs):
+        calls.append({"env": env, "checkpoint": checkpoint, "device": device, **kwargs})
+        return True, None
+
+    monkeypatch.setattr(local_cmd, "verify_checkpoint", fake_verify)
+    return calls
+
+
+def _make_args(root: Path, weights: Path, **overrides):
+    class _Args:
+        pass
+
+    args = _Args()
+    args.path = str(overrides.get("path", weights))
+    args.env = overrides.get("env", "uma")
+    args.id = overrides.get("id", "my-uma-ft")
+    args.kwarg = overrides.get("kwarg")
+    args.device = overrides.get("device", "cuda")
+    args.no_verify = overrides.get("no_verify", False)
+    args.root = str(root)
+    return args
+
+
+def test_add_local_happy_path(fake_root, weights, registry, verify_calls):
+    rc = cmd_add_local(_make_args(fake_root, weights, kwarg=["task=omol"]))
+    assert rc == 0
+
+    entry = local_checkpoints_for_root(fake_root)["my-uma-ft"]
+    assert entry.env == "uma"
+    assert entry.path == str(weights.resolve())
+    assert entry.setup_kwargs == {"task": "omol"}
+    assert entry.verified_at is not None
+    assert entry.verified_device == "cuda"
+
+    # Verification ran against the registered path with registered kwargs.
+    assert verify_calls == [
+        {
+            "env": "uma",
+            "checkpoint": "my-uma-ft",
+            "device": "cuda",
+            "setup_kwargs": {"task": "omol"},
+            "cache_root": fake_root,
+            "checkpoint_path": str(weights.resolve()),
+        }
+    ]
+
+
+def test_add_local_no_verify(fake_root, weights, registry, verify_calls):
+    rc = cmd_add_local(_make_args(fake_root, weights, no_verify=True))
+    assert rc == 0
+    entry = local_checkpoints_for_root(fake_root)["my-uma-ft"]
+    assert entry.verified_at is None
+    assert verify_calls == []
+
+
+def test_add_local_verify_failure_keeps_entry(fake_root, weights, registry, monkeypatch):
+    monkeypatch.setattr(
+        local_cmd, "verify_checkpoint", lambda *a, **kw: (False, "CUDA out of memory")
+    )
+    rc = cmd_add_local(_make_args(fake_root, weights))
+    assert rc == 1
+    entry = local_checkpoints_for_root(fake_root)["my-uma-ft"]
+    assert entry.verified_at is None
+    assert entry.last_error == "verify: CUDA out of memory"
+
+
+def test_add_local_env_without_hook(fake_root, weights, registry, verify_calls, capsys):
+    rc = cmd_add_local(_make_args(fake_root, weights, env="mace"))
+    assert rc == 1
+    assert "setup_from_path" in capsys.readouterr().err
+    assert local_checkpoints_for_root(fake_root) == {}
+
+
+def test_add_local_canonical_collision(fake_root, weights, registry, verify_calls, capsys):
+    rc = cmd_add_local(_make_args(fake_root, weights, id="uma-s-1p1"))
+    assert rc == 1
+    assert "canonical" in capsys.readouterr().err
+
+
+def test_add_local_reserved_kwarg(fake_root, weights, registry, verify_calls, capsys):
+    rc = cmd_add_local(_make_args(fake_root, weights, kwarg=["path=/x"]))
+    assert rc == 1
+    assert "reserved" in capsys.readouterr().err
+
+
+def test_add_local_bad_kwarg_is_usage_error(fake_root, weights, registry, verify_calls):
+    rc = cmd_add_local(_make_args(fake_root, weights, kwarg=["no-equals-sign"]))
+    assert rc == 2
+
+
+def test_add_local_missing_weights(fake_root, registry, verify_calls, capsys, tmp_path):
+    rc = cmd_add_local(_make_args(fake_root, tmp_path / "nope.pt"))
+    assert rc == 1
+    assert "not found" in capsys.readouterr().err
+
+
+def test_add_local_leaves_umask_alone(fake_root, weights, registry, verify_calls):
+    # cmd_add forces umask 0o002 for shared-cache writes; add-local writes
+    # nothing shared and must not touch the caller's umask.
+    before = os.umask(0o077)
+    os.umask(before)
+    cmd_add_local(_make_args(fake_root, weights))
+    after = os.umask(0o077)
+    os.umask(after)
+    assert after == before

--- a/tests/cli/test_benchmark_local.py
+++ b/tests/cli/test_benchmark_local.py
@@ -1,0 +1,62 @@
+"""Tests for benchmark guards on local (user-registered) checkpoints."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rootstock import local_checkpoints
+from rootstock.benchmark import benchmark_one
+from rootstock.local_checkpoints import register_local_checkpoint
+
+_ENV_SOURCE = """\
+CHECKPOINTS = {"uma-s-1p1": "uma-s-1p1"}
+
+
+def setup(checkpoint, device="cuda"):
+    return None
+
+
+def setup_from_path(path, device="cuda", **kwargs):
+    return None
+"""
+
+
+@pytest.fixture
+def fake_root(tmp_path: Path) -> Path:
+    env_dir = tmp_path / "root" / "envs" / "uma"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+    (env_dir / "env_source.py").write_text(_ENV_SOURCE)
+    return tmp_path / "root"
+
+
+@pytest.fixture
+def registry(tmp_path: Path, monkeypatch) -> Path:
+    path = tmp_path / "registry.json"
+    monkeypatch.setattr(local_checkpoints, "DEFAULT_LOCAL_REGISTRY_FILE", path)
+    return path
+
+
+def test_benchmark_one_missing_local_weights(fake_root, registry, tmp_path):
+    # Fails before either arm spawns — same message as the calculator guard —
+    # instead of a raw subprocess traceback from the in-env worker.
+    weights = tmp_path / "ft.pt"
+    weights.write_bytes(b"weights")
+    register_local_checkpoint(fake_root, "my-ft", "uma", weights)
+    weights.unlink()
+
+    with pytest.raises(RuntimeError, match="no longer exists"):
+        benchmark_one(
+            checkpoint="my-ft",
+            device="cpu",
+            root=fake_root,
+            cache_root=None,
+            cluster=None,
+            atoms=None,
+            frames=None,
+            n_warmup=0,
+            setup_kwargs={},
+            work_dir=tmp_path,
+        )

--- a/tests/cli/test_remove_local.py
+++ b/tests/cli/test_remove_local.py
@@ -1,0 +1,86 @@
+"""Tests for ``rootstock remove-local``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rootstock import local_checkpoints
+from rootstock.commands.local import cmd_remove_local
+from rootstock.local_checkpoints import (
+    local_checkpoints_for_root,
+    register_local_checkpoint,
+)
+
+_ENV_SOURCE = """\
+CHECKPOINTS = {"uma-s-1p1": "uma-s-1p1"}
+
+
+def setup(checkpoint, device="cuda"):
+    return None
+
+
+def setup_from_path(path, device="cuda", **kwargs):
+    return None
+"""
+
+
+@pytest.fixture
+def fake_root(tmp_path: Path) -> Path:
+    env_dir = tmp_path / "root" / "envs" / "uma"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+    (env_dir / "env_source.py").write_text(_ENV_SOURCE)
+    return tmp_path / "root"
+
+
+@pytest.fixture
+def registry(tmp_path: Path, monkeypatch) -> Path:
+    path = tmp_path / "registry.json"
+    monkeypatch.setattr(local_checkpoints, "DEFAULT_LOCAL_REGISTRY_FILE", path)
+    return path
+
+
+@pytest.fixture
+def weights(tmp_path: Path) -> Path:
+    path = tmp_path / "ft.pt"
+    path.write_bytes(b"weights")
+    return path
+
+
+def _make_args(root: Path, checkpoint: str):
+    class _Args:
+        pass
+
+    args = _Args()
+    args.checkpoint = checkpoint
+    args.root = str(root)
+    return args
+
+
+def test_remove_local_happy_path(fake_root, weights, registry, capsys):
+    register_local_checkpoint(fake_root, "my-ft", "uma", weights)
+    rc = cmd_remove_local(_make_args(fake_root, "my-ft"))
+    assert rc == 0
+    assert local_checkpoints_for_root(fake_root) == {}
+    assert weights.exists()  # never deletes the weights file
+    out = capsys.readouterr().out
+    assert "weights file untouched" in out
+    assert str(weights.resolve()) in out
+
+
+def test_remove_local_unknown_id_lists_registered(fake_root, weights, registry, capsys):
+    register_local_checkpoint(fake_root, "my-ft", "uma", weights)
+    rc = cmd_remove_local(_make_args(fake_root, "typo"))
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "my-ft" in err
+    # Registry untouched by the failed removal.
+    assert "my-ft" in local_checkpoints_for_root(fake_root)
+
+
+def test_remove_local_empty_registry(fake_root, registry, capsys):
+    rc = cmd_remove_local(_make_args(fake_root, "my-ft"))
+    assert rc == 1
+    assert "No local checkpoints" in capsys.readouterr().err

--- a/tests/cli/test_serve_local.py
+++ b/tests/cli/test_serve_local.py
@@ -1,0 +1,78 @@
+"""Tests for ``rootstock serve`` guards on local (user-registered) checkpoints."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rootstock import local_checkpoints
+from rootstock.commands.serve import cmd_serve
+from rootstock.local_checkpoints import register_local_checkpoint
+
+_ENV_SOURCE = """\
+CHECKPOINTS = {"uma-s-1p1": "uma-s-1p1"}
+
+
+def setup(checkpoint, device="cuda"):
+    return None
+
+
+def setup_from_path(path, device="cuda", **kwargs):
+    return None
+"""
+
+
+@pytest.fixture
+def fake_root(tmp_path: Path) -> Path:
+    env_dir = tmp_path / "root" / "envs" / "uma"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+    (env_dir / "env_source.py").write_text(_ENV_SOURCE)
+    return tmp_path / "root"
+
+
+@pytest.fixture
+def registry(tmp_path: Path, monkeypatch) -> Path:
+    path = tmp_path / "registry.json"
+    monkeypatch.setattr(local_checkpoints, "DEFAULT_LOCAL_REGISTRY_FILE", path)
+    return path
+
+
+@pytest.fixture
+def weights(tmp_path: Path) -> Path:
+    path = tmp_path / "ft.pt"
+    path.write_bytes(b"weights")
+    return path
+
+
+@pytest.fixture
+def registered(fake_root, weights, registry) -> str:
+    register_local_checkpoint(fake_root, "my-ft", "uma", weights)
+    return "my-ft"
+
+
+def _make_args(root: Path, checkpoint: str, **overrides):
+    class _Args:
+        pass
+
+    args = _Args()
+    args.root = str(root)
+    args.checkpoint = checkpoint
+    args.socket = str(root / "sock")
+    args.device = overrides.get("device", "cpu")
+    args.kwarg = overrides.get("kwarg")
+    return args
+
+
+def test_serve_rejects_path_kwarg_for_local(fake_root, registered, capsys):
+    rc = cmd_serve(_make_args(fake_root, registered, kwarg=["path=/x"]))
+    assert rc == 2
+    assert "reserved" in capsys.readouterr().err
+
+
+def test_serve_missing_weights_file(fake_root, registered, weights, capsys):
+    weights.unlink()
+    rc = cmd_serve(_make_args(fake_root, registered))
+    assert rc == 1
+    assert "no longer exists" in capsys.readouterr().err

--- a/tests/cli/test_smoke_test_local.py
+++ b/tests/cli/test_smoke_test_local.py
@@ -1,0 +1,240 @@
+"""Tests for ``rootstock smoke-test`` over local (user-registered) checkpoints."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from rootstock import local_checkpoints
+from rootstock.commands import smoke_test as smoke_module
+from rootstock.commands.smoke_test import cmd_smoke_test
+from rootstock.config import UserConfig
+from rootstock.local_checkpoints import (
+    local_checkpoints_for_root,
+    register_local_checkpoint,
+)
+from rootstock.manifest import (
+    EnvironmentInfo,
+    create_manifest,
+    load_manifest,
+    save_manifest,
+)
+
+_ENV_SOURCE = """\
+CHECKPOINTS = {"uma-s-1p1": "uma-s-1p1"}
+
+
+def setup(checkpoint, device="cuda"):
+    return None
+
+
+def setup_from_path(path, device="cuda", **kwargs):
+    return None
+"""
+
+
+@pytest.fixture
+def fake_root(tmp_path: Path, monkeypatch) -> Path:
+    """A root with one built env (uma) in the manifest, no fetched canonical
+    checkpoints — so only local checkpoints are selectable."""
+    root = tmp_path / "root"
+    env_dir = root / "envs" / "uma"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+    (env_dir / "env_source.py").write_text(_ENV_SOURCE)
+
+    cfg = UserConfig(name="t", email="t@t.t")
+    manifest = create_manifest(root, "test", cfg)
+    manifest.environments["uma"] = EnvironmentInfo(
+        built_at="2026-01-01T00:00:00+00:00",
+        source_hash="sha256:abc",
+        source="",
+        python_requires=">=3.10",
+        dependencies={},
+    )
+    save_manifest(manifest, root)
+
+    monkeypatch.setattr(
+        "rootstock.commands.smoke_test.update_and_push_manifest",
+        lambda *a, **kw: True,
+    )
+    return root
+
+
+@pytest.fixture
+def registry(tmp_path: Path, monkeypatch) -> Path:
+    path = tmp_path / "registry.json"
+    monkeypatch.setattr(local_checkpoints, "DEFAULT_LOCAL_REGISTRY_FILE", path)
+    return path
+
+
+@pytest.fixture
+def weights(tmp_path: Path) -> Path:
+    path = tmp_path / "ft.pt"
+    path.write_bytes(b"fine-tuned weights")
+    return path
+
+
+@pytest.fixture
+def registered(fake_root, weights, registry) -> str:
+    register_local_checkpoint(fake_root, "my-uma-ft", "uma", weights, setup_kwargs={"task": "omol"})
+    return "my-uma-ft"
+
+
+def _make_args(root: Path, **overrides):
+    class _Args:
+        pass
+
+    args = _Args()
+    args.env = overrides.get("env")
+    args.checkpoint = overrides.get("checkpoint")
+    args.device = overrides.get("device", "cuda")
+    args.json = overrides.get("json", False)
+    args.root = str(root)
+    args.no_push = overrides.get("no_push", True)
+    return args
+
+
+def test_local_checkpoint_verified_with_registered_kwargs(
+    fake_root, weights, registry, registered, monkeypatch
+):
+    calls = []
+
+    def fake_verify(**kwargs):
+        calls.append(kwargs)
+        return True, None
+
+    monkeypatch.setattr(smoke_module, "verify_checkpoint", fake_verify)
+    rc = cmd_smoke_test(_make_args(fake_root))
+    assert rc == 0
+
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["env_name"] == "uma"
+    assert call["checkpoint"] == "my-uma-ft"
+    assert call["checkpoint_path"] == str(weights.resolve())
+    # Registered kwargs, not {} — deliberate divergence from canonical policy.
+    assert call["setup_kwargs"] == {"task": "omol"}
+
+    entry = local_checkpoints_for_root(fake_root)["my-uma-ft"]
+    assert entry.verified_at is not None
+    assert entry.verified_device == "cuda"
+
+
+def test_local_failure_recorded_in_registry_not_manifest(
+    fake_root, weights, registry, registered, monkeypatch
+):
+    monkeypatch.setattr(smoke_module, "verify_checkpoint", lambda **kw: (False, "boom"))
+    manifest_before = (fake_root / "manifest.json").read_text()
+
+    rc = cmd_smoke_test(_make_args(fake_root))
+    assert rc == 1
+
+    entry = local_checkpoints_for_root(fake_root)["my-uma-ft"]
+    assert entry.last_error == "smoke-test: boom"
+    # Local-only run: the shared manifest is untouched (a non-maintainer
+    # couldn't write it anyway).
+    assert (fake_root / "manifest.json").read_text() == manifest_before
+
+
+def test_hash_mismatch_fails_without_verify(fake_root, weights, registry, registered, monkeypatch):
+    def unexpected_verify(**kw):
+        raise AssertionError("verify must not run on a hash mismatch")
+
+    monkeypatch.setattr(smoke_module, "verify_checkpoint", unexpected_verify)
+    weights.write_bytes(b"silently swapped weights")
+
+    rc = cmd_smoke_test(_make_args(fake_root))
+    assert rc == 1
+    entry = local_checkpoints_for_root(fake_root)["my-uma-ft"]
+    assert "changed on disk" in entry.last_error
+
+
+def test_missing_file_fails_without_verify(fake_root, weights, registry, registered, monkeypatch):
+    def unexpected_verify(**kw):
+        raise AssertionError("verify must not run on a missing file")
+
+    monkeypatch.setattr(smoke_module, "verify_checkpoint", unexpected_verify)
+    weights.unlink()
+
+    rc = cmd_smoke_test(_make_args(fake_root))
+    assert rc == 1
+    entry = local_checkpoints_for_root(fake_root)["my-uma-ft"]
+    assert "missing" in entry.last_error
+
+
+def test_env_filter_applies_to_locals(
+    fake_root, weights, registry, registered, monkeypatch, capsys
+):
+    monkeypatch.setattr(smoke_module, "verify_checkpoint", lambda **kw: (True, None))
+    rc = cmd_smoke_test(_make_args(fake_root, env="mace"))
+    assert rc == 0
+    assert "No fetched checkpoints to test." in capsys.readouterr().out
+
+
+def test_checkpoint_filter_selects_local(fake_root, weights, registry, registered, monkeypatch):
+    calls = []
+
+    def fake_verify(**kwargs):
+        calls.append(kwargs["checkpoint"])
+        return True, None
+
+    monkeypatch.setattr(smoke_module, "verify_checkpoint", fake_verify)
+    rc = cmd_smoke_test(_make_args(fake_root, env="uma", checkpoint="my-uma-ft"))
+    assert rc == 0
+    assert calls == ["my-uma-ft"]
+
+
+def test_json_output_tags_local_results(
+    fake_root, weights, registry, registered, monkeypatch, capsys
+):
+    monkeypatch.setattr(smoke_module, "verify_checkpoint", lambda **kw: (True, None))
+    rc = cmd_smoke_test(_make_args(fake_root, json=True))
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["passed"] == 1
+    (result,) = payload["results"]
+    assert result["local"] is True
+    assert result["checkpoint"] == "my-uma-ft"
+    assert result["verified_current"] is True
+
+
+def test_local_only_run_works_without_manifest(
+    fake_root, weights, registry, registered, monkeypatch
+):
+    # A root with no manifest but registered locals still smoke-tests them
+    # (e.g. a personal install created without init).
+    (fake_root / "manifest.json").unlink()
+    monkeypatch.setattr(smoke_module, "verify_checkpoint", lambda **kw: (True, None))
+    rc = cmd_smoke_test(_make_args(fake_root))
+    assert rc == 0
+    entry = local_checkpoints_for_root(fake_root)["my-uma-ft"]
+    assert entry.verified_at is not None
+    # Still no manifest afterwards — nothing shared was created.
+    assert not (fake_root / "manifest.json").exists()
+
+
+def test_manifest_updated_when_canonical_also_selected(
+    fake_root, weights, registry, registered, monkeypatch
+):
+    # Add a fetched canonical checkpoint; both it and the local one run, and
+    # the manifest write happens for the canonical outcome.
+    from rootstock.manifest import CheckpointInfo
+
+    manifest = load_manifest(fake_root)
+    manifest.environments["uma"].checkpoints["uma-s-1p1"] = CheckpointInfo(
+        fetched_at="2026-01-02T00:00:00+00:00"
+    )
+    save_manifest(manifest, fake_root)
+
+    monkeypatch.setattr(smoke_module, "verify_checkpoint", lambda **kw: (True, None))
+    rc = cmd_smoke_test(_make_args(fake_root))
+    assert rc == 0
+
+    fresh = load_manifest(fake_root)
+    canonical = fresh.environments["uma"].checkpoints["uma-s-1p1"]
+    assert canonical.verified_at is not None
+    # The local id never leaks into the manifest.
+    assert "my-uma-ft" not in fresh.environments["uma"].checkpoints

--- a/tests/cli/test_smoke_test_local.py
+++ b/tests/cli/test_smoke_test_local.py
@@ -165,6 +165,58 @@ def test_missing_file_fails_without_verify(fake_root, weights, registry, registe
     assert "missing" in entry.last_error
 
 
+def test_unreadable_file_fails_without_verify(
+    fake_root, weights, registry, registered, monkeypatch
+):
+    def unexpected_verify(**kw):
+        raise AssertionError("verify must not run on an unreadable file")
+
+    monkeypatch.setattr(smoke_module, "verify_checkpoint", unexpected_verify)
+    weights.chmod(0o000)
+
+    rc = cmd_smoke_test(_make_args(fake_root))
+    assert rc == 1
+    entry = local_checkpoints_for_root(fake_root)["my-uma-ft"]
+    assert "unreadable" in entry.last_error
+
+
+def test_unreadable_local_does_not_lose_canonical_outcomes(
+    fake_root, weights, registry, registered, monkeypatch
+):
+    # The local loop runs between the canonical loop and the manifest write;
+    # a per-file OSError must not abort the run and drop canonical outcomes.
+    from rootstock.manifest import CheckpointInfo
+
+    manifest = load_manifest(fake_root)
+    manifest.environments["uma"].checkpoints["uma-s-1p1"] = CheckpointInfo(
+        fetched_at="2026-01-02T00:00:00+00:00"
+    )
+    save_manifest(manifest, fake_root)
+    weights.chmod(0o000)
+
+    monkeypatch.setattr(smoke_module, "verify_checkpoint", lambda **kw: (True, None))
+    rc = cmd_smoke_test(_make_args(fake_root))
+    assert rc == 1  # the unreadable local failed
+
+    fresh = load_manifest(fake_root)
+    assert fresh.environments["uma"].checkpoints["uma-s-1p1"].verified_at is not None
+
+
+def test_failed_local_revokes_earlier_verification(
+    fake_root, weights, registry, registered, monkeypatch
+):
+    from rootstock.local_checkpoints import record_local_verification
+
+    record_local_verification(fake_root, "my-uma-ft", ok=True, device="cuda")
+    monkeypatch.setattr(smoke_module, "verify_checkpoint", lambda **kw: (False, "boom"))
+
+    rc = cmd_smoke_test(_make_args(fake_root))
+    assert rc == 1
+    entry = local_checkpoints_for_root(fake_root)["my-uma-ft"]
+    assert entry.verified_at is None
+    assert entry.last_error == "smoke-test: boom"
+
+
 def test_env_filter_applies_to_locals(
     fake_root, weights, registry, registered, monkeypatch, capsys
 ):

--- a/tests/cli/test_status_local.py
+++ b/tests/cli/test_status_local.py
@@ -1,0 +1,158 @@
+"""Tests for the local-checkpoints section of ``rootstock status``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from rootstock import local_checkpoints
+from rootstock.commands.status import cmd_status
+from rootstock.config import UserConfig
+from rootstock.local_checkpoints import (
+    record_local_verification,
+    register_local_checkpoint,
+)
+from rootstock.manifest import (
+    EnvironmentInfo,
+    create_manifest,
+    save_manifest,
+)
+
+_ENV_SOURCE = """\
+CHECKPOINTS = {"uma-s-1p1": "uma-s-1p1"}
+
+
+def setup(checkpoint, device="cuda"):
+    return None
+
+
+def setup_from_path(path, device="cuda", **kwargs):
+    return None
+"""
+
+
+@pytest.fixture
+def fake_root(tmp_path: Path) -> Path:
+    root = tmp_path / "root"
+    env_dir = root / "envs" / "uma"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+    (env_dir / "env_source.py").write_text(_ENV_SOURCE)
+
+    cfg = UserConfig(name="t", email="t@t.t")
+    manifest = create_manifest(root, "test", cfg)
+    manifest.environments["uma"] = EnvironmentInfo(
+        built_at="2026-01-01T00:00:00+00:00",
+        source_hash="sha256:abc",
+        source="",
+        python_requires=">=3.10",
+        dependencies={},
+    )
+    save_manifest(manifest, root)
+    return root
+
+
+@pytest.fixture
+def registry(tmp_path: Path, monkeypatch) -> Path:
+    path = tmp_path / "registry.json"
+    monkeypatch.setattr(local_checkpoints, "DEFAULT_LOCAL_REGISTRY_FILE", path)
+    return path
+
+
+@pytest.fixture
+def weights(tmp_path: Path) -> Path:
+    path = tmp_path / "ft.pt"
+    path.write_bytes(b"weights")
+    return path
+
+
+def _make_args(root: Path, **overrides):
+    class _Args:
+        pass
+
+    args = _Args()
+    args.root = str(root)
+    args.json = overrides.get("json", False)
+    args.sizes = overrides.get("sizes", False)
+    return args
+
+
+def test_status_omits_section_when_no_locals(fake_root, registry, capsys):
+    assert cmd_status(_make_args(fake_root)) == 0
+    assert "Local checkpoints" not in capsys.readouterr().out
+
+
+def test_status_shows_verified_local(fake_root, registry, weights, capsys):
+    register_local_checkpoint(fake_root, "my-ft", "uma", weights)
+    record_local_verification(fake_root, "my-ft", ok=True, device="cuda")
+
+    assert cmd_status(_make_args(fake_root)) == 0
+    out = capsys.readouterr().out
+    assert "Local checkpoints (this user):" in out
+    assert "my-ft" in out
+    assert str(weights.resolve()) in out
+    assert "✓" in out
+    assert "file missing" not in out
+
+
+def test_status_flags_missing_file_and_unverified(fake_root, registry, weights, capsys):
+    register_local_checkpoint(fake_root, "my-ft", "uma", weights)
+    weights.unlink()
+
+    cmd_status(_make_args(fake_root))
+    out = capsys.readouterr().out
+    assert "file missing" in out
+    assert "not verified" in out
+
+
+def test_status_flags_stale_after_env_rebuild(fake_root, registry, weights, capsys):
+    register_local_checkpoint(fake_root, "my-ft", "uma", weights)
+    # Verified before the (future-dated) env rebuild → stale.
+    record_local_verification(fake_root, "my-ft", ok=True, device="cuda")
+    from rootstock.manifest import load_manifest
+
+    manifest = load_manifest(fake_root)
+    manifest.environments["uma"].built_at = "2999-01-01T00:00:00+00:00"
+    save_manifest(manifest, fake_root)
+
+    cmd_status(_make_args(fake_root))
+    assert "stale" in capsys.readouterr().out
+
+
+def test_status_flags_shadowed_local(fake_root, registry, weights, capsys):
+    register_local_checkpoint(fake_root, "my-ft", "uma", weights)
+    # An env source updated afterwards to declare the same id shadows it.
+    (fake_root / "envs" / "uma" / "env_source.py").write_text(
+        _ENV_SOURCE.replace('"uma-s-1p1": "uma-s-1p1"', '"my-ft": "x"')
+    )
+    cmd_status(_make_args(fake_root))
+    assert "shadowed" in capsys.readouterr().out
+
+
+def test_status_json_local_checkpoints(fake_root, registry, weights, capsys):
+    register_local_checkpoint(fake_root, "my-ft", "uma", weights, setup_kwargs={"task": "omol"})
+    record_local_verification(fake_root, "my-ft", ok=True, device="cuda")
+
+    assert cmd_status(_make_args(fake_root, json=True)) == 0
+    payload = json.loads(capsys.readouterr().out)
+    entry = payload["local_checkpoints"]["my-ft"]
+    assert entry["env"] == "uma"
+    assert entry["path"] == str(weights.resolve())
+    assert entry["exists"] is True
+    assert entry["verified_current"] is True
+    assert entry["shadowed_by"] is None
+    assert entry["setup_kwargs"] == {"task": "omol"}
+
+
+def test_status_json_empty_locals_key_present(fake_root, registry, capsys):
+    cmd_status(_make_args(fake_root, json=True))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["local_checkpoints"] == {}
+
+
+def test_status_survives_corrupt_registry(fake_root, registry, capsys):
+    registry.write_text("{not json")
+    assert cmd_status(_make_args(fake_root)) == 0
+    assert "unreadable" in capsys.readouterr().out

--- a/tests/integrations/test_mlipx.py
+++ b/tests/integrations/test_mlipx.py
@@ -24,7 +24,9 @@ def test_get_calculator_reaches_env_boundary():
     # Without an installed env, construction gets all the way to the checkpoint
     # lookup and raises. This proves the wiring reaches Rootstock without
     # requiring a built environment (so it runs in CI).
-    model = RootstockMLIPxModel(checkpoint="mace-mp-0-medium", root="/tmp/no_env_here", device="cpu")
+    model = RootstockMLIPxModel(
+        checkpoint="mace-mp-0-medium", root="/tmp/no_env_here", device="cpu"
+    )
     with pytest.raises(CheckpointNotFoundError):
         model.get_calculator()
 

--- a/tests/local/test_declares_setup_from_path.py
+++ b/tests/local/test_declares_setup_from_path.py
@@ -1,0 +1,54 @@
+"""Tests for environment.declares_setup_from_path."""
+
+from __future__ import annotations
+
+from rootstock.environment import declares_setup_from_path
+
+_WITH_HOOK = """\
+CHECKPOINTS = {"a-1": "a"}
+
+
+def setup(checkpoint, device="cuda"):
+    return None
+
+
+def setup_from_path(path, device="cuda", **kwargs):
+    return None
+"""
+
+_WITHOUT_HOOK = """\
+CHECKPOINTS = {"a-1": "a"}
+
+
+def setup(checkpoint, device="cuda"):
+    return None
+"""
+
+_NESTED_ONLY = """\
+CHECKPOINTS = {"a-1": "a"}
+
+
+def setup(checkpoint, device="cuda"):
+    def setup_from_path(path):
+        return None
+
+    return None
+"""
+
+
+def test_detects_module_level_hook(tmp_path):
+    src = tmp_path / "env_source.py"
+    src.write_text(_WITH_HOOK)
+    assert declares_setup_from_path(src) is True
+
+
+def test_absent_hook(tmp_path):
+    src = tmp_path / "env_source.py"
+    src.write_text(_WITHOUT_HOOK)
+    assert declares_setup_from_path(src) is False
+
+
+def test_nested_definition_does_not_count(tmp_path):
+    src = tmp_path / "env_source.py"
+    src.write_text(_NESTED_ONLY)
+    assert declares_setup_from_path(src) is False

--- a/tests/local/test_registry.py
+++ b/tests/local/test_registry.py
@@ -1,0 +1,261 @@
+"""Tests for the per-user local-checkpoint registry."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from rootstock.local_checkpoints import (
+    LocalCheckpointEntry,
+    LocalCheckpointError,
+    hash_weights_file,
+    load_local_registry,
+    local_checkpoints_for_root,
+    record_local_verification,
+    register_local_checkpoint,
+    remove_local_checkpoint,
+    save_local_registry,
+)
+
+_ENV_WITH_HOOK = """\
+CHECKPOINTS = {"uma-s-1p1": "uma-s-1p1"}
+
+
+def setup(checkpoint, device="cuda"):
+    return None
+
+
+def setup_from_path(path, device="cuda", **kwargs):
+    return None
+"""
+
+_ENV_WITHOUT_HOOK = """\
+CHECKPOINTS = {"mace-mp-0-medium": "medium"}
+
+
+def setup(checkpoint, device="cuda"):
+    return None
+"""
+
+
+@pytest.fixture
+def fake_root(tmp_path: Path) -> Path:
+    """Install root with a hook-declaring 'uma' env and a plain 'mace' env."""
+    root = tmp_path / "root"
+    for name, source in (("uma", _ENV_WITH_HOOK), ("mace", _ENV_WITHOUT_HOOK)):
+        env_dir = root / "envs" / name
+        (env_dir / "bin").mkdir(parents=True)
+        (env_dir / "bin" / "python").touch()
+        (env_dir / "env_source.py").write_text(source)
+    return root
+
+
+@pytest.fixture
+def weights(tmp_path: Path) -> Path:
+    path = tmp_path / "my-uma-ft.pt"
+    path.write_bytes(b"weights bytes " * 100)
+    return path
+
+
+@pytest.fixture
+def registry(tmp_path: Path) -> Path:
+    return tmp_path / "registry.json"
+
+
+# ---------- hash_weights_file ----------------------------------------------
+
+
+def test_hash_weights_file(weights):
+    sha, size = hash_weights_file(weights)
+    expected = hashlib.sha256(weights.read_bytes()).hexdigest()
+    assert sha == f"sha256:{expected}"
+    assert size == weights.stat().st_size
+
+
+# ---------- load / save round-trip ------------------------------------------
+
+
+def test_load_missing_file_is_empty(registry):
+    assert load_local_registry(registry) == {}
+
+
+def test_round_trip(registry):
+    entry = LocalCheckpointEntry(
+        env="uma",
+        path="/scratch/me/ft.pt",
+        sha256="sha256:abc",
+        size=42,
+        setup_kwargs={"task": "omol"},
+        registered_at="2026-07-21T00:00:00+00:00",
+    )
+    save_local_registry({"/some/root": {"my-ft": entry}}, registry)
+    loaded = load_local_registry(registry)
+    assert loaded["/some/root"]["my-ft"] == entry
+
+
+def test_save_leaves_no_temp_files(registry):
+    save_local_registry({}, registry)
+    siblings = [p.name for p in registry.parent.iterdir()]
+    assert siblings == [registry.name]
+
+
+def test_corrupt_registry_raises(registry):
+    registry.write_text("{not json")
+    with pytest.raises(LocalCheckpointError, match="corrupted"):
+        load_local_registry(registry)
+
+
+def test_newer_schema_raises(registry):
+    registry.write_text(json.dumps({"schema_version": 99, "roots": {}}))
+    with pytest.raises(LocalCheckpointError, match="newer rootstock"):
+        load_local_registry(registry)
+
+
+# ---------- register validations --------------------------------------------
+
+
+def test_register_happy_path(fake_root, weights, registry):
+    entry = register_local_checkpoint(
+        fake_root,
+        "my-uma-ft",
+        "uma",
+        weights,
+        setup_kwargs={"task": "omol"},
+        registry_path=registry,
+    )
+    assert entry.env == "uma"
+    assert entry.path == str(weights.resolve())
+    assert entry.sha256.startswith("sha256:")
+    assert entry.size == weights.stat().st_size
+    assert entry.verified_at is None
+
+    on_disk = local_checkpoints_for_root(fake_root, registry_path=registry)
+    assert on_disk["my-uma-ft"] == entry
+
+
+def test_register_missing_weights_file(fake_root, registry, tmp_path):
+    with pytest.raises(LocalCheckpointError, match="not found"):
+        register_local_checkpoint(
+            fake_root, "my-ft", "uma", tmp_path / "nope.pt", registry_path=registry
+        )
+
+
+def test_register_unbuilt_env(fake_root, weights, registry):
+    with pytest.raises(LocalCheckpointError, match="not built"):
+        register_local_checkpoint(fake_root, "my-ft", "tensornet", weights, registry_path=registry)
+
+
+def test_register_env_without_hook(fake_root, weights, registry):
+    with pytest.raises(LocalCheckpointError, match="setup_from_path") as exc:
+        register_local_checkpoint(fake_root, "my-ft", "mace", weights, registry_path=registry)
+    # The error points at envs that DO support local checkpoints.
+    assert "uma" in str(exc.value)
+
+
+def test_register_canonical_collision(fake_root, weights, registry):
+    with pytest.raises(LocalCheckpointError, match="canonical"):
+        register_local_checkpoint(fake_root, "uma-s-1p1", "uma", weights, registry_path=registry)
+
+
+@pytest.mark.parametrize("key", ["checkpoint", "device", "path"])
+def test_register_reserved_kwargs(fake_root, weights, registry, key):
+    with pytest.raises(LocalCheckpointError, match="reserved"):
+        register_local_checkpoint(
+            fake_root,
+            "my-ft",
+            "uma",
+            weights,
+            setup_kwargs={key: "x"},
+            registry_path=registry,
+        )
+
+
+def test_reregister_overwrites_and_resets_verification(fake_root, weights, registry):
+    register_local_checkpoint(fake_root, "my-ft", "uma", weights, registry_path=registry)
+    record_local_verification(fake_root, "my-ft", ok=True, device="cuda", registry_path=registry)
+    assert (
+        local_checkpoints_for_root(fake_root, registry_path=registry)["my-ft"].verified_at
+        is not None
+    )
+
+    entry = register_local_checkpoint(fake_root, "my-ft", "uma", weights, registry_path=registry)
+    assert entry.verified_at is None
+    assert entry.last_error is None
+
+
+def test_root_key_normalization(fake_root, weights, registry):
+    register_local_checkpoint(fake_root, "my-ft", "uma", weights, registry_path=registry)
+    # Reaching the same root through ".." resolves to the same entry set.
+    indirect = fake_root / "envs" / ".."
+    assert "my-ft" in local_checkpoints_for_root(indirect, registry_path=registry)
+
+
+# ---------- remove -----------------------------------------------------------
+
+
+def test_remove_happy_path(fake_root, weights, registry):
+    register_local_checkpoint(fake_root, "my-ft", "uma", weights, registry_path=registry)
+    entry = remove_local_checkpoint(fake_root, "my-ft", registry_path=registry)
+    assert entry.path == str(weights.resolve())
+    assert local_checkpoints_for_root(fake_root, registry_path=registry) == {}
+    # Weights file untouched.
+    assert weights.exists()
+    # Empty root key pruned from the file.
+    assert load_local_registry(registry) == {}
+
+
+def test_remove_unknown_id_lists_registered(fake_root, weights, registry):
+    register_local_checkpoint(fake_root, "my-ft", "uma", weights, registry_path=registry)
+    with pytest.raises(LocalCheckpointError, match="my-ft"):
+        remove_local_checkpoint(fake_root, "typo", registry_path=registry)
+
+
+def test_remove_from_empty_registry(fake_root, registry):
+    with pytest.raises(LocalCheckpointError, match="No local checkpoints"):
+        remove_local_checkpoint(fake_root, "my-ft", registry_path=registry)
+
+
+# ---------- record_local_verification ----------------------------------------
+
+
+def test_record_verification_success(fake_root, weights, registry):
+    register_local_checkpoint(fake_root, "my-ft", "uma", weights, registry_path=registry)
+    record_local_verification(fake_root, "my-ft", ok=True, device="cuda", registry_path=registry)
+    entry = local_checkpoints_for_root(fake_root, registry_path=registry)["my-ft"]
+    assert entry.verified_at is not None
+    assert entry.verified_device == "cuda"
+    assert entry.last_error is None
+
+
+def test_record_verification_failure(fake_root, weights, registry):
+    register_local_checkpoint(fake_root, "my-ft", "uma", weights, registry_path=registry)
+    record_local_verification(
+        fake_root,
+        "my-ft",
+        ok=False,
+        device="cuda",
+        error="verify: boom",
+        registry_path=registry,
+    )
+    entry = local_checkpoints_for_root(fake_root, registry_path=registry)["my-ft"]
+    assert entry.verified_at is None
+    assert entry.last_error == "verify: boom"
+
+
+def test_record_verification_for_removed_id_is_noop(fake_root, registry):
+    # Outcome for an id removed meanwhile has nothing to attach to.
+    record_local_verification(fake_root, "gone", ok=True, device="cuda", registry_path=registry)
+    assert load_local_registry(registry) == {}
+
+
+# ---------- permissions -------------------------------------------------------
+
+
+def test_registry_file_is_private(fake_root, weights, registry):
+    register_local_checkpoint(fake_root, "my-ft", "uma", weights, registry_path=registry)
+    mode = os.stat(registry).st_mode & 0o777
+    assert mode == 0o600

--- a/tests/local/test_registry.py
+++ b/tests/local/test_registry.py
@@ -246,6 +246,25 @@ def test_record_verification_failure(fake_root, weights, registry):
     assert entry.last_error == "verify: boom"
 
 
+def test_record_verification_failure_revokes_earlier_success(fake_root, weights, registry):
+    # Same semantics as the manifest: a failure clears verified state, so a
+    # previously-verified checkpoint can't show ✓ alongside last_error.
+    register_local_checkpoint(fake_root, "my-ft", "uma", weights, registry_path=registry)
+    record_local_verification(fake_root, "my-ft", ok=True, device="cuda", registry_path=registry)
+    record_local_verification(
+        fake_root,
+        "my-ft",
+        ok=False,
+        device="cuda",
+        error="smoke-test: boom",
+        registry_path=registry,
+    )
+    entry = local_checkpoints_for_root(fake_root, registry_path=registry)["my-ft"]
+    assert entry.verified_at is None
+    assert entry.verified_device is None
+    assert entry.last_error == "smoke-test: boom"
+
+
 def test_record_verification_for_removed_id_is_noop(fake_root, registry):
     # Outcome for an id removed meanwhile has nothing to attach to.
     record_local_verification(fake_root, "gone", ok=True, device="cuda", registry_path=registry)

--- a/tests/local/test_resolve_checkpoint.py
+++ b/tests/local/test_resolve_checkpoint.py
@@ -1,0 +1,113 @@
+"""Tests for resolve_checkpoint (canonical + local overlay)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rootstock.environment import CheckpointNotFoundError
+from rootstock.local_checkpoints import (
+    register_local_checkpoint,
+    resolve_checkpoint,
+)
+
+_ENV_SOURCE = """\
+CHECKPOINTS = {"uma-s-1p1": "uma-s-1p1"}
+
+
+def setup(checkpoint, device="cuda"):
+    return None
+
+
+def setup_from_path(path, device="cuda", **kwargs):
+    return None
+"""
+
+
+@pytest.fixture
+def fake_root(tmp_path: Path) -> Path:
+    root = tmp_path / "root"
+    env_dir = root / "envs" / "uma"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+    (env_dir / "env_source.py").write_text(_ENV_SOURCE)
+    return root
+
+
+@pytest.fixture
+def weights(tmp_path: Path) -> Path:
+    path = tmp_path / "ft.pt"
+    path.write_bytes(b"weights")
+    return path
+
+
+@pytest.fixture
+def registry(tmp_path: Path) -> Path:
+    return tmp_path / "registry.json"
+
+
+def test_canonical_hit(fake_root, registry):
+    resolved = resolve_checkpoint(fake_root, "uma-s-1p1", registry_path=registry)
+    assert resolved.env_name == "uma"
+    assert resolved.path is None
+    assert resolved.setup_kwargs == {}
+    assert not resolved.is_local
+
+
+def test_local_hit(fake_root, weights, registry):
+    register_local_checkpoint(
+        fake_root,
+        "my-ft",
+        "uma",
+        weights,
+        setup_kwargs={"task": "omol"},
+        registry_path=registry,
+    )
+    resolved = resolve_checkpoint(fake_root, "my-ft", registry_path=registry)
+    assert resolved.is_local
+    assert resolved.env_name == "uma"
+    assert resolved.path == str(weights.resolve())
+    assert resolved.setup_kwargs == {"task": "omol"}
+
+
+def test_canonical_shadows_local(fake_root, weights, registry):
+    # Registration prevents this direction, but an env installed *after* a
+    # local registration can introduce a collision — canonical wins.
+    register_local_checkpoint(fake_root, "my-ft", "uma", weights, registry_path=registry)
+    (fake_root / "envs" / "uma" / "env_source.py").write_text(
+        _ENV_SOURCE.replace('"uma-s-1p1": "uma-s-1p1"', '"my-ft": "x", "uma-s-1p1": "y"')
+    )
+    resolved = resolve_checkpoint(fake_root, "my-ft", registry_path=registry)
+    assert not resolved.is_local
+
+
+def test_miss_mentions_both_namespaces(fake_root, weights, registry):
+    register_local_checkpoint(fake_root, "my-ft", "uma", weights, registry_path=registry)
+    with pytest.raises(CheckpointNotFoundError) as exc:
+        resolve_checkpoint(fake_root, "typo", registry_path=registry)
+    msg = str(exc.value)
+    assert "uma-s-1p1" in msg  # canonical listing preserved
+    assert "my-ft" in msg  # registered local ids listed
+    assert "add-local" in msg  # registration hint
+
+
+def test_miss_without_locals_still_hints_add_local(fake_root, registry):
+    with pytest.raises(CheckpointNotFoundError, match="add-local"):
+        resolve_checkpoint(fake_root, "typo", registry_path=registry)
+
+
+def test_corrupt_registry_does_not_affect_canonical(fake_root, registry):
+    # Canonical ids resolve before the registry is consulted at all.
+    registry.write_text("{not json")
+    resolved = resolve_checkpoint(fake_root, "uma-s-1p1", registry_path=registry)
+    assert resolved.env_name == "uma"
+
+
+def test_corrupt_registry_warns_and_misses_cleanly(fake_root, registry, capsys):
+    # A broken per-user file must surface as CheckpointNotFoundError (with a
+    # warning), never as a LocalCheckpointError crash.
+    registry.write_text("{not json")
+    with pytest.raises(CheckpointNotFoundError):
+        resolve_checkpoint(fake_root, "typo", registry_path=registry)
+    assert "ignoring local-checkpoint registry" in capsys.readouterr().err

--- a/tests/server/test_worker_payload.py
+++ b/tests/server/test_worker_payload.py
@@ -1,0 +1,59 @@
+"""Tests for the worker-spec payload RootstockServer hands to spawn_in_env."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from rootstock.server import RootstockServer
+
+
+class _StopSpawn(RuntimeError):
+    """Raised by the fake spawn_in_env so _start_worker never launches."""
+
+
+@pytest.fixture
+def captured_payload(monkeypatch):
+    captured = {}
+
+    @contextmanager
+    def fake_spawn(root, env_name, wrapper_source, payload, cache_root=None):
+        captured.update(payload)
+        raise _StopSpawn("payload captured")
+        yield  # pragma: no cover
+
+    # _start_worker imports spawn_in_env from .spawn at call time.
+    monkeypatch.setattr("rootstock.spawn.spawn_in_env", fake_spawn)
+    return captured
+
+
+def _start(server) -> None:
+    server.socket_path = "/tmp/fake_sock"
+    with pytest.raises(_StopSpawn):
+        server._start_worker()
+
+
+def test_payload_carries_checkpoint_path(captured_payload, tmp_path: Path):
+    server = RootstockServer(
+        env_name="uma",
+        checkpoint="my-ft",
+        device="cpu",
+        root=tmp_path,
+        checkpoint_path="/scratch/me/ft.pt",
+    )
+    _start(server)
+    assert captured_payload["checkpoint"] == "my-ft"
+    assert captured_payload["checkpoint_path"] == "/scratch/me/ft.pt"
+
+
+def test_payload_checkpoint_path_defaults_to_none(captured_payload, tmp_path: Path):
+    server = RootstockServer(
+        env_name="mace",
+        checkpoint="mace-mp-0-medium",
+        device="cpu",
+        root=tmp_path,
+    )
+    _start(server)
+    assert captured_payload["checkpoint_path"] is None

--- a/tests/verify/test_verify_checkpoint.py
+++ b/tests/verify/test_verify_checkpoint.py
@@ -118,6 +118,33 @@ def test_verify_rejects_nonfinite_forces(stub_server):
     assert "forces" in err
 
 
+def test_verify_forwards_checkpoint_path(monkeypatch):
+    captured = {}
+
+    def factory(**ctor_kwargs):
+        captured.update(ctor_kwargs)
+        return _StubServer(energy=-10.5, forces=_ok_forces(), virial=_ok_virial())
+
+    monkeypatch.setattr("rootstock.server.RootstockServer", factory)
+    ok, _ = verify.verify_checkpoint(
+        Path("/tmp"), "uma", "my-ft", "cuda", checkpoint_path="/scratch/me/ft.pt"
+    )
+    assert ok is True
+    assert captured["checkpoint_path"] == "/scratch/me/ft.pt"
+
+
+def test_verify_defaults_checkpoint_path_to_none(monkeypatch):
+    captured = {}
+
+    def factory(**ctor_kwargs):
+        captured.update(ctor_kwargs)
+        return _StubServer(energy=-10.5, forces=_ok_forces(), virial=_ok_virial())
+
+    monkeypatch.setattr("rootstock.server.RootstockServer", factory)
+    verify.verify_checkpoint(Path("/tmp"), "mace", "mace-mp-0-medium", "cuda")
+    assert captured["checkpoint_path"] is None
+
+
 def test_verify_rejects_all_zero_forces(stub_server):
     """The silent-failure guard — model returned zeros for everything."""
     stub_server(energy=-1.0, forces=np.zeros((3, 3)), virial=_ok_virial())

--- a/tests/worker/test_wrapper_kwargs.py
+++ b/tests/worker/test_wrapper_kwargs.py
@@ -64,6 +64,13 @@ def test_setup_kwargs_round_trip_through_json_sidecar(fake_root, kwargs):
         assert spec_data["setup_kwargs"] == kwargs
 
 
+def test_checkpoint_path_round_trip(fake_root):
+    payload = {**_payload(), "checkpoint_path": "/scratch/me/ft.pt"}
+    with spawn_in_env(fake_root, "fake_env", WORKER_WRAPPER, payload) as spec:
+        spec_data = json.loads(Path(spec.cmd[2]).read_text())
+        assert spec_data["checkpoint_path"] == "/scratch/me/ft.pt"
+
+
 def test_staged_files_removed_on_exit(fake_root):
     with spawn_in_env(fake_root, "fake_env", WORKER_WRAPPER, _payload()) as spec:
         wrapper, sidecar = Path(spec.cmd[1]), Path(spec.cmd[2])

--- a/tests/worker/test_wrapper_local_e2e.py
+++ b/tests/worker/test_wrapper_local_e2e.py
@@ -1,0 +1,92 @@
+"""End-to-end tests of WORKER_WRAPPER's setup vs setup_from_path branch.
+
+Executes the actual wrapper text under this interpreter against a fake env
+whose loaders record their arguments and exit before any socket I/O.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from rootstock.spawn import WORKER_WRAPPER
+
+_ENV_SOURCE_TEMPLATE = """\
+import json
+
+CHECKPOINTS = {{"canon-1": "canon"}}
+
+
+def setup(checkpoint, device="cuda", **kwargs):
+    with open({record!r}, "w") as f:
+        json.dump({{"fn": "setup", "target": checkpoint, "device": device, "kwargs": kwargs}}, f)
+    raise SystemExit(0)
+
+
+def setup_from_path(path, device="cuda", **kwargs):
+    with open({record!r}, "w") as f:
+        json.dump(
+            {{"fn": "setup_from_path", "target": path, "device": device, "kwargs": kwargs}}, f
+        )
+    raise SystemExit(0)
+"""
+
+
+@pytest.fixture
+def staged(tmp_path: Path):
+    """Stage the real wrapper text + a fake env_source; return a runner."""
+    record = tmp_path / "record.json"
+    env_dir = tmp_path / "env"
+    env_dir.mkdir()
+    (env_dir / "env_source.py").write_text(_ENV_SOURCE_TEMPLATE.format(record=str(record)))
+    wrapper = tmp_path / "wrapper.py"
+    wrapper.write_text(WORKER_WRAPPER)
+
+    def run(spec: dict) -> dict:
+        sidecar = tmp_path / "spec.json"
+        sidecar.write_text(json.dumps({**spec, "env_dir": str(env_dir)}))
+        result = subprocess.run(
+            [sys.executable, str(wrapper), str(sidecar)],
+            cwd=Path(__file__).resolve().parents[2],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        return json.loads(record.read_text())
+
+    return run
+
+
+def _spec(**extra) -> dict:
+    return {
+        "checkpoint": "canon-1",
+        "device": "cpu",
+        "socket_path": "/tmp/does_not_matter",
+        "setup_kwargs": {"task": "omol"},
+        **extra,
+    }
+
+
+def test_canonical_mode_uses_setup(staged):
+    record = staged(_spec())
+    assert record["fn"] == "setup"
+    assert record["target"] == "canon-1"
+    assert record["kwargs"] == {"task": "omol"}
+
+
+def test_local_mode_uses_setup_from_path(staged):
+    record = staged(_spec(checkpoint="my-ft", checkpoint_path="/scratch/me/ft.pt"))
+    assert record["fn"] == "setup_from_path"
+    assert record["target"] == "/scratch/me/ft.pt"
+    assert record["kwargs"] == {"task": "omol"}
+
+
+def test_null_checkpoint_path_is_canonical(staged):
+    # The server always includes the key; null must mean canonical.
+    record = staged(_spec(checkpoint_path=None))
+    assert record["fn"] == "setup"
+    assert record["target"] == "canon-1"


### PR DESCRIPTION
## Summary

Users can now bring their own checkpoints — e.g. a fine-tuned UMA model — **without any write access to the shared install**:

```bash
rootstock add-local /scratch/me/my-uma-ft.pt --env uma --id my-uma-ft --kwarg task=omol
```

```python
with RootstockCalculator(cluster="sophia", checkpoint="my-uma-ft") as calc:
    ...
```

The registered id works everywhere a canonical id does (calculator, `serve`, `benchmark`, `status`, `smoke-test`).

## Design

A local checkpoint is a **registered, named checkpoint bound to an existing env** — this extends the checkpoint namespace, not the environment mechanism. Three constraints shaped it:

1. Shared installs are world-readable but maintainer-writable, so all BYO state is a **per-user overlay**: the weights stay on the user's own storage, and the registration lives in `~/.config/rootstock/local-checkpoints.json` (atomic writes, sha256 + size recorded, schema-versioned).
2. Loading a weights *file* is usually a different upstream call than loading a registry *name* (FAIRChem: `load_predict_unit(path)` vs `get_predict_unit(name)`), so envs opt in by declaring `setup_from_path(path, device, **kwargs)` next to `setup()`. Presence is AST-detected like `CHECKPOINTS`; envs without it reject registration with a clear error.
3. Resolution checks env-declared canonical ids first, then the registry (`resolve_checkpoint()` in the new `rootstock/local_checkpoints.py`); registration rejects collisions in the other direction, and `status` flags shadowing.

The existing `verified_at > built_at` staleness rule now covers fine-tunes for free: an env rebuild (e.g. a fairchem bump) marks registered locals stale until re-verified.

## Implementation notes

- **`worker.py` is untouched.** Workers frozen inside built envs swallow unknown `run_worker` kwargs (`**_ignored`), so a new kwarg would be silently dropped. Instead the static `WORKER_WRAPPER` branches on a new `checkpoint_path` sidecar field, imports `setup_from_path` as the setup function, and passes the path through the existing `checkpoint` parameter — works against every env ever built.
- `add-local` runs the same H2O verification as `add` (`--no-verify` for login nodes); failures keep the entry with `last_error` recorded, same recoverable semantics as `add`.
- `smoke-test` re-hashes each local first — a silently swapped file fails without being blessed — then verifies with the *registered* kwargs (unlike the canonical `{}` policy: they're part of the registration contract). Outcomes go to the per-user registry; **a local-only run never takes the manifest lock or pushes**, so non-maintainers can schedule their own re-verification.
- `remove-local` deletes the registry entry only, never the weights file.
- `benchmark` needed two changes: resolution in `benchmark_one` plus a hidden `--checkpoint-path` branch in its in-env worker mode, keeping both arms on identical code.
- Reserved setup kwargs now include `"path"` (it's `setup_from_path`'s first parameter).
- A corrupt registry fails loudly in `add-local`/`remove-local` but degrades to canonical-only (with a warning) in resolution and `status`, so a broken per-user file can't brick canonical use.

Docs: `setup_from_path` authoring guide in `docs/environments.md`, new sections in `docs/api.md`, README, CLAUDE.md, and `docs/nightly-smoke-testing.md`.

## Testing

- ~65 new unit tests (registry, resolution, wrapper branch e2e under a real interpreter, calculator, both CLI commands, status/smoke-test integration); full suite: **476 passed, 2 skipped**; `ruff check` clean.
- Verified end-to-end with a real worker subprocess and i-PI socket round-trip using a Lennard-Jones env: register → verify → `RootstockCalculator` energy/forces → `status`/`add --list` → tampered-file detection in `smoke-test` → `remove-local` → post-removal `CheckpointNotFoundError` pointing at `add-local`.
- Not yet exercised: a real fine-tuned UMA `.pt` on a cluster as a non-maintainer (planned on Sophia). The bundled `uma` env file needs its `setup_from_path` added at deploy time (env sources aren't tracked in this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)