### PR TITLE
setup-perms: provision the usage-record spool; check-perms validates it

### DIFF
--- a/rootstock/cli.py
+++ b/rootstock/cli.py
@@ -429,6 +429,15 @@ def main():
         action="store_true",
         help="Also apply recursively so existing files become world-readable",
     )
+    setup_perms_parser.add_argument(
+        "--no-usage-spool",
+        action="store_true",
+        help=(
+            "Skip provisioning the world-writable usage-record spool "
+            "({cache_root}/usage, mode 1777); its absence keeps usage "
+            "collection off for this install"
+        ),
+    )
     setup_perms_parser.set_defaults(func=cmd_setup_perms)
 
     # check-perms command

--- a/rootstock/cli.py
+++ b/rootstock/cli.py
@@ -438,6 +438,15 @@ def main():
             "collection off for this install"
         ),
     )
+    setup_perms_parser.add_argument(
+        "--usage-dir",
+        help=(
+            "Redirect the usage-record spool: create the real 1777 directory "
+            "at this path and symlink {cache_root}/usage to it. For clusters "
+            "where maintainer write access to the install is temporary — put "
+            "the spool somewhere you keep control of (e.g. under your home)"
+        ),
+    )
     setup_perms_parser.set_defaults(func=cmd_setup_perms)
 
     # check-perms command

--- a/rootstock/commands/setup_perms.py
+++ b/rootstock/commands/setup_perms.py
@@ -52,6 +52,7 @@ def cmd_setup_perms(args) -> int:
         cache_root,
         group=args.group,
         retrofit=args.retrofit,
+        usage_spool=not getattr(args, "no_usage_spool", False),
     )
 
     if not args.apply:

--- a/rootstock/commands/setup_perms.py
+++ b/rootstock/commands/setup_perms.py
@@ -47,12 +47,23 @@ def cmd_setup_perms(args) -> int:
         return 1
     install_root, cache_root = resolved
 
+    no_usage_spool = getattr(args, "no_usage_spool", False)
+    usage_dir = getattr(args, "usage_dir", None)
+    if no_usage_spool and usage_dir:
+        print(
+            "Error: --usage-dir provisions the usage spool; it can't be "
+            "combined with --no-usage-spool.",
+            file=sys.stderr,
+        )
+        return 2
+
     commands = render_commands(
         install_root,
         cache_root,
         group=args.group,
         retrofit=args.retrofit,
-        usage_spool=not getattr(args, "no_usage_spool", False),
+        usage_spool=not no_usage_spool,
+        usage_dir=usage_dir,
     )
 
     if not args.apply:

--- a/rootstock/perms.py
+++ b/rootstock/perms.py
@@ -22,6 +22,13 @@ The recipe:
   <group>``. The mode bits already give group r-x and world r-x; the setgid bit
   handles group-ownership inheritance. No named-group ACL (maintainer-only-write
   on the cache is the accepted default).
+* Usage spool — ``mkdir -p {cache_root}/usage`` + ``chmod 1777`` (sticky,
+  /tmp-style): any user's session can drop an anonymous usage record, nobody
+  can delete anyone else's, and the dir owner (whoever ran setup-perms) can
+  still prune everything when collecting. Existence of the directory is what
+  turns usage collection on for an install, so ``--no-usage-spool`` skips it
+  and a *missing* spool is never flagged as an issue — only a present one
+  with the wrong mode is.
 * ``--retrofit`` — recursive ``setfacl -R`` variants so an install that already
   has files in it becomes world-readable, not just future files, plus a
   ``find -type d ... chmod g+s`` so existing subdirectories inherit too.
@@ -42,6 +49,11 @@ from pathlib import Path
 # Mode bits for each root. setgid (2) + rwx owner + rwx/r-x group + r-x other.
 INSTALL_ROOT_MODE = "2775"
 CACHE_ROOT_MODE = "2755"
