### PR TITLE
setup-perms --apply: skip ACL commands when setfacl is missing instead of crashing

### DIFF
--- a/rootstock/commands/setup_perms.py
+++ b/rootstock/commands/setup_perms.py
@@ -78,7 +78,8 @@ def cmd_setup_perms(args) -> int:
             print(format_command(argv))
         return 0
 
-    # --apply: confirm, then run each command, stopping at the first failure.
+    # --apply: confirm, then run each command, stopping at the first failure
+    # (except a missing setfacl, which downgrades to skipping the ACL commands).
     print(f"About to apply these permissions to {install_root} (group: {args.group}):")
     for argv in commands:
         print(f"  {format_command(argv)}")
@@ -87,8 +88,35 @@ def cmd_setup_perms(args) -> int:
         print("Aborted.")
         return 1
 
+    setfacl_missing = False
     for argv in commands:
-        result = subprocess.run(argv, capture_output=True, text=True)
+        if setfacl_missing and argv[0] == "setfacl":
+            continue
+        try:
+            result = subprocess.run(argv, capture_output=True, text=True)
+        except FileNotFoundError:
+            # A host without ACL tooling is a known configuration (Frontier
+            # login nodes ship no setfacl), not a broken one: skip the ACL
+            # commands and keep going so the trailing chmods — which the
+            # recipe deliberately orders last — still run. The re-check below
+            # reports whatever the skips left wrong, mirroring how
+            # perms._run_getfacl degrades when getfacl is absent. Any other
+            # missing binary (chgrp, chmod, mkdir...) means something is
+            # genuinely off with the host, so abort cleanly.
+            if argv[0] == "setfacl":
+                setfacl_missing = True
+                print(
+                    "Warning: setfacl not found on this host; skipping ACL "
+                    "commands. Mode bits and group ownership will still be "
+                    "applied.",
+                    file=sys.stderr,
+                )
+                continue
+            print(
+                f"Error: command not found: {argv[0]} (needed for: {format_command(argv)})",
+                file=sys.stderr,
+            )
+            return 1
         if result.returncode != 0:
             print(f"Error: command failed: {format_command(argv)}", file=sys.stderr)
             if result.stderr:

--- a/tests/cli/test_setup_perms.py
+++ b/tests/cli/test_setup_perms.py
@@ -181,6 +181,76 @@ def test_apply_aborts_without_confirmation(monkeypatch, capsys):
     assert "Aborted." in capsys.readouterr().out
 
 
