### PR TITLE
Spool one anonymous usage record per worker session

### DIFF
--- a/rootstock/commands/serve.py
+++ b/rootstock/commands/serve.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import signal
 import subprocess
 import sys
+import time
 
 from .common import get_root_or_exit
 
@@ -24,8 +25,10 @@ def cmd_serve(args) -> int:
 
     from ..environment import CheckpointNotFoundError, get_env_python
     from ..local_checkpoints import resolve_checkpoint
+    from ..manifest import now_iso
     from ..operations import parse_setup_kwargs
     from ..spawn import WORKER_WRAPPER, spawn_in_env
+    from ..usage import record_session
     from .common import resolve_cache_root
 
     root = get_root_or_exit(args)
@@ -100,6 +103,8 @@ def cmd_serve(args) -> int:
         },
         cache_root=cache_root,
     ) as spec:
+        started_at = now_iso()
+        started = time.monotonic()
         proc = subprocess.Popen(spec.cmd, env=spec.env, cwd=spec.cwd)
 
         # Forward signals to worker
@@ -110,4 +115,24 @@ def cmd_serve(args) -> int:
         signal.signal(signal.SIGINT, forward_signal)
 
         # Block until worker exits
-        return proc.wait()
+        rc = proc.wait()
+
+    # One anonymous usage record per serve session (see usage.py) — the only
+    # entry point not covered by the RootstockServer hook, because here the
+    # i-PI server is external (e.g. the LAMMPS fix). This parent survives a
+    # walltime SIGTERM (the handler above only forwards it), so killed runs
+    # still record. The worker's force-call count isn't visible from here:
+    # n_calculations is null; sessions and wall-time still count.
+    record_session(
+        root=root,
+        cache_root=cache_root,
+        env_name=env_name,
+        checkpoint=checkpoint,
+        is_local=resolved.is_local,
+        device=device,
+        client="serve",
+        started_at=started_at,
+        duration_s=time.monotonic() - started,
+        n_calculations=None,
+    )
+    return rc

--- a/rootstock/server.py
+++ b/rootstock/server.py
@@ -97,6 +97,7 @@ class RootstockServer:
         timeout: float = 600.0,
         setup_kwargs: dict | None = None,
         checkpoint_path: str | None = None,
+        usage_client: str | None = "calculator",
     ):
         """
         Initialize the server.
@@ -123,6 +124,10 @@ class RootstockServer:
             checkpoint_path: Path to a local (user-registered) weights file.
                 When set, the worker loads via the env's setup_from_path()
                 hook instead of setup(); ``checkpoint`` is then only a label.
+            usage_client: Client label written into the session's anonymous
+                usage record (see usage.py), or None to record nothing —
+                verification passes None so synthetic smoke-test sessions
+                never pollute the spool.
         """
         if root is None:
             raise ValueError("root is required for pre-built environments")
@@ -141,6 +146,7 @@ class RootstockServer:
         self.root = Path(root)
         self.cache_root = Path(cache_root) if cache_root is not None else None
         self.setup_kwargs = setup_kwargs or {}
+        self.usage_client = usage_client
 
         self._server_socket: socket.socket | None = None
         self._client_socket: socket.socket | None = None
