### PR TITLE
Bound worker-connect wait by the calculator timeout

### DIFF
--- a/rootstock/server.py
+++ b/rootstock/server.py
@@ -242,9 +242,19 @@ class RootstockServer:
         )
 
     def _accept_connection(self):
-        """Accept connection from worker process."""
+        """Accept connection from worker process.
+
+        Bounded by ``self.timeout``: the socket timeouts below only start
+        counting once a connection exists, so without a deadline here a
+        worker that is alive but never connects — wedged in setup() on
+        stalled filesystem I/O, say — would hang this loop forever with no
+        way for the caller's timeout to fire (observed on Delta, workers
+        blocked in Lustre reads of /work/hdd during model load).
+        """
         # Use short timeout for accept so we can check if process died
         self._server_socket.settimeout(1.0)
+        deadline = time.monotonic() + self.timeout
+        next_heartbeat = 30.0
 
         while True:
             try:
@@ -254,6 +264,28 @@ class RootstockServer:
                 # Check if process died
                 if self._process.poll() is not None:
                     raise self._worker_failure_error("Worker process died before connecting")
+                waited = self.timeout - (deadline - time.monotonic())
+                if waited >= next_heartbeat:
+                    logger.info(
+                        "Still waiting for worker %d to connect (%.0fs elapsed, "
+                        "typically loading the model)",
+                        self._process.pid,
+                        waited,
+                    )
+                    next_heartbeat += 30.0
+                if time.monotonic() >= deadline:
+                    # Read the post-mortem (live output tails) before stop()
+                    # closes the capture files, then tear the worker down —
+                    # stop()'s bounded waits make that safe even when the
+                    # worker is stuck in uninterruptible I/O.
+                    error = self._worker_failure_error(
+                        f"Worker did not connect within timeout ({self.timeout:g}s). "
+                        "The worker never finished setup() — a slow or stalled "
+                        "model load (cold cache, degraded filesystem). If the "
+                        "load is genuinely slow, raise `timeout`"
+                    )
+                    self.stop()
+                    raise error
 
         # Restore original timeout
         self._server_socket.settimeout(self.timeout)

--- a/tests/server/test_startup_connect_timeout.py
+++ b/tests/server/test_startup_connect_timeout.py
@@ -1,0 +1,87 @@
+"""start() must not hang on a worker that is alive but never connects.
+
+Observed on NCSA Delta (2026-07-24, issue #160): a worker blocked in Lustre
+sync I/O (`wchan cl_sync_io_wait`) during model load never reached the
+socket connect, and the parent sat in ``_accept_connection``'s accept()
+poll loop forever. The calculator's ``timeout`` only ever applied to the
+*connected* socket, so from the user's chair "the timeout arg didn't
+actually time out" — no matter what value was passed.
+
+``_accept_connection`` now carries a deadline of ``self.timeout``: on
+expiry it raises a WorkerDiedError post-mortem (with the worker's live
+output tails) and tears the worker down.
+
+Uses the faked-env harness from the post-mortem tests: ``bin/python``
+symlinked to this interpreter, ``PYTHONPATH`` handed down so the worker
+can import rootstock + ase.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from rootstock.server import RootstockServer, WorkerDiedError
+
+_CHECKPOINT = "never-connects-dummy"
+_SETUP_MARKER = "SETUP-STARTED-MARKER"
+
+
+@pytest.fixture
+def never_connecting_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Env whose setup() announces itself and then blocks forever — the
+    shape of a model load stuck on stalled filesystem I/O. The worker only
+    connects *after* setup() returns, so it never does."""
+    import ase
+
+    import rootstock
+
+    pythonpath = os.pathsep.join(
+        sorted({str(Path(m.__file__).resolve().parents[1]) for m in (ase, rootstock)})
+    )
+    monkeypatch.setenv("PYTHONPATH", pythonpath)
+
+    env_dir = tmp_path / "envs" / "stalled"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").symlink_to(sys.executable)
+    (env_dir / "env_source.py").write_text(
+        f"CHECKPOINTS = {{{_CHECKPOINT!r}: 'dummy'}}\n\n"
+        "def setup(checkpoint, device='cpu', **kwargs):\n"
+        "    import sys, time\n"
+        f"    sys.stderr.write({_SETUP_MARKER!r})\n"
+        "    sys.stderr.flush()\n"
+        "    time.sleep(3600)\n"
+    )
+    return tmp_path
+
+
+def test_start_times_out_when_worker_never_connects(never_connecting_root: Path):
+    server = RootstockServer(
+        env_name="stalled",
+        checkpoint=_CHECKPOINT,
+        device="cpu",
+        root=never_connecting_root,
+        timeout=3.0,
+        socket_name=f"stalled_{os.getpid()}",
+    )
+
+    began = time.monotonic()
+    with pytest.raises(WorkerDiedError) as excinfo:
+        server.start()
+    elapsed = time.monotonic() - began
+
+    # Bounded: the old code looped in accept() forever. Allow slack for
+    # worker spawn + the 1 s accept poll granularity + teardown.
+    assert elapsed < 30.0
+
+    message = str(excinfo.value)
+    assert "did not connect within timeout" in message
+    assert "still running" in message  # fate: alive-but-stuck, not dead
+    assert _SETUP_MARKER in message  # live-read output tail made it in
+
+    # The stuck worker was torn down, not orphaned.
+    assert server._process is None


### PR DESCRIPTION
The actual root cause of #160 (which #161 closed prematurely — that fix was real but secondary).

## Problem

The calculator's `timeout` was only ever installed on the socket **after** the worker connected. `_accept_connection()` polled `accept()` in an unbounded 1 s loop as long as the worker process stayed alive — so a worker wedged in `setup()` hung the parent forever, silently, regardless of the timeout value passed.

Confirmed by live repro on Delta (2026-07-24, rootstock 1.1.0): Ctrl-C traceback showed the parent in `_accept_connection` → `socket.accept()`; the worker sat at `wchan cl_sync_io_wait`, demand-paging mmap'd torch `.so`s over cold-cache HDD Lustre at ~350 KB/s (measured via `/proc/<pid>/io`) — a model load that would take hours, indistinguishable from a hang. Reproduced identically on login and compute nodes; device and node type were incidental.

## Fix

`_accept_connection()` now enforces a deadline of `self.timeout`:

- On expiry it builds the `WorkerDiedError` post-mortem **before** teardown (live-read worker output tails + process fate: "still running (hung, or blocked on the device?)"), then calls `stop()` — safe against unkillable workers thanks to #161's bounded waits — and raises.
- While waiting, an INFO heartbeat fires every 30 s naming the worker PID, so a slow-but-legitimate model load looks alive instead of frozen.
- The error message tells users to raise `timeout` if their load is genuinely slow.

Behavior change to be aware of: a model load slower than `timeout` (default 600 s) now fails with a diagnostic error instead of waiting indefinitely. That's the intent — on a filesystem this slow, "wait forever with no output" was the failure mode being reported.

## Test

`tests/server/test_startup_connect_timeout.py`: fake env whose `setup()` announces itself on stderr and blocks forever; asserts `start()` raises within bounds, the message carries the "did not connect within timeout" context, the alive-but-stuck fate, and the live-read stderr marker, and that the worker was torn down. Verified to hang indefinitely against the pre-fix code.

A follow-up issue proposes a page-cache prewarm at worker spawn to address the underlying slow-load condition itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)