### PR TITLE
Prewarm the whole env tree with parallel readers

### DIFF
--- a/rootstock/prewarm.py
+++ b/rootstock/prewarm.py
@@ -13,6 +13,11 @@ When the cache is already warm this costs seconds of memory-speed reads.
 it inside the *target env's* Python before any heavy import — so it must
 stay stdlib-only and compatible with any Python an env might ship.
 
+Files are read concurrently (Lustre stripes across OSTs, so a few
+parallel streams multiply throughput), largest-first so a multi-GB
+library starting late can't extend the tail single-threaded.
+``ROOTSTOCK_PREWARM_THREADS`` overrides the reader count.
+
 Best-effort by design: unreadable files are skipped, any unexpected error
 aborts the prewarm and never the worker, and ``ROOTSTOCK_NO_PREWARM=1``
 skips it entirely (e.g. on node-local or known-warm installs where it is
@@ -24,16 +29,28 @@ from __future__ import annotations
 import os
 import sys
 import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 _CHUNK_SIZE = 16 * 1024 * 1024
+_DEFAULT_THREADS = 8
+
+
+def _thread_count() -> int:
+    try:
+        n = int(os.environ.get("ROOTSTOCK_PREWARM_THREADS", ""))
+    except ValueError:
+        return _DEFAULT_THREADS
+    return max(1, n)
 
 
 def iter_prewarm_files(spec: dict):
     """Yield the files worth warming for a worker spawn spec.
 
-    - every shared library under the env (``{env_dir}/**/*.so*`` — the bulk
-      of the import cost; torch dominates),
+    - every file under the env tree (the ``.so`` libraries dominate the
+      volume, but imports also open thousands of small ``.py``/``.pyc``
+      files whose cold reads are just as latency-bound — covering them adds
+      little data and removes the residual small-file tail),
     - the local checkpoint weights file, when the spec names one,
     - any extra files or directory trees a client lists in
       ``spec["prewarm_paths"]`` (reserved for future use; directories are
@@ -41,7 +58,7 @@ def iter_prewarm_files(spec: dict):
     """
     env_dir = spec.get("env_dir")
     if env_dir:
-        yield from sorted(Path(env_dir).rglob("*.so*"))
+        yield from sorted(p for p in Path(env_dir).rglob("*") if p.is_file())
 
     extras = list(spec.get("prewarm_paths") or [])
     if spec.get("checkpoint_path"):
@@ -54,25 +71,56 @@ def iter_prewarm_files(spec: dict):
             yield path
 
 
-def prewarm_files(paths) -> tuple[int, int]:
-    """Sequentially read ``paths``, discarding the bytes.
+def _read_file(path) -> int:
+    """Read one file front to back, discarding the bytes; returns its size."""
+    n = 0
+    with open(path, "rb") as f:
+        while True:
+            chunk = f.read(_CHUNK_SIZE)
+            if not chunk:
+                break
+            n += len(chunk)
+    return n
 
-    Returns ``(n_files, n_bytes)`` actually read. Files that vanish or
-    can't be opened are skipped — the goal is a warm cache, not an audit.
+
+def prewarm_files(paths, max_workers: int | None = None) -> tuple[int, int]:
+    """Read ``paths`` concurrently, discarding the bytes.
+
+    Each file is one unit of work (streamed sequentially within itself, so
+    readahead still engages), dispatched largest-first across the reader
+    pool. Duplicate paths are read once. Returns ``(n_files, n_bytes)``
+    actually read. Files that vanish or can't be opened are skipped — the
+    goal is a warm cache, not an audit.
     """
-    n_files = 0
-    n_bytes = 0
+    # Size lookup doubles as dedup + existence filter; the rglob that
+    # produced these paths just stat'ed them, so the attributes are still
+    # in the client's metadata cache and this pass is cheap.
+    sized: list[tuple[int, Path]] = []
+    seen = set()
     for path in paths:
+        path = Path(path)
+        if path in seen:
+            continue
+        seen.add(path)
         try:
-            with open(path, "rb") as f:
-                while True:
-                    chunk = f.read(_CHUNK_SIZE)
-                    if not chunk:
-                        break
-                    n_bytes += len(chunk)
+            sized.append((os.stat(path).st_size, path))
         except OSError:
             continue
-        n_files += 1
+    sized.sort(key=lambda item: item[0], reverse=True)
+
+    if max_workers is None:
+        max_workers = _thread_count()
+
+    n_files = 0
+    n_bytes = 0
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = [pool.submit(_read_file, path) for _, path in sized]
+        for future in futures:
+            try:
+                n_bytes += future.result()
+            except OSError:
+                continue
+            n_files += 1
     return n_files, n_bytes
 
 

--- a/tests/worker/test_prewarm.py
+++ b/tests/worker/test_prewarm.py
@@ -47,9 +47,11 @@ def fake_env(tmp_path: Path) -> dict:
     }
 
 
-def test_iter_finds_shared_libs_and_checkpoint(fake_env):
+def test_iter_finds_whole_env_tree_and_checkpoint(fake_env):
+    # Whole tree, not just shared libraries: small .py/.pyc reads are just
+    # as latency-bound on a cold cache (#170).
     found = {p.name for p in iter_prewarm_files(fake_env)}
-    assert found == {"libtorch_cpu.so", "libc10.so.1", "weights.pt"}
+    assert found == {"libtorch_cpu.so", "libc10.so.1", "env_source.py", "weights.pt"}
 
 
 def test_iter_walks_extra_prewarm_dirs(fake_env, tmp_path: Path):
@@ -62,16 +64,37 @@ def test_iter_walks_extra_prewarm_dirs(fake_env, tmp_path: Path):
 
 
 def test_prewarm_reads_every_byte(fake_env):
+    expected_bytes = sum(p.stat().st_size for p in iter_prewarm_files(fake_env))
     n_files, n_bytes = prewarm_files(iter_prewarm_files(fake_env))
-    assert n_files == 3
-    assert n_bytes == 1024 + 512 + 256
+    assert n_files == 4
+    assert n_bytes == expected_bytes
+
+
+def test_single_reader_matches_parallel(fake_env):
+    parallel = prewarm_files(iter_prewarm_files(fake_env))
+    serial = prewarm_files(iter_prewarm_files(fake_env), max_workers=1)
+    assert serial == parallel
+
+
+def test_thread_knob_tolerates_garbage(fake_env, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ROOTSTOCK_PREWARM_THREADS", "banana")
+    n_files, _ = prewarm_files(iter_prewarm_files(fake_env))
+    assert n_files == 4
+
+
+def test_duplicate_paths_read_once(fake_env):
+    # The checkpoint listed again via prewarm_paths must not double-count.
+    fake_env["prewarm_paths"] = [fake_env["checkpoint_path"]]
+    n_files, n_bytes = prewarm_files(iter_prewarm_files(fake_env))
+    assert n_files == 4
+    assert n_bytes == sum(p.stat().st_size for p in set(iter_prewarm_files(fake_env)))
 
 
 def test_prewarm_from_spec_reports_summary(fake_env):
     log = io.StringIO()
     prewarm_from_spec(fake_env, log=log)
     message = log.getvalue()
-    assert "Prewarmed page cache: 3 files" in message
+    assert "Prewarmed page cache: 4 files" in message
 
 
 def test_env_var_skips_prewarm(fake_env, monkeypatch: pytest.MonkeyPatch):
@@ -89,8 +112,8 @@ def test_unreadable_file_is_skipped(fake_env):
         n_files, n_bytes = prewarm_files(iter_prewarm_files(fake_env))
     finally:
         os.chmod(blocked, 0o644)  # let tmp_path cleanup work
-    assert n_files == 3  # the readable three, blocked.so skipped
-    assert n_bytes == 1024 + 512 + 256
+    assert n_files == 4  # the readable four, blocked.so skipped
+    assert n_bytes == 1024 + 512 + 256 + len("# not a shared library")
 
 
 def test_prewarm_from_spec_never_raises():
@@ -118,7 +141,9 @@ def test_wrapper_runs_prewarm_end_to_end(tmp_path: Path):
             spec.cmd, env=spec.env, cwd=spec.cwd, capture_output=True, text=True
         )
     assert result.returncode == 0, result.stderr
-    assert "Prewarmed page cache: 1 files" in result.stderr
+    # Whole tree: libfake.so + env_source.py + bin/python (the symlinked
+    # interpreter binary — warming it is a feature, not an accident).
+    assert "Prewarmed page cache: 3 files" in result.stderr
 
 
 def test_spawn_stages_prewarm_module_next_to_wrapper(tmp_path: Path):


### PR DESCRIPTION
Implements item 1 of #170 (the agreed easy win; the `rootstock prewarm` CLI from item 2 stays open pending team discussion).

## Changes

- **Whole-tree coverage.** The #168 pass read only `*.so*`. Imports also open thousands of small `.py`/`.pyc` files, each costing cold metadata + read RPCs — the residual small-file latency tail. They add little volume next to the libraries, so the prewarm now reads every file under the env dir (the symlinked `bin/python` interpreter binary included — warming it is a feature).
- **Parallel readers.** Lustre stripes across OSTs, so concurrent streams multiply cold throughput; on Delta's measured ~100 MB/s single-stream day, 4–8 readers should cut the ~70 s mace-env pass to ~15–25 s (real number to be confirmed on Delta and posted here). Files are deduped, then dispatched **largest-first** across the pool — per-file granularity means a multi-GB library submitted last would otherwise run out the tail single-threaded. Each file is still streamed sequentially within itself, so per-stream readahead engages as before. Default 8 threads, `ROOTSTOCK_PREWARM_THREADS` to override.

The module stays stdlib-only (it executes inside the target env's Python via the staged wrapper) — `concurrent.futures` threads, no processes; buffered reads release the GIL so the pool genuinely overlaps I/O. Best-effort semantics unchanged and still test-pinned: unreadable files skipped, duplicates counted once, `ROOTSTOCK_NO_PREWARM=1` skips, no error reaches the worker.

## Tests

Existing suite updated for whole-tree expectations plus new cases: duplicate paths counted once, serial (`max_workers=1`) and parallel results identical, garbage `ROOTSTOCK_PREWARM_THREADS` falls back to the default, and the end-to-end staged-wrapper run reporting the full tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)