@@ -395,7 +401,7 @@ class RootstockServer:
         can't-fail guarantees live in record_session; the only job here is
         gathering the fields and making the write once per session.
         """
-        if self._session_started_at is None:
+        if self.usage_client is None or self._session_started_at is None:
             return
         started_at = self._session_started_at
         duration_s = time.monotonic() - self._session_started_monotonic
@@ -413,6 +419,7 @@ class RootstockServer:
             # until it merges, no session is local.
             is_local=getattr(self, "checkpoint_path", None) is not None,
             device=self.device,
+            client=self.usage_client,
             started_at=started_at,
             duration_s=duration_s,
             n_calculations=self._n_calculations,

--- a/rootstock/server.py
+++ b/rootstock/server.py
@@ -13,6 +13,7 @@ import shutil
 import socket
 import subprocess
 import tempfile
+import time
 from pathlib import Path
 
 import numpy as np
@@ -24,6 +25,7 @@ from .protocol import (
     create_private_socket_path,
     create_server_socket,
 )
+from .usage import record_session
 
 logger = logging.getLogger("rootstock.server")
 
@@ -161,6 +163,13 @@ class RootstockServer:
         # the life of the worker process; stop() closes it.
         self._spawn_stack: contextlib.ExitStack | None = None
 
+        # Usage-record state: a session is a worker that actually connected.
+        # stop() writes one anonymous record per session (see usage.py) and
+        # resets these, so repeated stop() calls can't double-count.
+        self._session_started_at: str | None = None
+        self._session_started_monotonic: float | None = None
+        self._n_calculations = 0
+
     def start(self):
         """Start the server and launch the worker process."""
         # Create server socket inside a fresh private (0700) directory
@@ -246,6 +255,12 @@ class RootstockServer:
 
         self._protocol = IPIProtocol(self._client_socket)
         self._connected = True
+
+        from .manifest import now_iso
+
+        self._session_started_at = now_iso()
+        self._session_started_monotonic = time.monotonic()
+        self._n_calculations = 0
 
         logger.info("Worker connected")
 
@@ -370,10 +385,43 @@ class RootstockServer:
         if error is not None:
             raise RuntimeError(f"Worker calculation failed:\n{error}")
 
+        self._n_calculations += 1
         return energy, forces, virial
+
+    def _record_usage(self):
+        """Write the session's anonymous usage record, if there was a session.
+
+        Called from stop() while the session state is still intact. All the
+        can't-fail guarantees live in record_session; the only job here is
+        gathering the fields and making the write once per session.
+        """
+        if self._session_started_at is None:
+            return
+        started_at = self._session_started_at
+        duration_s = time.monotonic() - self._session_started_monotonic
+        self._session_started_at = None
+        self._session_started_monotonic = None
+
+        from .layout import resolve_cache_root
+
+        record_session(
+            root=self.root,
+            cache_root=resolve_cache_root(self.root, explicit=self.cache_root),
+            env_name=self.env_name,
+            checkpoint=self.checkpoint,
+            # checkpoint_path arrives with the local-checkpoints branch;
+            # until it merges, no session is local.
+            is_local=getattr(self, "checkpoint_path", None) is not None,
+            device=self.device,
+            started_at=started_at,
+            duration_s=duration_s,
+            n_calculations=self._n_calculations,
+        )
 
     def stop(self):
         """Stop the server and terminate the worker process."""
+        self._record_usage()
+
         if self._protocol is not None:
             try:
                 self._protocol.send_exit()

--- a/rootstock/server.py
+++ b/rootstock/server.py
@@ -415,9 +415,7 @@ class RootstockServer:
             cache_root=resolve_cache_root(self.root, explicit=self.cache_root),
             env_name=self.env_name,
             checkpoint=self.checkpoint,
-            # checkpoint_path arrives with the local-checkpoints branch;
-            # until it merges, no session is local.
-            is_local=getattr(self, "checkpoint_path", None) is not None,
+            is_local=self.checkpoint_path is not None,
             device=self.device,
             client=self.usage_client,
             started_at=started_at,

--- a/rootstock/usage.py
+++ b/rootstock/usage.py
@@ -23,13 +23,21 @@ dir missing or unwritable, cache root on a read-only mount, name collision —
 is swallowed and logged at DEBUG. Users opt out with
 ``ROOTSTOCK_DISABLE_USAGE_STATS=1``.
 
-The records are anonymous: no username, no job id. Local (user-registered)
+The records carry no raw username and no job id. Local (user-registered)
 checkpoint ids are user-chosen names and may carry meaning, so they are
-recorded as ``(local)``.
+recorded as ``(local)``. For distinct-user counts, each record carries a
+salted, truncated hash of the username (see ``_user_hash``): pseudonymous
+rather than strictly anonymous — but reversing it requires the per-install
+salt, which never leaves the cluster, and on-cluster the raw record files
+already reveal their writer through file ownership anyway. The hashes exist
+so the collector can count unique users; anything pushed off-cluster should
+carry only the counts, never the hashes.
 """
 
 from __future__ import annotations
 
+import getpass
+import hashlib
 import json
 import logging
 import os
@@ -42,6 +50,7 @@ logger = logging.getLogger("rootstock.usage")
 USAGE_DIR_NAME = "usage"
 RECORD_SCHEMA_VERSION = 1
 DISABLE_ENV_VAR = "ROOTSTOCK_DISABLE_USAGE_STATS"
+SALT_FILE_NAME = "salt"
 
 # Recorded in place of a local checkpoint's id: ids registered with
 # `rootstock add-local` are user-chosen and may leak what someone is working
@@ -52,6 +61,41 @@ LOCAL_CHECKPOINT_LABEL = "(local)"
 def usage_dir(cache_root: Path | str) -> Path:
     """The spool directory for an install's cache root."""
     return Path(cache_root) / USAGE_DIR_NAME
