### PR TITLE
Fix teardown hang on workers stuck in uninterruptible sleep

### DIFF
--- a/rootstock/calculator.py
+++ b/rootstock/calculator.py
@@ -6,6 +6,7 @@ This is the main user-facing interface for Rootstock.
 
 from __future__ import annotations
 
+import logging
 import uuid
 from pathlib import Path
 
@@ -18,6 +19,8 @@ from .config import resolve_default_root
 from .layout import ensure_layout_compatible, resolve_cache_root
 from .local_checkpoints import LocalCheckpointError, resolve_checkpoint
 from .server import RootstockServer, WorkerDiedError
+
+logger = logging.getLogger("rootstock.calculator")
 
 
 class RootstockCalculator(Calculator):
@@ -243,7 +246,17 @@ class RootstockCalculator(Calculator):
             # this instance being permanently bricked by one GPU OOM mid-MD.
             # No automatic retry — the same configuration would likely fail
             # the same way; the caller decides whether to try again.
-            self.close()
+            # Teardown is best-effort: the post-mortem in the exception is
+            # the user's only diagnostic, so a cleanup failure must never
+            # mask it.
+            try:
+                self.close()
+            except Exception:
+                logger.warning(
+                    "Server teardown after worker death failed; raising the original error anyway",
+                    exc_info=True,
+                )
+                self._server = None
             raise
 
         # Store results

--- a/rootstock/server.py
+++ b/rootstock/server.py
@@ -447,7 +447,19 @@ class RootstockServer:
                 self._process.wait(timeout=5.0)
             except subprocess.TimeoutExpired:
                 self._process.kill()
-                self._process.wait()
+                try:
+                    self._process.wait(timeout=5.0)
+                except subprocess.TimeoutExpired:
+                    # A worker in uninterruptible sleep (D state — dead Lustre
+                    # mount, swap thrash) ignores SIGKILL until its syscall
+                    # returns. Waiting here would hang teardown forever, so
+                    # abandon the process; the kernel reaps it when it wakes.
+                    logger.warning(
+                        "Worker process %d did not exit after SIGKILL "
+                        "(likely stuck in uninterruptible I/O); "
+                        "abandoning it and continuing teardown",
+                        self._process.pid,
+                    )
             self._process = None
 
         # Close worker output temp files

