### PR TITLE
Prewarm the page cache at worker spawn

### DIFF
--- a/rootstock/prewarm.py
+++ b/rootstock/prewarm.py
@@ -1,0 +1,105 @@
+"""Sequentially pre-read env files into the OS page cache before heavy imports.
+
+Python's import machinery mmaps large shared libraries and faults them in
+roughly a page per synchronous read. On a cold page cache over a network
+filesystem each fault is a full round-trip — measured on NCSA Delta's
+HDD-backed Lustre at ~0.35 MB/s (hours for a torch-sized env) while the
+same files streamed sequentially at 13 MB/s cold on the same node (#167).
+Reading the bytes sequentially and discarding them populates the page
+cache, so the mmap faults that follow hit memory instead of the wire.
+When the cache is already warm this costs seconds of memory-speed reads.
+
+``spawn_in_env`` stages this module next to the worker wrapper, which runs
+it inside the *target env's* Python before any heavy import — so it must
+stay stdlib-only and compatible with any Python an env might ship.
+
+Best-effort by design: unreadable files are skipped, any unexpected error
+aborts the prewarm and never the worker, and ``ROOTSTOCK_NO_PREWARM=1``
+skips it entirely (e.g. on node-local or known-warm installs where it is
+pure overhead).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+_CHUNK_SIZE = 16 * 1024 * 1024
+
+
+def iter_prewarm_files(spec: dict):
+    """Yield the files worth warming for a worker spawn spec.
+
+    - every shared library under the env (``{env_dir}/**/*.so*`` — the bulk
+      of the import cost; torch dominates),
+    - the local checkpoint weights file, when the spec names one,
+    - any extra files or directory trees a client lists in
+      ``spec["prewarm_paths"]`` (reserved for future use; directories are
+      walked recursively).
+    """
+    env_dir = spec.get("env_dir")
+    if env_dir:
+        yield from sorted(Path(env_dir).rglob("*.so*"))
+
+    extras = list(spec.get("prewarm_paths") or [])
+    if spec.get("checkpoint_path"):
+        extras.append(spec["checkpoint_path"])
+    for extra in extras:
+        path = Path(extra)
+        if path.is_dir():
+            yield from sorted(p for p in path.rglob("*") if p.is_file())
+        elif path.is_file():
+            yield path
+
+
+def prewarm_files(paths) -> tuple[int, int]:
+    """Sequentially read ``paths``, discarding the bytes.
+
+    Returns ``(n_files, n_bytes)`` actually read. Files that vanish or
+    can't be opened are skipped — the goal is a warm cache, not an audit.
+    """
+    n_files = 0
+    n_bytes = 0
+    for path in paths:
+        try:
+            with open(path, "rb") as f:
+                while True:
+                    chunk = f.read(_CHUNK_SIZE)
+                    if not chunk:
+                        break
+                    n_bytes += len(chunk)
+        except OSError:
+            continue
+        n_files += 1
+    return n_files, n_bytes
+
+
+def prewarm_from_spec(spec: dict, log=None) -> None:
+    """Warm the page cache for a worker spawn spec; never raises.
+
+    The one-line summary goes to ``log`` (default stderr, so it lands in
+    the worker's captured output and any post-mortem) — its duration is a
+    direct read on filesystem health: seconds when warm, and when cold it
+    replaces an hours-long stall with a visible, bounded read.
+    """
+    if os.environ.get("ROOTSTOCK_NO_PREWARM"):
+        return
+    if log is None:
+        log = sys.stderr
+    try:
+        began = time.monotonic()
+        n_files, n_bytes = prewarm_files(iter_prewarm_files(spec))
+        elapsed = time.monotonic() - began
+        print(
+            f"[Worker] Prewarmed page cache: {n_files} files, "
+            f"{n_bytes / 1e6:.0f} MB in {elapsed:.1f}s",
+            file=log,
+            flush=True,
+        )
+    except Exception as exc:  # noqa: BLE001 - never take the worker down
+        try:
+            print(f"[Worker] Prewarm skipped: {type(exc).__name__}: {exc}", file=log, flush=True)
+        except Exception:
+            pass

--- a/rootstock/spawn.py
+++ b/rootstock/spawn.py
@@ -33,10 +33,23 @@ from pathlib import Path
 from .environment import get_env_python, get_model_cache_env
 
 WORKER_WRAPPER = """\
-import json, sys
+import json, os, sys
 
 with open(sys.argv[1]) as f:
     spec = json.load(f)
+
+# Warm the page cache before the heavy imports below fault their way
+# through multi-GB mmap'd libraries at network-round-trip speed (#167).
+# The helper is staged next to this wrapper; best-effort, never fatal.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _here)
+try:
+    import prewarm
+    prewarm.prewarm_from_spec(spec)
+except ImportError:
+    pass  # wrapper run without staged helper (e.g. tests); warming is optional
+finally:
+    sys.path.remove(_here)
 
 sys.path.insert(0, spec["env_dir"])
 from rootstock.worker import run_worker
@@ -62,10 +75,22 @@ run_worker(
 """
 
 DOWNLOAD_WRAPPER = """\
-import json, sys
+import json, os, sys
 
 with open(sys.argv[1]) as f:
     spec = json.load(f)
+
+# Same cold-cache prewarm as WORKER_WRAPPER — setup() below imports the
+# same multi-GB libraries before it can download anything.
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _here)
+try:
+    import prewarm
+    prewarm.prewarm_from_spec(spec)
+except ImportError:
+    pass  # wrapper run without staged helper (e.g. tests); warming is optional
+finally:
+    sys.path.remove(_here)
 
 sys.path.insert(0, spec["env_dir"])
 from env_source import setup
@@ -117,6 +142,12 @@ def spawn_in_env(
     try:
         wrapper = Path(tmp_dir) / "wrapper.py"
         wrapper.write_text(wrapper_source)
+        # The prewarm helper runs inside the env's (different) Python, so it
+        # travels as staged source next to the wrapper rather than being
+        # imported from the client's installation.
+        (Path(tmp_dir) / "prewarm.py").write_text(
+            (Path(__file__).parent / "prewarm.py").read_text()
+        )
         sidecar = Path(tmp_dir) / "spec.json"
         sidecar.write_text(json.dumps({**payload, "env_dir": str(env_dir)}))
 

--- a/tests/worker/test_prewarm.py
+++ b/tests/worker/test_prewarm.py
@@ -1,0 +1,136 @@
+"""Page-cache prewarm at worker spawn (issue #167).
+
+On a cold page cache over Lustre, the worker's imports fault mmap'd
+shared libraries in at network-round-trip speed (~0.35 MB/s measured on
+Delta) while sequential reads of the same files run at bandwidth. The
+prewarm module — staged next to the spawn wrapper, run inside the env's
+Python before any heavy import — reads the env's ``.so`` files and the
+checkpoint sequentially to populate the cache.
+
+Correctness here means: it reads the right files, it is skippable, and it
+can never take the worker down. The staging test pins the contract that
+the module travels with the wrapper (that's what lets already-deployed
+envs benefit without a rebuild).
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from rootstock.prewarm import iter_prewarm_files, prewarm_files, prewarm_from_spec
+from rootstock.spawn import DOWNLOAD_WRAPPER, WORKER_WRAPPER, spawn_in_env
+
+
+@pytest.fixture
+def fake_env(tmp_path: Path) -> dict:
+    """A spec pointing at an env tree with libraries, noise, and weights."""
+    env_dir = tmp_path / "envs" / "fake"
+    lib = env_dir / "lib" / "python3.11" / "site-packages" / "torch" / "lib"
+    lib.mkdir(parents=True)
+    (lib / "libtorch_cpu.so").write_bytes(b"x" * 1024)
+    (lib / "libc10.so.1").write_bytes(b"y" * 512)
+    (env_dir / "env_source.py").write_text("# not a shared library")
+
+    weights = tmp_path / "weights.pt"
+    weights.write_bytes(b"w" * 256)
+
+    return {
+        "env_dir": str(env_dir),
+        "checkpoint": "fake-ckpt",
+        "checkpoint_path": str(weights),
+    }
+
+
+def test_iter_finds_shared_libs_and_checkpoint(fake_env):
+    found = {p.name for p in iter_prewarm_files(fake_env)}
+    assert found == {"libtorch_cpu.so", "libc10.so.1", "weights.pt"}
+
+
+def test_iter_walks_extra_prewarm_dirs(fake_env, tmp_path: Path):
+    cache = tmp_path / "cache" / "fake"
+    cache.mkdir(parents=True)
+    (cache / "model.bin").write_bytes(b"m")
+    fake_env["prewarm_paths"] = [str(cache)]
+    found = {p.name for p in iter_prewarm_files(fake_env)}
+    assert "model.bin" in found
+
+
+def test_prewarm_reads_every_byte(fake_env):
+    n_files, n_bytes = prewarm_files(iter_prewarm_files(fake_env))
+    assert n_files == 3
+    assert n_bytes == 1024 + 512 + 256
+
+
+def test_prewarm_from_spec_reports_summary(fake_env):
+    log = io.StringIO()
+    prewarm_from_spec(fake_env, log=log)
+    message = log.getvalue()
+    assert "Prewarmed page cache: 3 files" in message
+
+
+def test_env_var_skips_prewarm(fake_env, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ROOTSTOCK_NO_PREWARM", "1")
+    log = io.StringIO()
+    prewarm_from_spec(fake_env, log=log)
+    assert log.getvalue() == ""
+
+
+def test_unreadable_file_is_skipped(fake_env):
+    blocked = Path(fake_env["env_dir"]) / "lib" / "blocked.so"
+    blocked.write_bytes(b"z" * 128)
+    os.chmod(blocked, 0o000)
+    try:
+        n_files, n_bytes = prewarm_files(iter_prewarm_files(fake_env))
+    finally:
+        os.chmod(blocked, 0o644)  # let tmp_path cleanup work
+    assert n_files == 3  # the readable three, blocked.so skipped
+    assert n_bytes == 1024 + 512 + 256
+
+
+def test_prewarm_from_spec_never_raises():
+    # Garbage spec: iter explodes on a non-dict-shaped value inside.
+    log = io.StringIO()
+    prewarm_from_spec({"env_dir": 0xBAD, "prewarm_paths": 42}, log=log)
+    assert "Prewarm skipped" in log.getvalue()
+
+
+def test_wrapper_runs_prewarm_end_to_end(tmp_path: Path):
+    """Through the real staging + subprocess path, the summary line lands on
+    the worker's stderr — which is what the post-mortem capture reads."""
+    env_dir = tmp_path / "envs" / "fake"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").symlink_to(sys.executable)
+    (env_dir / "lib").mkdir()
+    (env_dir / "lib" / "libfake.so").write_bytes(b"x" * 2048)
+    (env_dir / "env_source.py").write_text(
+        "def setup(checkpoint, device='cpu', **kwargs):\n    return None\n"
+    )
+
+    payload = {"checkpoint": "c", "device": "cpu", "setup_kwargs": {}}
+    with spawn_in_env(tmp_path, "fake", DOWNLOAD_WRAPPER, payload) as spec:
+        result = subprocess.run(
+            spec.cmd, env=spec.env, cwd=spec.cwd, capture_output=True, text=True
+        )
+    assert result.returncode == 0, result.stderr
+    assert "Prewarmed page cache: 1 files" in result.stderr
+
+
+def test_spawn_stages_prewarm_module_next_to_wrapper(tmp_path: Path):
+    env_dir = tmp_path / "envs" / "fake"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+
+    with spawn_in_env(tmp_path, "fake", WORKER_WRAPPER, {"checkpoint": "x"}) as spec:
+        staged_dir = Path(spec.cmd[1]).parent
+        staged = staged_dir / "prewarm.py"
+        assert staged.exists()
+        # Byte-identical to the client's module: the staged copy IS the
+        # implementation the env's python runs.
+        source = Path(__file__).resolve().parents[2] / "rootstock" / "prewarm.py"
+        assert staged.read_text() == source.read_text()


### PR DESCRIPTION
Closes #167.

## Problem

On a cold page cache over a network filesystem, the worker's imports fault mmap'd multi-GB shared libraries in roughly a page per synchronous RPC. Measured on Delta's HDD-backed Lustre (2026-07-24, while diagnosing #160): the worker read at **~0.35 MB/s** (`/proc/<pid>/io`) — hours for a torch import — while a sequential read of the same files ran **37× faster cold** (13 MB/s, 2.9 GB/s warm) on the same node at the same moment. Sequentially `cat`-ing the env's `.so` files from another shell unstalled a live wedged worker immediately; this PR just makes rootstock do that itself.

## Design

New stdlib-only `rootstock/prewarm.py`: sequentially reads the env's `**/*.so*`, the local checkpoint file (when the spec names one), and any paths listed under a new optional `prewarm_paths` spec key, discarding the bytes to populate the cache. `spawn_in_env` stages it next to the wrapper, and both `WORKER_WRAPPER` and `DOWNLOAD_WRAPPER` (same cold-import cost in `rootstock add`) run it before their heavy imports.

Because wrappers are re-staged by the client on every spawn — only `rootstock.worker` is frozen inside built envs — **every already-deployed env benefits as soon as the client updates, with no rebuilds**. It runs inside the env's own Python, hence the stdlib-only constraint.

Best-effort throughout, each property test-pinned:
- unreadable/vanished files are skipped
- any unexpected error aborts the prewarm, never the worker
- a wrapper run without the staged helper degrades gracefully
- `ROOTSTOCK_NO_PREWARM=1` skips it entirely (node-local / known-warm installs)

The one-line summary (`[Worker] Prewarmed page cache: N files, X MB in Y.Zs`) goes to worker stderr, so it lands in post-mortems and doubles as the filesystem health probe discussed in #167: seconds = warm, minutes = cold-but-working, anything worse now has a number attached instead of a silent stall.

## Scope note

Canonical-checkpoint weights are not yet prewarmed — their on-disk location is known to the model library, not rootstock, so warming them means encoding per-library cache conventions. The `prewarm_paths` spec key is the hook if we decide to. The `.so` files dominate the cold-start cost regardless.

Pairs with #166: that PR makes a slow load *visible and bounded*; this one makes it *fast*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)