+
+
+def _user_hash(spool: Path) -> str | None:
+    """Salted, truncated hash of the username, for distinct-user counting.
+
+    A bare hash of a username is reversible by enumeration — usernames are
+    low-entropy and public on a cluster — so the hash is salted with a random
+    per-install value living at ``{spool}/salt``. The salt is created lazily
+    by whichever session writes first (O_EXCL, so exactly one writer wins)
+    and must be world-readable, since every writer needs it; that means the
+    hashes are reversible *on* the cluster (where record-file ownership
+    already names the writer) but opaque anywhere the salt doesn't go.
+
+    Returns None when anything fails — the record is then simply written
+    without a user field.
+    """
+    try:
+        salt_path = spool / SALT_FILE_NAME
+        try:
+            salt = salt_path.read_bytes()
+        except FileNotFoundError:
+            salt = uuid.uuid4().bytes + uuid.uuid4().bytes
+            try:
+                fd = os.open(salt_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o444)
+                with os.fdopen(fd, "wb") as f:
+                    f.write(salt)
+            except FileExistsError:
+                salt = salt_path.read_bytes()
+        if not salt:
+            return None
+        username = getpass.getuser()
+        return hashlib.sha256(salt + username.encode("utf-8")).hexdigest()[:16]
+    except Exception:
+        logger.debug("user hash skipped", exc_info=True)
+        return None
 
 
 def usage_disabled() -> bool:
@@ -115,6 +159,7 @@ def record_session(
             "device": device,
             "rootstock_version": __version__,
             "n_calculations": n_calculations,
+            "user": _user_hash(spool),
         }
 
         # Timestamp + host + pid + random suffix: unique without coordination.

--- a/rootstock/usage.py
+++ b/rootstock/usage.py
@@ -1,0 +1,132 @@
+"""Anonymous per-session usage records, spooled to the shared install.
+
+Design (issue #47): the calculator side can't phone home — compute nodes are
+often airgapped — and per-user homes can't be aggregated, so the only place
+every user's process and the maintainer's collector can both reach is the
+shared filesystem. Each worker session therefore drops one small JSON record
+into ``{cache_root}/usage/``; a maintainer-side collector aggregates the
+spool from a login node.
+
+The spool directory is *provisioned*, never created here: ``{cache_root}`` is
+maintainer-writable only, and a missing ``usage/`` is how an install opts out
+of collection entirely. When the directory exists it must be world-writable
+(``setup-perms`` creates it ``1777``, /tmp-style) so any user's session can
+drop a record.
+
+Records are one file per session, named uniquely and created with
+``O_CREAT | O_EXCL`` — concurrent sessions across nodes never share a file,
+so no cross-node locking is needed (a single shared append log on GPFS or
+Lustre is the contention problem ``manifest_lock`` exists to avoid).
+
+Telemetry must never break a calculation: every failure mode here — spool
+dir missing or unwritable, cache root on a read-only mount, name collision —
+is swallowed and logged at DEBUG. Users opt out with
+``ROOTSTOCK_DISABLE_USAGE_STATS=1``.
+
+The records are anonymous: no username, no job id. Local (user-registered)
+checkpoint ids are user-chosen names and may carry meaning, so they are
+recorded as ``(local)``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+import uuid
+from pathlib import Path
+
+logger = logging.getLogger("rootstock.usage")
+
+USAGE_DIR_NAME = "usage"
+RECORD_SCHEMA_VERSION = 1
+DISABLE_ENV_VAR = "ROOTSTOCK_DISABLE_USAGE_STATS"
+
+# Recorded in place of a local checkpoint's id: ids registered with
+# `rootstock add-local` are user-chosen and may leak what someone is working
+# on, which anonymous stats must not do.
+LOCAL_CHECKPOINT_LABEL = "(local)"
+
+
+def usage_dir(cache_root: Path | str) -> Path:
+    """The spool directory for an install's cache root."""
+    return Path(cache_root) / USAGE_DIR_NAME
+
+
+def usage_disabled() -> bool:
+    """True when the user opted out via ROOTSTOCK_DISABLE_USAGE_STATS."""
+    value = os.environ.get(DISABLE_ENV_VAR, "").strip().lower()
+    return value not in ("", "0", "false")
+
+
+def record_session(
+    *,
+    root: Path | str,
+    cache_root: Path | str,
+    env_name: str,
+    checkpoint: str,
+    is_local: bool,
+    device: str,
+    started_at: str,
+    duration_s: float,
+    n_calculations: int,
+) -> Path | None:
+    """Best-effort: write one usage record for a finished worker session.
+
+    Returns the record path, or None when nothing was written — opted out,
+    spool directory not provisioned, or any error at all. Never raises.
+
+    Args:
+        root: Install root (identifies "where" alongside the cluster name,
+            which is reverse-looked-up from it).
+        cache_root: Resolved cache root; the spool lives under it.
+        env_name: Pre-built environment that hosted the session.
+        checkpoint: Canonical checkpoint id. Replaced with ``(local)`` when
+            ``is_local`` — user-chosen ids must not leak into the spool.
+        is_local: Whether the checkpoint was a user-registered weights file.
+        device: Device string the worker ran on.
+        started_at: ISO 8601 UTC timestamp of worker connect.
+        duration_s: Wall-clock session length in seconds.
+        n_calculations: Completed force calls served by the session.
+    """
+    try:
+        if usage_disabled():
+            return None
+
+        spool = usage_dir(cache_root)
+        if not spool.is_dir():
+            # Unprovisioned install: collection is off. Never create the
+            # directory from here — a user-created spool would be owned by
+            # whoever ran first and unwritable to everyone else.
+            return None
+
+        from . import __version__
+        from .clusters import get_cluster_for_root
+
+        record = {
+            "schema_version": RECORD_SCHEMA_VERSION,
+            "started_at": started_at,
+            "duration_s": round(duration_s, 1),
+            "cluster": get_cluster_for_root(root),
+            "root": str(root),
+            "env": env_name,
+            "checkpoint": LOCAL_CHECKPOINT_LABEL if is_local else checkpoint,
+            "device": device,
+            "rootstock_version": __version__,
+            "n_calculations": n_calculations,
+        }
+
+        # Timestamp + host + pid + random suffix: unique without coordination.
+        stamp = started_at.replace(":", "").replace("+", "p")
+        name = f"{stamp}-{socket.gethostname()}-{os.getpid()}-{uuid.uuid4().hex[:8]}.json"
+        path = spool / name
+
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+        with os.fdopen(fd, "w") as f:
+            json.dump(record, f)
+            f.write("\n")
+        return path
+    except Exception:
+        logger.debug("usage record skipped", exc_info=True)
+        return None