--- a/tests/calculator/test_worker_died_teardown.py
+++ b/tests/calculator/test_worker_died_teardown.py
@@ -1,0 +1,66 @@
+"""A failing teardown must not mask the WorkerDiedError post-mortem.
+
+Companion to tests/server/test_stop_unkillable_worker.py (NCSA Delta,
+2026-07-23): calculate()'s WorkerDiedError handler used to call close()
+before re-raising, so a stop() that hung or raised swallowed the one
+exception carrying the worker's exit code and output tails.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from ase import Atoms
+
+from rootstock.calculator import RootstockCalculator
+from rootstock.server import WorkerDiedError
+
+_ENV_SOURCE = """\
+CHECKPOINTS = {"uma-s-1p1": "uma-s-1p1"}
+
+
+def setup(checkpoint, device="cuda"):
+    return None
+"""
+
+_POSTMORTEM = "worker exited with code 19\nMID-CALCULATE-BOOM"
+
+
+class _DoomedServer:
+    """calculate() reports a dead worker; stop() itself then blows up."""
+
+    def __init__(self, **kwargs):
+        pass
+
+    def start(self):
+        pass
+
+    def calculate(self, *args, **kwargs):
+        raise WorkerDiedError(_POSTMORTEM)
+
+    def stop(self):
+        raise RuntimeError("teardown failed too")
+
+
+@pytest.fixture
+def fake_root(tmp_path: Path) -> Path:
+    env_dir = tmp_path / "root" / "envs" / "uma"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+    (env_dir / "env_source.py").write_text(_ENV_SOURCE)
+    return tmp_path / "root"
+
+
+def test_worker_died_error_survives_failing_close(fake_root, monkeypatch, caplog):
+    monkeypatch.setattr("rootstock.calculator.RootstockServer", _DoomedServer)
+    calc = RootstockCalculator(checkpoint="uma-s-1p1", root=fake_root, device="cpu")
+    atoms = Atoms("H2", positions=[[0, 0, 0], [0.74, 0, 0]])
+    atoms.calc = calc
+
+    with pytest.raises(WorkerDiedError, match="MID-CALCULATE-BOOM"):
+        calc.calculate(atoms)
+
+    # The broken server was still discarded, so the next calculation
+    # would build a fresh one instead of reusing the dead worker.
+    assert calc._server is None

--- a/tests/server/test_stop_unkillable_worker.py
+++ b/tests/server/test_stop_unkillable_worker.py
@@ -1,0 +1,118 @@
+"""stop() must not hang on a worker process that never dies.
+
+Observed on NCSA Delta (2026-07-23): a worker wedged in uninterruptible
+sleep (D state — dead Lustre I/O, swap thrash) ignores SIGKILL until its
+syscall returns, so the old ``self._process.wait()`` (no timeout) after
+``kill()`` blocked teardown forever. User-visible symptom: the 600 s socket
+timeout fired, but the WorkerDiedError post-mortem never printed because
+the calculator's teardown hung first — "the timeout arg didn't actually
+time out".
+
+SIGKILL immunity can't be faked from userspace, so the harness combines a
+real child process that ignores SIGTERM (proving terminate() alone can't
+reap it) with a Popen wrapper whose ``wait(timeout=...)`` always raises
+``TimeoutExpired`` — the observable behavior of a D-state process that
+outlives both signals. A ``wait()`` call *without* a timeout fails the
+test immediately: that is exactly the call that hangs on a real cluster.
+"""
+
+from __future__ import annotations
+
+import logging
+import signal
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from rootstock.server import RootstockServer
+
+_SIGTERM_IMMUNE_WORKER = (
+    "import signal, sys, time\n"
+    "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+    "print('ready', flush=True)\n"
+    "time.sleep(3600)\n"
+)
+
+
+class _UnkillablePopen:
+    """Wraps a real SIGTERM-immune process, but reports every bounded wait
+    as timing out and refuses unbounded waits — the shape of a D-state
+    worker that survives SIGKILL."""
+
+    def __init__(self, proc: subprocess.Popen):
+        self._proc = proc
+        self.pid = proc.pid
+        self.kill_called = False
+
+    def terminate(self):
+        self._proc.terminate()  # real signal, really ignored
+
+    def kill(self):
+        # Deliberately not delivered to the real child: the simulated
+        # worker survives SIGKILL. The fixture reaps it afterwards.
+        self.kill_called = True
+
+    def wait(self, timeout=None):
+        if timeout is None:
+            pytest.fail(
+                "Popen.wait() called without a timeout during stop() — "
+                "this hangs forever on a worker stuck in uninterruptible sleep"
+            )
+        raise subprocess.TimeoutExpired(cmd="fake-worker", timeout=timeout)
+
+
+@pytest.fixture
+def sigterm_immune_proc():
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _SIGTERM_IMMUNE_WORKER],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    # Don't race the signal handler installation
+    assert proc.stdout.readline().strip() == "ready"
+    try:
+        yield proc
+    finally:
+        proc.send_signal(signal.SIGKILL)
+        proc.wait(timeout=10)
+        proc.stdout.close()
+
+
+def _bare_server(tmp_path: Path) -> RootstockServer:
+    """A server that was never start()ed — stop() tolerates the unopened
+    sockets/files, so we can graft a fake process straight onto it."""
+    return RootstockServer(
+        env_name="unused",
+        checkpoint="unused",
+        device="cpu",
+        root=tmp_path,
+        socket_name="unkillable-test",
+    )
+
+
+def test_stop_abandons_worker_that_survives_sigkill(tmp_path: Path, sigterm_immune_proc, caplog):
+    server = _bare_server(tmp_path)
+    fake = _UnkillablePopen(sigterm_immune_proc)
+    server._process = fake
+
+    with caplog.at_level(logging.WARNING, logger="rootstock.server"):
+        server.stop()  # must return instead of blocking on wait()
+
+    assert fake.kill_called  # escalated terminate -> kill before giving up
+    assert server._process is None  # teardown completed past the process
+    warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any(str(fake.pid) in msg and "SIGKILL" in msg for msg in warnings)
+
+
+def test_stop_reaps_worker_that_only_ignores_sigterm(tmp_path: Path, sigterm_immune_proc):
+    # The ordinary escalation path, end to end with a real process: SIGTERM
+    # is ignored, the 5 s bounded wait expires, SIGKILL actually lands.
+    server = _bare_server(tmp_path)
+    server._process = sigterm_immune_proc
+
+    server.stop()
+
+    assert server._process is None
+    assert sigterm_immune_proc.returncode == -signal.SIGKILL


### PR DESCRIPTION
Closes #160.

## Problem

On Delta (2026-07-23), a worker wedged in uninterruptible sleep (D state — dead Lustre I/O) during its first MLIP calculation. The parent's 600 s socket timeout fired as designed, but the user saw an indefinite hang: "the timeout arg didn't actually time out."

Two compounding bugs:

1. **`RootstockServer.stop()`**: after escalating to `kill()`, the follow-up `wait()` had no timeout. A D-state process ignores SIGKILL until its syscall returns, so teardown blocked forever.
2. **`RootstockCalculator.calculate()`**: the `except WorkerDiedError` handler called `close()` *before* re-raising, so the hanging teardown swallowed the post-mortem (exit code + worker stdout/stderr tails) that would have explained the failure.

## Fix

- `stop()` bounds the post-SIGKILL wait at 5 s; on expiry it logs a WARNING naming the unkillable PID and continues teardown (sockets, temp files, and the socket dir are still cleaned up; the kernel reaps the process when its syscall returns).
- The `WorkerDiedError` handler's teardown is now best-effort: a failing `close()` logs a warning, the dead server reference is still dropped (next calculation starts fresh), and the original `WorkerDiedError` always propagates.

## Tests

SIGKILL immunity can't be faked from userspace, so the regression harness combines a real child process that ignores SIGTERM with a `Popen` wrapper whose `wait(timeout=...)` always raises `TimeoutExpired`. A `wait()` call *without* a timeout fails the test immediately — verified that the pre-fix code fails at exactly the line that hung on Delta. A second test exercises the real terminate → kill escalation end to end, and a calculator-side test asserts the post-mortem survives a teardown that itself raises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)