+def test_apply_skips_acl_commands_when_setfacl_is_missing(monkeypatch, capsys):
+    """No setfacl on the host (e.g. Frontier login nodes) skips ACLs, not chmod.
+
+    The recipe orders chmod last, so a crash on the first setfacl used to
+    abort before the mode bits were ever asserted."""
+    calls = []
+
+    def fake_run(argv, capture_output=False, text=False):
+        if argv[0] == "setfacl":
+            raise FileNotFoundError(2, "No such file or directory", "setfacl")
+        calls.append(argv)
+        return SimpleNamespace(returncode=0, stderr="")
+
+    monkeypatch.setattr("rootstock.commands.setup_perms.subprocess.run", fake_run)
+    monkeypatch.setattr("rootstock.commands.setup_perms.check_permissions", lambda *a, **k: [])
+    monkeypatch.setattr("builtins.input", lambda _prompt: "y")
+
+    rc = cmd_setup_perms(_args(root="/install/root", apply=True, retrofit=True))
+    assert rc == 0
+    # The rest of the recipe still ran, chmod included.
+    assert ["chgrp", "m4845", "/install/root"] in calls
+    assert ["chmod", "2775", "/install/root"] in calls
+    captured = capsys.readouterr()
+    assert "Permissions applied." in captured.out
+    # One warning, even though --retrofit renders many setfacl commands.
+    assert captured.err.count("setfacl not found") == 1
+
+
+def test_apply_skipped_setfacl_still_reports_surviving_issues(monkeypatch, capsys):
+    """Skipping ACLs defers to the post-apply re-check, which must still run."""
+
+    def fake_run(argv, capture_output=False, text=False):
+        if argv[0] == "setfacl":
+            raise FileNotFoundError(2, "No such file or directory", "setfacl")
+        return SimpleNamespace(returncode=0, stderr="")
+
+    monkeypatch.setattr("rootstock.commands.setup_perms.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "rootstock.commands.setup_perms.check_permissions",
+        lambda *a, **k: [PermIssue(Path("/install/root"), "no default ACL")],
+    )
+    monkeypatch.setattr("builtins.input", lambda _prompt: "y")
+
+    rc = cmd_setup_perms(_args(root="/install/root", apply=True))
+    assert rc == 1
+    assert "still look wrong" in capsys.readouterr().err
+
+
+def test_apply_aborts_cleanly_when_another_binary_is_missing(monkeypatch, capsys):
+    """A missing chgrp is a broken host, not a known configuration: clean abort."""
+    calls = []
+
+    def fake_run(argv, capture_output=False, text=False):
+        calls.append(argv)
+        if argv[0] == "chgrp":
+            raise FileNotFoundError(2, "No such file or directory", "chgrp")
+        return SimpleNamespace(returncode=0, stderr="")
+
+    monkeypatch.setattr("rootstock.commands.setup_perms.subprocess.run", fake_run)
+    monkeypatch.setattr("builtins.input", lambda _prompt: "y")
+
+    rc = cmd_setup_perms(_args(root="/install/root", apply=True))
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "command not found: chgrp" in err
+    assert "Traceback" not in err
+    # Stopped at the missing binary — nothing after chgrp was attempted.
+    assert not any(c[0] == "setfacl" for c in calls)
+
+
 def test_apply_bails_on_first_failure(monkeypatch, capsys):
     calls = []
 


### PR DESCRIPTION
Fixes #164.

## Problem

`rootstock setup-perms --apply` on a host without `setfacl` (observed on ORNL Frontier login nodes, rootstock 1.1.0, 2026-07-24) crashed with a raw `FileNotFoundError` traceback: the `--apply` loop handles nonzero exit codes but not a missing binary. Worse than the traceback itself: the recipe from `perms.render_commands` deliberately orders the `chmod` commands **last** (setting an ACL can clear setgid), so the crash on the first `setfacl` aborted the run before the mode bits — the part of the recipe that works fine without ACL tooling — were ever asserted.

## Fix

Catch `FileNotFoundError` per command:

- **Missing `setfacl`** → warn once ("skipping ACL commands"), skip all remaining `setfacl` commands, and keep applying the rest of the recipe (mkdir/chgrp/chmod). The existing post-apply re-check then reports anything the skips left wrong — the same graceful degradation `perms._run_getfacl` already does for a missing `getfacl`, and consistent with the re-check's existing "this filesystem may not support part of the recipe" framing.
- **Any other missing binary** (`chgrp`, `chmod`, `mkdir`, ...) → clean one-line `Error: command not found` and exit 1, since that indicates a genuinely broken host rather than a known configuration.

Issue #164 lays out the alternative (clean abort for *everything*, including setfacl) — happy to switch to that if you'd rather; skip-and-continue seemed more in the spirit of the existing degradation paths.

## Tests

Three new tests in `tests/cli/test_setup_perms.py`:
- missing `setfacl` skips ACL commands but still runs `chgrp`/`chmod` and warns exactly once (even with `--retrofit`'s many setfacl commands), exiting 0 when the re-check is clean;
- the post-apply re-check still runs and still fails the command when issues survive the skipped ACLs;
- a missing `chgrp` aborts cleanly with "command not found" and no traceback.

Full suite: 589 passed, 2 skipped. `ruff check` / `ruff format` clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