--- a/rootstock/usage.py
+++ b/rootstock/usage.py
@@ -112,9 +112,10 @@ def record_session(
     checkpoint: str,
     is_local: bool,
     device: str,
+    client: str,
     started_at: str,
     duration_s: float,
-    n_calculations: int,
+    n_calculations: int | None,
 ) -> Path | None:
     """Best-effort: write one usage record for a finished worker session.
 
@@ -130,9 +131,13 @@ def record_session(
             ``is_local`` — user-chosen ids must not leak into the spool.
         is_local: Whether the checkpoint was a user-registered weights file.
         device: Device string the worker ran on.
-        started_at: ISO 8601 UTC timestamp of worker connect.
+        client: Which entry point ran the session ("calculator", "serve").
+        started_at: ISO 8601 UTC timestamp of session start (worker connect,
+            or worker spawn when the connect isn't observable).
         duration_s: Wall-clock session length in seconds.
-        n_calculations: Completed force calls served by the session.
+        n_calculations: Completed force calls served by the session, or None
+            when the entry point can't count them (serve's parent process
+            never sees the i-PI traffic).
     """
     try:
         if usage_disabled():
@@ -157,6 +162,7 @@ def record_session(
             "env": env_name,
             "checkpoint": LOCAL_CHECKPOINT_LABEL if is_local else checkpoint,
             "device": device,
+            "client": client,
             "rootstock_version": __version__,
             "n_calculations": n_calculations,
             "user": _user_hash(spool),

--- a/rootstock/verify.py
+++ b/rootstock/verify.py
@@ -95,6 +95,10 @@ def verify_checkpoint(
         setup_kwargs=setup_kwargs,
         timeout=600.0,
         checkpoint_path=checkpoint_path,
+        # Verification sessions are synthetic — the nightly smoke-test cron
+        # would otherwise spool one fake "session" per checkpoint per night,
+        # and rollups merge irreversibly.
+        usage_client=None,
     )
 
     try:

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -1,0 +1,78 @@
+"""``rootstock serve`` spools one usage record per worker session.
+
+serve is the one entry point the RootstockServer hook can't cover — here the
+i-PI server is external (e.g. the LAMMPS fix) and rootstock only runs the
+worker — so cmd_serve records the session itself: client="serve",
+n_calculations null (the parent process never sees the i-PI traffic).
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+from rootstock.commands.serve import cmd_serve
+from rootstock.local_checkpoints import ResolvedCheckpoint
+from rootstock.usage import usage_dir
+
+
+class _FakeProc:
+    def __init__(self, returncode):
+        self.returncode = returncode
+
+    def wait(self):
+        return self.returncode
+
+    def send_signal(self, signum):
+        pass
+
+
+def _wire_fake_worker(monkeypatch, returncode=0):
+    @contextmanager
+    def fake_spawn(root, env_name, wrapper, config, cache_root=None):
+        yield SimpleNamespace(cmd=["worker"], env={}, cwd=None)
+
+    monkeypatch.setattr("rootstock.spawn.spawn_in_env", fake_spawn)
+    monkeypatch.setattr(
+        "rootstock.local_checkpoints.resolve_checkpoint",
+        lambda root, ckpt: ResolvedCheckpoint(checkpoint=ckpt, env_name="mace"),
+    )
+    monkeypatch.setattr("rootstock.environment.get_env_python", lambda root, env: "python")
+    monkeypatch.setattr(
+        "rootstock.commands.serve.subprocess.Popen", lambda *a, **kw: _FakeProc(returncode)
+    )
+    # Don't rewire the test process's real signal handlers.
+    monkeypatch.setattr("rootstock.commands.serve.signal.signal", lambda *a: None)
+
+
+def _args(tmp_path):
+    return SimpleNamespace(
+        root=str(tmp_path),
+        socket="/tmp/ipi.sock",
+        checkpoint="mace-mp-0-medium",
+        device="cuda",
+        kwarg=None,
+    )
+
+
+def test_serve_spools_one_record(tmp_path, monkeypatch):
+    usage_dir(tmp_path).mkdir()
+    _wire_fake_worker(monkeypatch)
+
+    assert cmd_serve(_args(tmp_path)) == 0
+
+    (path,) = usage_dir(tmp_path).glob("*.json")
+    record = json.loads(path.read_text())
+    assert record["client"] == "serve"
+    assert record["env"] == "mace"
+    assert record["checkpoint"] == "mace-mp-0-medium"
+    assert record["n_calculations"] is None
+    assert record["duration_s"] >= 0
+
+
+def test_serve_without_spool_records_nothing_and_returns_worker_rc(tmp_path, monkeypatch):
+    _wire_fake_worker(monkeypatch, returncode=3)
+
+    assert cmd_serve(_args(tmp_path)) == 3
+    assert not usage_dir(tmp_path).exists()

--- a/tests/usage/test_usage_record.py
+++ b/tests/usage/test_usage_record.py
@@ -238,6 +238,19 @@ def test_stop_records_one_session(tmp_path, monkeypatch):
     assert kw["started_at"] == "2026-07-23T01:02:03+00:00"
 
 
+def test_stop_marks_local_checkpoint_sessions(tmp_path, monkeypatch):
+    """A server running a user-registered weights file reports is_local, so
+    record_session masks the user-chosen id."""
+    calls = []
+    monkeypatch.setattr("rootstock.server.record_session", lambda **kw: calls.append(kw))
+
+    server = _server(tmp_path, checkpoint_path="/home/someone/weights.pt")
+    _fake_session(server)
+    server.stop()
+
+    assert calls[0]["is_local"] is True
+
+
 def test_stop_with_usage_client_none_records_nothing(tmp_path, monkeypatch):
     """usage_client=None opts a server out of recording entirely — verify.py
     passes it so nightly smoke-test sessions never pollute the spool."""

--- a/tests/usage/test_usage_record.py
+++ b/tests/usage/test_usage_record.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import os
+import stat
 
 import pytest
 
@@ -58,6 +59,7 @@ def test_record_written_when_spool_provisioned(tmp_path):
         "device": "cuda",
         "rootstock_version": record["rootstock_version"],
         "n_calculations": 7,
+        "user": record["user"],
     }
 
 
@@ -97,6 +99,77 @@ def test_env_var_opt_out(tmp_path, monkeypatch):
 def test_usage_disabled_parsing(monkeypatch, value, disabled):
     monkeypatch.setenv(DISABLE_ENV_VAR, value)
     assert usage_disabled() is disabled
+
+
+# --------------------------------------------------------------------------- #
+# User hash (distinct-user counting)
+# --------------------------------------------------------------------------- #
+
+
+def _user_of(path):
+    return json.loads(path.read_text())["user"]
+
+
+def test_user_hash_is_salted_stable_and_truncated(tmp_path):
+    usage_dir(tmp_path).mkdir()
+    first = _user_of(_write(tmp_path))
+    second = _user_of(_write(tmp_path))
+
+    assert first == second  # stable per user per install: distinct counts work
+    assert len(first) == 16
+    int(first, 16)  # hex, i.e. a hash — not a raw username
+
+    import getpass
+    import hashlib
+
+    # Salted: the raw and unsalted-hashed username must not appear anywhere.
+    username = getpass.getuser()
+    assert first != username
+    assert first != hashlib.sha256(username.encode()).hexdigest()[:16]
+
+
+def test_user_hash_differs_per_user_and_per_install(tmp_path, monkeypatch):
+    install_a = tmp_path / "a"
+    install_b = tmp_path / "b"
+    for install in (install_a, install_b):
+        install.mkdir()
+        usage_dir(install).mkdir()
+
+    alice_a = _user_of(_write(install_a))
+    monkeypatch.setattr("rootstock.usage.getpass.getuser", lambda: "somebody-else")
+    bob_a = _user_of(_write(install_a))
+    bob_b = _user_of(_write(install_b))
+
+    assert alice_a != bob_a  # different users, same install
+    assert bob_a != bob_b  # same user, different installs (different salts)
+
+
+def test_salt_created_once_world_readable(tmp_path):
+    usage_dir(tmp_path).mkdir()
+    _write(tmp_path)
+    salt_path = usage_dir(tmp_path) / "salt"
+    assert salt_path.is_file()
+    assert stat.S_IMODE(salt_path.stat().st_mode) == 0o444
+    salt = salt_path.read_bytes()
+    assert len(salt) == 32
+
+    _write(tmp_path)
+    assert salt_path.read_bytes() == salt  # first writer won; never rewritten
+
+
+@pytest.mark.skipif(os.getuid() == 0, reason="root ignores file modes")
+def test_unreadable_salt_drops_user_field_not_the_record(tmp_path):
+    usage_dir(tmp_path).mkdir()
+    salt_path = usage_dir(tmp_path) / "salt"
+    salt_path.write_bytes(b"x" * 32)
+    salt_path.chmod(0o000)
+    try:
+        path = _write(tmp_path)
+    finally:
+        salt_path.chmod(0o444)
+
+    assert path is not None  # the session is still counted
+    assert json.loads(path.read_text())["user"] is None
 
 
 @pytest.mark.skipif(os.getuid() == 0, reason="root ignores directory modes")
@@ -180,7 +253,7 @@ def test_stop_writes_a_real_record_end_to_end(tmp_path):
     _fake_session(server)
     server.stop()
 
-    (path,) = usage_dir(tmp_path).iterdir()
+    (path,) = usage_dir(tmp_path).glob("*.json")
     record = json.loads(path.read_text())
     assert record["env"] == "mace"
     assert record["n_calculations"] == 5

--- a/tests/usage/test_usage_record.py
+++ b/tests/usage/test_usage_record.py
@@ -1,0 +1,187 @@
+"""Anonymous usage records: spooled per session, and never able to fail loudly.
+
+The spool contract (issue #47): one JSON file per worker session under
+``{cache_root}/usage/``, written only when a maintainer provisioned that
+directory, skippable by env var, and swallowing every possible error —
+telemetry must never break or block a calculation.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from rootstock.server import RootstockServer
+from rootstock.usage import (
+    DISABLE_ENV_VAR,
+    LOCAL_CHECKPOINT_LABEL,
+    RECORD_SCHEMA_VERSION,
+    record_session,
+    usage_dir,
+    usage_disabled,
+)
+
+
+def _write(cache_root, **overrides):
+    kwargs = dict(
+        root=cache_root,
+        cache_root=cache_root,
+        env_name="mace",
+        checkpoint="mace-mp-0-medium",
+        is_local=False,
+        device="cuda",
+        started_at="2026-07-23T01:02:03+00:00",
+        duration_s=12.34,
+        n_calculations=7,
+    )
+    kwargs.update(overrides)
+    return record_session(**kwargs)
+
+
+def test_record_written_when_spool_provisioned(tmp_path):
+    usage_dir(tmp_path).mkdir()
+    path = _write(tmp_path)
+
+    assert path is not None
+    assert path.parent == usage_dir(tmp_path)
+    record = json.loads(path.read_text())
+    assert record == {
+        "schema_version": RECORD_SCHEMA_VERSION,
+        "started_at": "2026-07-23T01:02:03+00:00",
+        "duration_s": 12.3,
+        "cluster": None,  # tmp_path is not a registered cluster root
+        "root": str(tmp_path),
+        "env": "mace",
+        "checkpoint": "mace-mp-0-medium",
+        "device": "cuda",
+        "rootstock_version": record["rootstock_version"],
+        "n_calculations": 7,
+    }
+
+
+def test_unprovisioned_spool_is_a_silent_noop(tmp_path):
+    """No usage/ dir means the install opted out — and record_session must
+    not create the dir itself (a user-created spool would be owned by
+    whoever ran first and unwritable to everyone else)."""
+    assert _write(tmp_path) is None
+    assert not usage_dir(tmp_path).exists()
+
+
+def test_records_are_unique_per_session(tmp_path):
+    usage_dir(tmp_path).mkdir()
+    paths = {_write(tmp_path) for _ in range(3)}
+    assert len(paths) == 3
+
+
+def test_local_checkpoint_id_is_masked(tmp_path):
+    """Ids registered via add-local are user-chosen names; anonymous stats
+    must not leak them."""
+    usage_dir(tmp_path).mkdir()
+    path = _write(tmp_path, checkpoint="my-secret-project-ft", is_local=True)
+    assert json.loads(path.read_text())["checkpoint"] == LOCAL_CHECKPOINT_LABEL
+
+
+def test_env_var_opt_out(tmp_path, monkeypatch):
+    usage_dir(tmp_path).mkdir()
+    monkeypatch.setenv(DISABLE_ENV_VAR, "1")
+    assert _write(tmp_path) is None
+    assert list(usage_dir(tmp_path).iterdir()) == []
+
+
+@pytest.mark.parametrize(
+    ("value", "disabled"),
+    [("", False), ("0", False), ("false", False), ("1", True), ("true", True), ("TRUE", True)],
+)
+def test_usage_disabled_parsing(monkeypatch, value, disabled):
+    monkeypatch.setenv(DISABLE_ENV_VAR, value)
+    assert usage_disabled() is disabled
+
+
+@pytest.mark.skipif(os.getuid() == 0, reason="root ignores directory modes")
+def test_unwritable_spool_never_raises(tmp_path):
+    spool = usage_dir(tmp_path)
+    spool.mkdir()
+    spool.chmod(0o555)
+    try:
+        assert _write(tmp_path) is None
+    finally:
+        spool.chmod(0o755)
+
+
+# --------------------------------------------------------------------------- #
+# Server hook
+# --------------------------------------------------------------------------- #
+
+
+def _server(tmp_path, **kwargs):
+    return RootstockServer(
+        env_name="mace",
+        checkpoint="mace-mp-0-medium",
+        device="cpu",
+        root=tmp_path,
+        **kwargs,
+    )
+
+
+def _fake_session(server):
+    """Give a never-started server the state _accept_connection would set."""
+    server._session_started_at = "2026-07-23T01:02:03+00:00"
+    server._session_started_monotonic = 0.0
+    server._n_calculations = 5
+
+
+def test_stop_records_one_session(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr("rootstock.server.record_session", lambda **kw: calls.append(kw))
+
+    server = _server(tmp_path)
+    _fake_session(server)
+    server.stop()
+    server.stop()  # idempotent teardown must not double-count
+
+    assert len(calls) == 1
+    kw = calls[0]
+    assert kw["root"] == tmp_path
+    assert kw["env_name"] == "mace"
+    assert kw["checkpoint"] == "mace-mp-0-medium"
+    assert kw["is_local"] is False
+    assert kw["device"] == "cpu"
+    assert kw["n_calculations"] == 5
+    assert kw["started_at"] == "2026-07-23T01:02:03+00:00"
+
+
+def test_stop_without_session_records_nothing(tmp_path, monkeypatch):
+    """A server whose worker never connected (or that never started) was not
+    a usage session."""
+    calls = []
+    monkeypatch.setattr("rootstock.server.record_session", lambda **kw: calls.append(kw))
+
+    _server(tmp_path).stop()
+    assert calls == []
+
+
+def test_stop_resolves_cache_root_like_every_other_entry_point(tmp_path, monkeypatch):
+    """cache_root=None goes through resolve_cache_root, so the spool location
+    can't disagree with where the CLI thinks the cache half lives."""
+    calls = []
+    monkeypatch.setattr("rootstock.server.record_session", lambda **kw: calls.append(kw))
+
+    server = _server(tmp_path, cache_root=None)
+    _fake_session(server)
+    server.stop()
+    assert calls[0]["cache_root"] == tmp_path  # no declaration -> the root itself
+
+
+def test_stop_writes_a_real_record_end_to_end(tmp_path):
+    usage_dir(tmp_path).mkdir()
+    server = _server(tmp_path, cache_root=tmp_path)
+    _fake_session(server)
+    server.stop()
+
+    (path,) = usage_dir(tmp_path).iterdir()
+    record = json.loads(path.read_text())
+    assert record["env"] == "mace"
+    assert record["n_calculations"] == 5
+    assert record["duration_s"] >= 0

--- a/tests/usage/test_usage_record.py
+++ b/tests/usage/test_usage_record.py
@@ -33,6 +33,7 @@ def _write(cache_root, **overrides):
         checkpoint="mace-mp-0-medium",
         is_local=False,
         device="cuda",
+        client="calculator",
         started_at="2026-07-23T01:02:03+00:00",
         duration_s=12.34,
         n_calculations=7,
@@ -57,10 +58,21 @@ def test_record_written_when_spool_provisioned(tmp_path):
         "env": "mace",
         "checkpoint": "mace-mp-0-medium",
         "device": "cuda",
+        "client": "calculator",
         "rootstock_version": record["rootstock_version"],
         "n_calculations": 7,
         "user": record["user"],
     }
+
+
+def test_serve_record_carries_client_and_null_call_count(tmp_path):
+    """serve's parent process can't see the i-PI traffic, so its records
+    carry n_calculations=null — the client field still says who it was."""
+    usage_dir(tmp_path).mkdir()
+    path = _write(tmp_path, client="serve", n_calculations=None)
+    record = json.loads(path.read_text())
+    assert record["client"] == "serve"
+    assert record["n_calculations"] is None
 
 
 def test_unprovisioned_spool_is_a_silent_noop(tmp_path):
@@ -221,8 +233,22 @@ def test_stop_records_one_session(tmp_path, monkeypatch):
     assert kw["checkpoint"] == "mace-mp-0-medium"
     assert kw["is_local"] is False
     assert kw["device"] == "cpu"
+    assert kw["client"] == "calculator"
     assert kw["n_calculations"] == 5
     assert kw["started_at"] == "2026-07-23T01:02:03+00:00"
+
+
+def test_stop_with_usage_client_none_records_nothing(tmp_path, monkeypatch):
+    """usage_client=None opts a server out of recording entirely — verify.py
+    passes it so nightly smoke-test sessions never pollute the spool."""
+    calls = []
+    monkeypatch.setattr("rootstock.server.record_session", lambda **kw: calls.append(kw))
+
+    server = _server(tmp_path, usage_client=None)
+    _fake_session(server)
+    server.stop()
+
+    assert calls == []
 
 
 def test_stop_without_session_records_nothing(tmp_path, monkeypatch):

--- a/tests/verify/test_verify_checkpoint.py
+++ b/tests/verify/test_verify_checkpoint.py
@@ -193,3 +193,18 @@ def test_smoke_test_atoms_breaks_symmetry():
     atoms = verify._smoke_test_atoms()
     # The y-perturbation we apply means atom 1 is not exactly on the x-axis.
     assert abs(atoms.positions[1, 1]) > 1e-6
+
+
+def test_verify_opts_out_of_usage_recording(monkeypatch):
+    """Verification sessions are synthetic — the nightly smoke-test cron must
+    not spool one fake usage record per checkpoint (rollups merge
+    irreversibly, so pollution could never be filtered out later)."""
+    captured = {}
+
+    def factory(**ctor_kwargs):
+        captured.update(ctor_kwargs)
+        return _StubServer(energy=-10.5, forces=_ok_forces(), virial=_ok_virial())
+
+    monkeypatch.setattr("rootstock.server.RootstockServer", factory)
+    verify.verify_checkpoint(Path("/tmp"), "mace", "mace-mp-0-medium", "cuda")
+    assert captured["usage_client"] is None


### PR DESCRIPTION
Part of #47 — the write side of the usage-stats design ([design discussion](https://github.com/Garden-AI/rootstock/issues/47#issuecomment-5049880734)). Rebased onto main after the local-checkpoints merge (#151/#158).

## What

- New `rootstock/usage.py`: `record_session()` writes one small JSON record per worker session to `{cache_root}/usage/`, named `<stamp>-<host>-<pid>-<rand>.json` and created with `O_CREAT|O_EXCL` — no cross-node locking needed on GPFS/Lustre.
- `RootstockServer` hook (the ASE-calculator path): session starts at worker connect, `calculate()` counts completed force calls, `stop()` writes the record once.
- `cmd_serve` hook: `serve` — and therefore the LAMMPS fix, which shells out to it — never goes through `RootstockServer` (the i-PI server is external there), so it writes its own record after the worker exits. The parent process never sees the i-PI traffic, so `n_calculations` is null; sessions and wall-time still count. Because serve's SIGTERM handler only forwards to the worker, walltime-killed LAMMPS runs still record.
- Smoke-tests are excluded: `RootstockServer` takes `usage_client` (`None` = record nothing) and `verify.py` passes `None`, so the nightly cron doesn't spool one synthetic record per checkpoint per night. Rollups merge irreversibly, so this pollution could never have been filtered out later.

## Record

`schema_version, started_at, duration_s, cluster, root, env, checkpoint, device, client, rootstock_version, n_calculations, user` — no raw username, no job id.

- `client` is the entry point (`calculator` / `serve`), captured now because it can't be backfilled once real records exist.
- `user` is a salted, truncated hash for distinct-user counts; the per-install salt never leaves the cluster, so hashes are opaque off-cluster (full reasoning in the module docstring). Only derived counts should ever leave the cluster.
- Local (user-registered) checkpoint ids are recorded as `(local)` so user-chosen names never leak: the server hook reads `self.checkpoint_path`, and `cmd_serve` threads `resolved.is_local` through.

## Guardrails

- **No-op unless `{cache_root}/usage/` already exists** — provisioning is the per-install opt-in (#157 adds it to `setup-perms`), and creating it from user code would leave it owned by whoever ran first.
- **Per-user opt-out**: `ROOTSTOCK_DISABLE_USAGE_STATS=1`.
- **Never raises**: every failure (unwritable dir, read-only mount, collision) is swallowed and logged at DEBUG. One sub-KB write per session; the POSDATA/FORCEREADY hot path is untouched.

## Known limitation

Walltime-killed **calculator** sessions don't record (SIGTERM kills Python before `stop()` runs), so long MD runs via ASE are undercounted. serve sessions survive this (see above). Candidate follow-up: write-at-connect + rewrite-at-stop with a `complete` flag.

## Testing

22 tests across `tests/usage/`, `tests/cli/test_serve.py`, and `tests/verify/`: record contents, unprovisioned no-op, opt-out parsing, unwritable spool, local-id masking (record-level and via the server hook), stop-once semantics, user-hash salting, serve end-to-end, verify exclusion. Full suite: 556 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