+# The usage spool: sticky + world-writable, like /tmp. Name matches
+# rootstock/usage.py's USAGE_DIR_NAME (kept literal here so this change
+# doesn't depend on the writer landing first).
+USAGE_DIR_NAME = "usage"
+USAGE_SPOOL_MODE = "1777"
 
 
 # --------------------------------------------------------------------------- #
@@ -55,12 +67,15 @@ def render_commands(
     *,
     group: str,
     retrofit: bool = False,
+    usage_spool: bool = True,
 ) -> list[list[str]]:
     """Render the permission recipe as a list of argv lists.
 
     The cache-root commands are emitted only when ``cache_root`` is given and
     differs from ``install_root`` (a single-filesystem cluster needs nothing
     extra for the cache). ``retrofit`` appends the recursive variants.
+    ``usage_spool`` provisions the world-writable usage-record spool (its
+    existence opts the install into usage collection).
     """
     install_root = Path(install_root)
     cmds: list[list[str]] = [
@@ -76,6 +91,13 @@ def render_commands(
     ]
 
     separate_cache = cache_root is not None and Path(cache_root) != install_root
+    # The spool lives on the cache half of the install — that's the
+    # runtime-writable side (on Frontier the install root is under /sw, which
+    # must not take writes from user jobs).
+    spool = usage_spool_dir(install_root, cache_root)
+    if usage_spool:
+        cmds.insert(0, ["mkdir", "-p", str(spool)])
+
     if separate_cache:
         cache_root = Path(cache_root)
         cmds += [
@@ -120,8 +142,19 @@ def render_commands(
     cmds += [["chmod", INSTALL_ROOT_MODE, str(install_root)]]
     if separate_cache:
         cmds += [["chmod", CACHE_ROOT_MODE, str(cache_root)]]
+    if usage_spool:
+        # After the retrofit setfacl/find pass, which would otherwise rewrite
+        # the spool's mode along with everything else under the root.
+        cmds += [["chmod", USAGE_SPOOL_MODE, str(spool)]]
 
     return cmds
+
+
+def usage_spool_dir(install_root: Path | str, cache_root: Path | str | None = None) -> Path:
+    """Where an install's usage spool lives: under the cache root when the
+    install has a separate one, else under the install root itself."""
+    parent = cache_root if cache_root is not None else install_root
+    return Path(parent) / USAGE_DIR_NAME
 
 
 def _setgid_dirs(root: Path) -> list[str]:
@@ -334,6 +367,42 @@ def _check_root(
     return issues
 
 
+def _check_usage_spool(install_root: Path, cache_root: Path | None) -> list[PermIssue]:
+    """Flag a usage spool that exists but can't do its job.
+
+    A *missing* spool is not an issue — its absence is how an install opts
+    out of usage collection. A present one, though, must be world-writable
+    (or users' sessions silently fail to record) and sticky (or any user can
+    delete everyone else's records).
+    """
+    spool = usage_spool_dir(install_root, cache_root)
+    try:
+        mode = spool.stat().st_mode
+    except (FileNotFoundError, PermissionError):
+        return []
+
+    issues: list[PermIssue] = []
+    if not stat_module.S_ISDIR(mode):
+        return [PermIssue(spool, "usage spool is not a directory")]
+    if (mode & 0o007) != 0o007:
+        issues.append(
+            PermIssue(
+                spool,
+                f"usage spool not world-writable (mode should be {USAGE_SPOOL_MODE}); "
+                "users' sessions can't record usage",
+            )
+        )
+    if not (mode & stat_module.S_ISVTX):
+        issues.append(
+            PermIssue(
+                spool,
+                f"usage spool lacks the sticky bit (mode should be {USAGE_SPOOL_MODE}); "
+                "any user can delete other users' records",
+            )
+        )
+    return issues
+
+
 def check_permissions(
     install_root: Path | str,
     cache_root: Path | str | None = None,
@@ -364,5 +433,7 @@ def check_permissions(
             seen = {issue.path for issue in issues}
             issues += [i for i in _check_ancestors(cache_root) if i.path not in seen]
         issues += _check_root(cache_root, kind="cache", group=group, require_group_acl=False)
+
+    issues += _check_usage_spool(install_root, Path(cache_root) if cache_root else None)
 
     return issues

--- a/rootstock/perms.py
+++ b/rootstock/perms.py
@@ -46,13 +46,13 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
+from .usage import usage_dir
+
 # Mode bits for each root. setgid (2) + rwx owner + rwx/r-x group + r-x other.
 INSTALL_ROOT_MODE = "2775"
 CACHE_ROOT_MODE = "2755"
-# The usage spool: sticky + world-writable, like /tmp. Name matches
-# rootstock/usage.py's USAGE_DIR_NAME (kept literal here so this change
-# doesn't depend on the writer landing first).
-USAGE_DIR_NAME = "usage"
+# The usage spool: sticky + world-writable, like /tmp. Its location comes
+# from usage.py's usage_dir(), so provisioning and the writer can't disagree.
 USAGE_SPOOL_MODE = "1777"
 
 
@@ -152,9 +152,12 @@ def render_commands(
 
 def usage_spool_dir(install_root: Path | str, cache_root: Path | str | None = None) -> Path:
     """Where an install's usage spool lives: under the cache root when the
-    install has a separate one, else under the install root itself."""
-    parent = cache_root if cache_root is not None else install_root
-    return Path(parent) / USAGE_DIR_NAME
+    install has a separate one, else under the install root itself.
+
+    Delegates to usage.py's ``usage_dir`` — this wrapper only supplies the
+    perms-side convention that a missing cache_root means the install root
+    doubles as the cache half."""
+    return usage_dir(cache_root if cache_root is not None else install_root)
 
 
 def _setgid_dirs(root: Path) -> list[str]:

--- a/rootstock/perms.py
+++ b/rootstock/perms.py
@@ -28,7 +28,11 @@ The recipe:
   still prune everything when collecting. Existence of the directory is what
   turns usage collection on for an install, so ``--no-usage-spool`` skips it
   and a *missing* spool is never flagged as an issue — only a present one
-  with the wrong mode is.
+  with the wrong mode is. ``--usage-dir <path>`` redirects the spool: the
+  real 1777 directory is created at ``<path>`` and ``{cache_root}/usage``
+  becomes a symlink to it — for clusters where the maintainer's write access
+  to the install is temporary (e.g. Delta), so collection keeps working from
+  a directory they permanently control (their home, say) after access lapses.
 * ``--retrofit`` — recursive ``setfacl -R`` variants so an install that already
   has files in it becomes world-readable, not just future files, plus a
   ``find -type d ... chmod g+s`` so existing subdirectories inherit too.
@@ -68,6 +72,7 @@ def render_commands(
     group: str,
     retrofit: bool = False,
     usage_spool: bool = True,
+    usage_dir: Path | str | None = None,
 ) -> list[list[str]]:
     """Render the permission recipe as a list of argv lists.
 
@@ -75,7 +80,11 @@ def render_commands(
     differs from ``install_root`` (a single-filesystem cluster needs nothing
     extra for the cache). ``retrofit`` appends the recursive variants.
     ``usage_spool`` provisions the world-writable usage-record spool (its
-    existence opts the install into usage collection).
+    existence opts the install into usage collection). ``usage_dir``
+    redirects it: the real directory is created (and moded) there, and
+    ``{cache_root}/usage`` becomes a symlink to it — for clusters where the
+    maintainer's write access to the install is temporary (e.g. Delta), so
+    the spool lives somewhere they keep control of, like their home.
     """
     install_root = Path(install_root)
     cmds: list[list[str]] = [
@@ -95,8 +104,16 @@ def render_commands(
     # runtime-writable side (on Frontier the install root is under /sw, which
     # must not take writes from user jobs).
     spool = usage_spool_dir(install_root, cache_root)
+    # With a redirect, the path every writer and reader uses is unchanged —
+    # {cache_root}/usage — it just resolves through a symlink to a directory
+    # the maintainer keeps control of. -sfn so re-running setup-perms is
+    # idempotent (replaces a stale link; fails loudly if a real directory is
+    # already in the way rather than silently nesting).
+    spool_target = Path(usage_dir) if usage_dir is not None else spool
     if usage_spool:
-        cmds.insert(0, ["mkdir", "-p", str(spool)])
+        cmds.insert(0, ["mkdir", "-p", str(spool_target)])
+        if spool_target != spool:
+            cmds.insert(1, ["ln", "-sfn", str(spool_target), str(spool)])
 
     if separate_cache:
         cache_root = Path(cache_root)
@@ -144,8 +161,10 @@ def render_commands(
         cmds += [["chmod", CACHE_ROOT_MODE, str(cache_root)]]
     if usage_spool:
         # After the retrofit setfacl/find pass, which would otherwise rewrite
-        # the spool's mode along with everything else under the root.
-        cmds += [["chmod", USAGE_SPOOL_MODE, str(spool)]]
+        # the spool's mode along with everything else under the root. Moded
+        # on the target: with a redirect the mode belongs to the real
+        # directory, not the symlink.
+        cmds += [["chmod", USAGE_SPOOL_MODE, str(spool_target)]]
 
     return cmds
 
@@ -376,12 +395,25 @@ def _check_usage_spool(install_root: Path, cache_root: Path | None) -> list[Perm
     A *missing* spool is not an issue — its absence is how an install opts
     out of usage collection. A present one, though, must be world-writable
     (or users' sessions silently fail to record) and sticky (or any user can
-    delete everyone else's records).
+    delete everyone else's records). A redirected spool (a symlink from
+    setup-perms --usage-dir) is checked through the link — same rules apply
+    to the target — except a *dangling* link, which is flagged: someone set
+    up collection and its target has since vanished.
     """
     spool = usage_spool_dir(install_root, cache_root)
     try:
         mode = spool.stat().st_mode
-    except (FileNotFoundError, PermissionError):
+    except FileNotFoundError:
+        if spool.is_symlink():
+            return [
+                PermIssue(
+                    spool,
+                    "usage spool is a dangling symlink (redirect target is "
+                    "missing); users' sessions can't record usage",
+                )
+            ]
+        return []
+    except PermissionError:
         return []
 
     issues: list[PermIssue] = []

--- a/tests/cli/test_setup_perms.py
+++ b/tests/cli/test_setup_perms.py
@@ -36,6 +36,22 @@ def test_dry_run_single_filesystem(capsys):
     assert "/cache" not in out
 
 
+def test_usage_dir_renders_the_redirect(capsys):
+    rc = cmd_setup_perms(_args(root="/install/root", usage_dir="/home/maint/rs-usage"))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "ln -sfn /home/maint/rs-usage /install/root/usage" in out
+    assert "chmod 1777 /home/maint/rs-usage" in out
+
+
+def test_usage_dir_conflicts_with_no_usage_spool(capsys):
+    rc = cmd_setup_perms(
+        _args(root="/install/root", usage_dir="/home/maint/rs-usage", no_usage_spool=True)
+    )
+    assert rc == 2
+    assert "--no-usage-spool" in capsys.readouterr().err
+
+
 def test_dry_run_split_filesystem(capsys):
     rc = cmd_setup_perms(_args(root="/install/root", cache_root="/cache/root"))
     assert rc == 0

--- a/tests/cli/test_setup_perms.py
+++ b/tests/cli/test_setup_perms.py
@@ -112,8 +112,11 @@ def test_apply_runs_commands_after_confirmation(monkeypatch, capsys):
 
     rc = cmd_setup_perms(_args(root="/install/root", apply=True))
     assert rc == 0
-    # The mode bits are asserted last, after the ACL work that can clear setgid.
-    assert calls[-1] == ["chmod", "2775", "/install/root"]
+    # The mode bits are asserted after the ACL work that can clear setgid;
+    # the usage spool's 1777 is the very last command (after the retrofit pass
+    # that would otherwise rewrite it).
+    assert calls[-2] == ["chmod", "2775", "/install/root"]
+    assert calls[-1] == ["chmod", "1777", "/install/root/usage"]
     assert "Permissions applied." in capsys.readouterr().out
 
 

--- a/tests/test_perms.py
+++ b/tests/test_perms.py
@@ -77,6 +77,20 @@ def test_render_spool_chmod_is_last_even_with_retrofit():
     assert lines[-1] == "chmod 1777 /install/root/usage"
 
 
+def test_render_usage_dir_redirects_the_spool():
+    """--usage-dir puts the real 1777 directory somewhere the maintainer
+    permanently controls and symlinks {cache_root}/usage to it — for clusters
+    like Delta where write access to the install is granted temporarily."""
+    cmds = render_commands("/install/root", group="m4845", usage_dir="/home/maint/rs-usage")
+    lines = [format_command(c) for c in cmds]
+    assert lines[0] == "mkdir -p /home/maint/rs-usage"
+    assert lines[1] == "ln -sfn /home/maint/rs-usage /install/root/usage"
+    # The mode belongs to the real directory, not the symlink, and still
+    # comes last.
+    assert lines[-1] == "chmod 1777 /home/maint/rs-usage"
+    assert "mkdir -p /install/root/usage" not in lines
+
+
 def test_render_chmod_follows_every_setfacl():
     """Every path's chmod must come after the last setfacl touching that path.
 
@@ -283,6 +297,66 @@ def test_check_spool_looked_up_on_the_cache_half(tmp_path: Path, monkeypatch):
     (install / "usage").mkdir()
     os.chmod(install / "usage", 0o755)
     assert [i.path for i in check_permissions(install, cache)] == [spool]
+
+
+def test_check_redirected_spool_is_checked_through_the_link(tmp_path: Path, monkeypatch):
+    """A --usage-dir redirect is a symlink; the mode rules apply to its
+    target, and check-perms follows it there."""
+    monkeypatch.setattr(perms, "_run_getfacl", lambda path: None)
+    root = tmp_path / "root"
+    root.mkdir()
+    os.chmod(root, 0o2775)
+    target = tmp_path / "home-spool"
+    target.mkdir()
+    os.chmod(target, 0o1777)
+    (root / "usage").symlink_to(target)
+
+    assert check_permissions(root) == []
+
+    os.chmod(target, 0o755)  # revoked-access aftermath: target lost its mode
+    problems = " ".join(i.problem for i in check_permissions(root))
+    assert "not world-writable" in problems
+
+
+def test_check_dangling_spool_symlink_is_flagged(tmp_path: Path, monkeypatch):
+    """A dangling redirect means someone turned collection on and its target
+    vanished — unlike a missing spool, that is not a deliberate opt-out."""
+    monkeypatch.setattr(perms, "_run_getfacl", lambda path: None)
+    root = tmp_path / "root"
+    root.mkdir()
+    os.chmod(root, 0o2775)
+    (root / "usage").symlink_to(tmp_path / "vanished")
+
+    issues = check_permissions(root)
+    assert [i.path for i in issues] == [root / "usage"]
+    assert "dangling" in issues[0].problem
+
+
+def test_records_write_through_a_redirected_spool(tmp_path: Path):
+    """The Delta scenario end-to-end: {cache_root}/usage is a symlink into a
+    directory the maintainer permanently controls, and sessions write
+    through it without knowing."""
+    from rootstock.usage import record_session
+
+    target = tmp_path / "home-spool"
+    target.mkdir()
+    (tmp_path / "usage").symlink_to(target)
+
+    path = record_session(
+        root=tmp_path,
+        cache_root=tmp_path,
+        env_name="mace",
+        checkpoint="mace-mp-0-medium",
+        is_local=False,
+        device="cuda",
+        client="calculator",
+        started_at="2026-07-23T01:02:03+00:00",
+        duration_s=1.0,
+        n_calculations=1,
+    )
+
+    assert path is not None
+    assert (target / path.name).is_file()  # the bytes live in the target
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_perms.py
+++ b/tests/test_perms.py
@@ -23,11 +23,13 @@ def test_render_single_filesystem():
     lines = [format_command(c) for c in cmds]
     # chmod goes last: setting an ACL rewrites the mode and can drop setgid.
     assert lines == [
+        "mkdir -p /install/root/usage",
         "chgrp m4845 /install/root",
         "setfacl -m g:m4845:rwx /install/root",
         "setfacl -dm g:m4845:rwx /install/root",
         "setfacl -dm o::r-X /install/root",
         "chmod 2775 /install/root",
+        "chmod 1777 /install/root/usage",
     ]
 
 
@@ -48,6 +50,31 @@ def test_render_cache_root_same_as_install_emits_nothing_extra():
     lines = [format_command(c) for c in cmds]
     assert not any("/cache" in line for line in lines)
     assert lines == [format_command(c) for c in render_commands("/install/root", group="m4845")]
+
+
+def test_render_spool_lives_on_the_cache_half():
+    """The spool takes runtime writes from user jobs, so it belongs on the
+    cache filesystem — never under an install root like Frontier's /sw."""
+    cmds = render_commands("/install/root", cache_root="/cache/root", group="m4845")
+    lines = [format_command(c) for c in cmds]
+    assert "mkdir -p /cache/root/usage" in lines
+    assert "chmod 1777 /cache/root/usage" in lines
+    assert not any("/install/root/usage" in line for line in lines)
+
+
+def test_render_no_usage_spool_omits_it():
+    cmds = render_commands("/install/root", group="m4845", usage_spool=False)
+    lines = [format_command(c) for c in cmds]
+    assert not any("usage" in line for line in lines)
+
+
+def test_render_spool_chmod_is_last_even_with_retrofit():
+    """The retrofit setfacl -R / find pass rewrites modes under the root, so
+    the spool's 1777 must be asserted after all of it — same reasoning as the
+    setgid-vs-setfacl ordering for the roots themselves."""
+    cmds = render_commands("/install/root", group="m4845", retrofit=True)
+    lines = [format_command(c) for c in cmds]
+    assert lines[-1] == "chmod 1777 /install/root/usage"
 
 
 def test_render_chmod_follows_every_setfacl():
@@ -193,6 +220,69 @@ def test_check_acl_flags_missing_default_and_mask_clamp(tmp_path: Path, monkeypa
     problems = " ".join(i.problem for i in issues)
     assert "no default ACL" in problems
     assert "mask clamps" in problems
+
+
+# --------------------------------------------------------------------------- #
+# usage spool
+# --------------------------------------------------------------------------- #
+
+
+def test_check_missing_spool_is_not_an_issue(tmp_path: Path, monkeypatch):
+    """No usage/ dir is how an install opts out of usage collection —
+    check-perms must not nag about a deliberate choice."""
+    monkeypatch.setattr(perms, "_run_getfacl", lambda path: None)
+    root = tmp_path / "root"
+    root.mkdir()
+    os.chmod(root, 0o2775)
+
+    assert check_permissions(root) == []
+
+
+def test_check_spool_with_correct_mode_is_clean(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(perms, "_run_getfacl", lambda path: None)
+    root = tmp_path / "root"
+    root.mkdir()
+    os.chmod(root, 0o2775)
+    spool = root / "usage"
+    spool.mkdir()
+    os.chmod(spool, 0o1777)
+
+    assert check_permissions(root) == []
+
+
+def test_check_spool_flags_not_world_writable_and_no_sticky(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(perms, "_run_getfacl", lambda path: None)
+    root = tmp_path / "root"
+    root.mkdir()
+    os.chmod(root, 0o2775)
+    spool = root / "usage"
+    spool.mkdir()
+    os.chmod(spool, 0o755)  # the umask-022 default a bare mkdir would leave
+
+    problems = " ".join(i.problem for i in check_permissions(root))
+    assert "not world-writable" in problems
+    assert "sticky" in problems
+
+
+def test_check_spool_looked_up_on_the_cache_half(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(perms, "_run_getfacl", lambda path: None)
+    install = tmp_path / "install"
+    cache = tmp_path / "cache"
+    install.mkdir()
+    cache.mkdir()
+    os.chmod(install, 0o2775)
+    os.chmod(cache, 0o2755)
+    spool = cache / "usage"
+    spool.mkdir()
+    os.chmod(spool, 0o777)  # world-writable but missing the sticky bit
+
+    issues = check_permissions(install, cache)
+    assert [i.path for i in issues] == [spool]
+    assert "sticky" in issues[0].problem
+    # A stray usage/ under the install root is not the spool.
+    (install / "usage").mkdir()
+    os.chmod(install / "usage", 0o755)
+    assert [i.path for i in check_permissions(install, cache)] == [spool]
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Part of #47 — the provisioning side of the usage-stats design ([design discussion](https://github.com/Garden-AI/rootstock/issues/47#issuecomment-5049880734)). **Now stacked on #156** (base: `feat/usage-spool-writer`; retarget to `main` after it merges): provisioning imports the spool location from `usage.py`, so render, check, and the writer can't disagree about where the spool lives.

## What

- `render_commands` grows `mkdir -p {cache_root}/usage` + `chmod 1777` (sticky, /tmp-style). The spool chmod is the **very last** command, after the retrofit `setfacl -R`/`find` pass that would otherwise rewrite it — same ordering rule that fixed the NERSC CFS setgid bug (#147).
- The spool lives on the **cache half** of a split install (the runtime-writable side — Frontier's install root is under `/sw`, which must not take writes from user jobs). `usage_spool_dir()` delegates to `usage.py`'s `usage_dir()`, adding only the perms-side convention that a missing cache_root means the install root doubles as the cache half.
- `--no-usage-spool` skips provisioning.
- `--usage-dir <path>` **redirects the spool via symlink** for clusters where maintainer write access to the install is temporary (e.g. Delta): the real `1777` directory is created at `<path>` — somewhere the maintainer permanently controls, like their home — and `{cache_root}/usage` becomes a symlink to it. Writers and readers keep using the same spool path and follow the link with zero resolution logic; when access to the install lapses, the maintainer still controls the target's permissions and can still prune it.
- `check_permissions`: a **missing** spool is not an issue (absence = the install's opt-out of usage collection), but a present one is flagged when it isn't world-writable (users' sessions silently can't record) or lacks the sticky bit (any user can delete other users' records). A redirected spool is checked through the link — and a *dangling* redirect is flagged, since that's not a deliberate opt-out.

## Notes for review

- Mode `1777` means a world-writable directory in project space — some centers' security scans flag that. The sticky bit + per-file O_EXCL writes make it /tmp-equivalent; #159 documents this (and `--usage-dir`) for maintainers in `docs/cluster-setup.md`.
- Whatever state the spool ends up in, an unwritable one never surfaces to users: `record_session` swallows every failure, so sessions silently skip recording and calculations are unaffected.

## Testing

13 spool tests (placement on split installs, --no-usage-spool, --usage-dir redirect rendering + conflict, chmod-last-even-with-retrofit ordering, missing-spool-is-clean, mode/sticky flagging through symlinks, dangling-redirect flagging, cache-half lookup, end-to-end write through a redirected spool); one existing setup-perms test updated for the new final command. Full suite: 569 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
