### PR TITLE
Resolve benchmark cache_root through layout.json like every other entry point

### DIFF
--- a/rootstock/benchmark.py
+++ b/rootstock/benchmark.py
@@ -397,18 +397,19 @@ def main(argv=None) -> int:
 
     # Resolve root and cache_root (needed even with --cluster: the in-env arm
     # builds its cache env from these paths directly, never going through
-    # RootstockCalculator's cluster resolution — so a registered split
-    # cache_root (e.g. Perlmutter's PSCRATCH) must be threaded through here or
-    # that arm looks for weights under `root`).
+    # RootstockCalculator's cluster resolution — so a split cache_root must be
+    # threaded through here or that arm looks for weights under `root`).
+    # cache_root resolves through resolve_cache_root like every other entry
+    # point, so a split cache declared in {root}/layout.json (e.g. Frontier:
+    # root on read-only /sw, weights on Lustre) is honored with a bare --root,
+    # not only via --cache-root or the cluster registry.
     cluster_info = None
     if args.cluster:
         from rootstock.clusters import get_cluster
         cluster_info = get_cluster(args.cluster)
     root = Path(args.root) if args.root else Path(cluster_info.root)
-    if args.cache_root:
-        cache_root = Path(args.cache_root)
-    else:
-        cache_root = cluster_info.cache_root if cluster_info else None
+    from rootstock.layout import resolve_cache_root
+    cache_root = resolve_cache_root(root, explicit=args.cache_root)
 
     if args.list:
         return list_available(root)

--- a/tests/cache/test_cache_root.py
+++ b/tests/cache/test_cache_root.py
@@ -16,6 +16,7 @@ from rootstock.clusters import (
 )
 from rootstock.commands.common import resolve_cache_root
 from rootstock.environment import get_model_cache_env, get_user_cache_dir
+from rootstock.layout import write_layout_marker
 from rootstock.spawn import WORKER_WRAPPER, spawn_in_env
 
 # Runtime write-back caches that must NEVER point into the shared roots —
@@ -317,6 +318,75 @@ def test_calculator_with_root_and_explicit_cache_root(tmp_path: Path):
     )
     assert calc.root == install
     assert calc.cache_root == cache
+
+
+# ---------- benchmark entry point ------------------------------------------
+#
+# benchmark.py threads root/cache_root to its in-env arm directly (never
+# through RootstockCalculator), so it must resolve the cache root the same
+# way every other entry point does — including a split cache declared in
+# {root}/layout.json (e.g. Frontier: root on /sw, read-only on compute
+# nodes; weights on Lustre). Regression: it used to honor only --cache-root
+# and the cluster registry, sending the in-env arm to {root}/cache.
+
+
+def _capture_benchmark_roots(monkeypatch, argv) -> dict:
+    """Run benchmark.main with benchmark_one stubbed to capture its roots."""
+    from rootstock import benchmark
+
+    captured: dict = {}
+
+    def fake_benchmark_one(checkpoint, device, root, cache_root, *args, **kwargs):
+        captured["root"] = root
+        captured["cache_root"] = cache_root
+        raise RuntimeError("captured")  # per-checkpoint errors don't abort main
+
+    monkeypatch.setattr(benchmark, "benchmark_one", fake_benchmark_one)
+    assert benchmark.main(argv + ["--checkpoints", "x", "--calls", "1", "--warmup", "0"]) == 0
+    return captured
+
+
+def test_benchmark_honors_layout_declared_cache_root(tmp_path: Path, monkeypatch):
+    root = tmp_path / "install"
+    cache = tmp_path / "cache"
+    root.mkdir()
+    write_layout_marker(root, cache_root=cache)
+
+    got = _capture_benchmark_roots(monkeypatch, ["--root", str(root)])
+    assert got["root"] == root
+    assert got["cache_root"] == cache
+
+
+def test_benchmark_cache_root_flag_overrides_declaration(tmp_path: Path, monkeypatch):
+    root = tmp_path / "install"
+    root.mkdir()
+    write_layout_marker(root, cache_root=tmp_path / "declared")
+    override = tmp_path / "override"
+
+    got = _capture_benchmark_roots(
+        monkeypatch, ["--root", str(root), "--cache-root", str(override)]
+    )
+    assert got["cache_root"] == override
+
+
+def test_benchmark_bare_root_defaults_cache_root_to_root(tmp_path: Path, monkeypatch):
+    """No declaration, no registry entry: cache root is the install root."""
+    got = _capture_benchmark_roots(monkeypatch, ["--root", str(tmp_path)])
+    assert got["cache_root"] == tmp_path
+
+
+def test_benchmark_cluster_registry_still_resolves(tmp_path: Path, monkeypatch):
+    install = tmp_path / "install"
+    cache = tmp_path / "cache"
+    monkeypatch.setitem(
+        CLUSTER_REGISTRY,
+        "_test_split",
+        Cluster(root=install, cache_root=cache),
+    )
+
+    got = _capture_benchmark_roots(monkeypatch, ["--cluster", "_test_split"])
+    assert got["root"] == install
+    assert got["cache_root"] == cache
 
 
 # ---------- End-to-end: cache_root reaches the worker spawn ---------------


### PR DESCRIPTION
## Problem

`rootstock benchmark` resolves `cache_root` only from `--cache-root` or the cluster registry (`--cluster`), falling back to `None`. With a bare `--root`, `get_model_cache_env(root, None)` points the in-env arm's HOME/XDG/HF redirect at `{root}/home` and `{root}/cache` — ignoring the split cache root the install declares in `{root}/layout.json` (written by `init --cache-root`, #149).

`resolve_cache_root()` in `layout.py` is documented as the single resolution path ("Every entry point resolves through here"), and the calculator, `add`, `smoke-test`, and `check-perms` all use it. `benchmark.py` was the one entry point that didn't.

## Observed on Frontier (2026-07-22)

Split-root install: root on `/sw` (read-only on compute nodes), cache on Lustre, declared in `layout.json`. Running `rootstock benchmark --root ...` in a batch job failed the in-env arm for 4 of 5 checkpoints with

```
OSError: [Errno 30] Read-only file system: '/sw/frontier/ums/ums047/rootstock/cache'
```

(and variants under `{root}/home/.cache`, `{root}/home/.local`); mace additionally attempted a re-download — doomed, since compute nodes have no egress — because its cache looked empty. Only chgnet passed, because its weights ship inside the wheel and its `setup()` never touches a cache dir. The managed arm was accidentally immune (RootstockCalculator resolves layout.json itself), which also means the two arms were running with *different* cache environments — exactly what the benchmark's methodology says must not happen.

## Fix

Resolve through `resolve_cache_root(root, explicit=args.cache_root)`. Precedence is unchanged where it previously worked — an explicit `--cache-root` still wins, and `--cluster` roots still reverse-resolve to the registry's cache root when no layout declaration exists — the layout.json declaration now fills the gap in between.

## Tests

Four new tests in `tests/cache/test_cache_root.py` driving `benchmark.main()` with `benchmark_one` stubbed: layout declaration honored with bare `--root`, `--cache-root` overrides the declaration, undeclared/unregistered root falls back to itself, and `--cluster` registry resolution still works. Full suite: 402 passed, 2 skipped. (The two ruff E501s in `benchmark.py` pre-exist on main and are untouched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)