### PR TITLE
Add '<family>:custom' CHECKPOINTS entries and weights= for user fine-tunes

### DIFF
--- a/rootstock/__init__.py
+++ b/rootstock/__init__.py
@@ -14,7 +14,7 @@ from importlib.metadata import version as _pkg_version
 
 from .calculator import RootstockCalculator
 from .clusters import CLUSTER_REGISTRY, Cluster, get_cluster, get_root_for_cluster
-from .environment import CheckpointNotFoundError, list_declared_checkpoints
+from .environment import CheckpointNotFoundError, CustomWeightsError, list_declared_checkpoints
 from .exceptions import RootstockError
 from .server import RootstockServer, WorkerDiedError
 
@@ -27,6 +27,7 @@ __all__ = [
     # Checkpoint discovery
     "list_declared_checkpoints",
     "CheckpointNotFoundError",
+    "CustomWeightsError",
     # Cluster name -> path bootstrap
     "CLUSTER_REGISTRY",
     "Cluster",

--- a/rootstock/benchmark.py
+++ b/rootstock/benchmark.py
@@ -270,12 +270,15 @@ def run_in_env_arm(root: Path, cache_root: Path | None, env_name: str, env_dir: 
 
 def run_rootstock_arm(root: Path, cache_root: Path | None, cluster: str | None,
                       checkpoint: str, device: str, setup_kwargs: dict,
-                      atoms, frames: np.ndarray, n_warmup: int) -> dict:
+                      atoms, frames: np.ndarray, n_warmup: int,
+                      weights: str | None = None) -> dict:
     """Time the same force loop through RootstockCalculator (IPC in the loop)."""
     from rootstock import RootstockCalculator
 
     kwargs: dict = {"checkpoint": checkpoint, "device": device,
                     "setup_kwargs": setup_kwargs}
+    if weights:
+        kwargs["weights"] = weights
     if cluster:
         kwargs["cluster"] = cluster
     else:
@@ -289,13 +292,17 @@ def run_rootstock_arm(root: Path, cache_root: Path | None, cluster: str | None,
 
 def benchmark_one(checkpoint: str, device: str, root: Path, cache_root: Path | None,
                   cluster: str | None, atoms, frames: np.ndarray, n_warmup: int,
-                  setup_kwargs: dict, work_dir: Path) -> dict:
+                  setup_kwargs: dict, work_dir: Path,
+                  weights: str | None = None) -> dict:
+    from rootstock.environment import bind_custom_weights
     from rootstock.local_checkpoints import resolve_checkpoint
 
     resolved = resolve_checkpoint(root, checkpoint)
+    # Same guards as the calculator — fail before either arm spawns, not as
+    # a raw subprocess traceback from the in-env worker.
+    custom_path = bind_custom_weights(root, resolved.env_name, checkpoint, weights, setup_kwargs)
+    checkpoint_path = custom_path if custom_path is not None else resolved.path
     if resolved.is_local and not Path(resolved.path).exists():
-        # Same guard as the calculator — fail before either arm spawns,
-        # not as a raw subprocess traceback from the in-env worker.
         raise RuntimeError(
             f"local checkpoint '{checkpoint}' points at {resolved.path}, "
             f"which no longer exists. Re-register it with `rootstock "
@@ -323,11 +330,12 @@ def benchmark_one(checkpoint: str, device: str, root: Path, cache_root: Path | N
     print(f"  [in-env]    {checkpoint} on {device} via {env_name} ...", flush=True)
     direct = run_in_env_arm(root, cache_root, env_name, env_dir, checkpoint,
                             device, setup_kwargs, npz_path,
-                            checkpoint_path=resolved.path)
+                            checkpoint_path=checkpoint_path)
 
     print(f"  [rootstock] {checkpoint} on {device} (IPC) ...", flush=True)
     rs = run_rootstock_arm(root, cache_root, cluster, checkpoint, device,
-                           setup_kwargs, atoms, frames, n_warmup)
+                           setup_kwargs, atoms, frames, n_warmup,
+                           weights=weights)
 
     overhead_ms = rs["median_ms"] - direct["median_ms"]
     overhead_pct = (
@@ -414,6 +422,9 @@ def main(argv=None) -> int:
     p.add_argument("--setup-kwargs", default="",
                    help='JSON forwarded to setup() for every checkpoint '
                         '(e.g. \'{"task":"omat"}\').')
+    p.add_argument("--weights",
+                   help="Path to your own weights file; requires a '<family>:custom' "
+                        "entry in --checkpoints (applies to every checkpoint given).")
     p.add_argument("--out", help="Write full results JSON here.")
     p.add_argument("--list", action="store_true", help="List installed checkpoints and exit.")
 
@@ -473,7 +484,8 @@ def main(argv=None) -> int:
                 print(f"\n>>> {checkpoint} @ {device}")
                 try:
                     r = benchmark_one(checkpoint, device, root, cache_root, args.cluster,
-                                      atoms, frames, args.warmup, setup_kwargs, work_dir)
+                                      atoms, frames, args.warmup, setup_kwargs, work_dir,
+                                      weights=args.weights)
                     print(f"    overhead: {r['overhead_ms_median']:.2f} ms/call "
                           f"({r['overhead_pct_median']:.1f}%)")
                 except Exception as e:  # noqa: BLE001 - one bad model shouldn't abort the rest

--- a/rootstock/calculator.py
+++ b/rootstock/calculator.py
@@ -16,6 +16,7 @@ from ase.stress import full_3x3_to_voigt_6_stress
 
 from .clusters import get_cluster
 from .config import resolve_default_root
+from .environment import bind_custom_weights
 from .layout import ensure_layout_compatible, resolve_cache_root
 from .local_checkpoints import LocalCheckpointError, resolve_checkpoint
 from .server import RootstockServer, WorkerDiedError
@@ -56,6 +57,19 @@ class RootstockCalculator(Calculator):
             atoms.calc = calc
             print(atoms.get_potential_energy())
 
+        # Run your own fine-tuned weights: use the ":custom" entry for the
+        # model family you fine-tuned (shown by `rootstock list`) and pass
+        # the weights file. The entry only selects the hosting env — no
+        # shipped weights are involved.
+        with RootstockCalculator(
+            checkpoint="uma:custom",
+            weights="/scratch/me/uma-ft.pt",
+            cluster="delta",
+            device="cuda",
+        ) as calc:
+            atoms.calc = calc
+            print(atoms.get_potential_energy())
+
     Note:
         Environments must be pre-built with `rootstock install` before use.
         The hosting env is resolved automatically by walking the installed envs
@@ -75,6 +89,7 @@ class RootstockCalculator(Calculator):
         device: str = "cuda",
         setup_kwargs: dict | None = None,
         timeout: float = 600.0,
+        weights: str | Path | None = None,
         **kwargs,
     ):
         """
@@ -88,7 +103,11 @@ class RootstockCalculator(Calculator):
         Args:
             checkpoint: Canonical checkpoint id (e.g., "mace-mp-0-medium",
                         "uma-s-1p1"). Required. The hosting env is resolved
-                        from the installed envs at ``root``.
+                        from the installed envs at ``root``. To run your own
+                        fine-tuned weights, use the ``:custom`` entry for
+                        the model family you fine-tuned (e.g. "uma:custom" —
+                        ``rootstock list`` shows the entries available) and
+                        pass ``weights``.
             cluster: Known cluster name (e.g., "delta", "perlmutter"). Mutually
                      exclusive with root; a name -> install-path bootstrap.
             root: Path to rootstock install directory. Mutually exclusive with
@@ -110,6 +129,12 @@ class RootstockCalculator(Calculator):
                      first real force call — which may pay for torch.compile
                      or large neighbor lists — runs under the same envelope
                      verification exercised.
+            weights: Path to your own weights file (e.g. a fine-tune of one
+                     of the family's shipped checkpoints). Required with —
+                     and only valid with — a ``:custom`` checkpoint id. The
+                     path must be visible from the compute nodes; it is
+                     loaded through the env's ``setup_from_path`` hook, and
+                     no shipped weights are involved.
             **kwargs: Additional arguments passed to ASE Calculator
         """
         # ASE's Calculator quietly absorbs unknown kwargs as parameters, so a
@@ -164,12 +189,22 @@ class RootstockCalculator(Calculator):
         # misleading resolution error.
         ensure_layout_compatible(self.root)
 
-        # Resolve the checkpoint id: env-declared canonical ids first, then
-        # the user's local-checkpoint registry. Raises CheckpointNotFoundError
-        # with a listing of both namespaces if nothing matches.
+        # Resolve the checkpoint id: env-declared ids first — canonical and
+        # ':custom' entries alike — then the user's local-checkpoint
+        # registry. Raises CheckpointNotFoundError with a listing if nothing
+        # matches.
         resolved = resolve_checkpoint(self.root, checkpoint)
         self.env_name = resolved.env_name
-        self.checkpoint_path = resolved.path
+        # Enforce the ':custom' / weights= pairing (both directions — a
+        # misspelled weights kwarg is absorbed by ASE, and with a custom id
+        # there are no shipped weights to silently fall back to). For a
+        # custom id this also validates the file exists and the built env
+        # declares the setup_from_path hook — at construction, not as an
+        # opaque WorkerDiedError minutes into a batch job.
+        custom_path = bind_custom_weights(
+            self.root, resolved.env_name, checkpoint, weights, setup_kwargs
+        )
+        self.checkpoint_path = custom_path if custom_path is not None else resolved.path
         # Registered defaults for a local checkpoint; per-call kwargs win.
         # Registration already rejected reserved keys in the defaults.
         self.setup_kwargs = {**resolved.setup_kwargs, **setup_kwargs}

--- a/rootstock/cli.py
+++ b/rootstock/cli.py
@@ -517,7 +517,11 @@ def main():
     )
     serve_parser.add_argument(
         "checkpoint",
-        help="Canonical checkpoint id (e.g., 'mace-mp-0-medium', 'uma-s-1p1')",
+        help=(
+            "Canonical checkpoint id (e.g., 'mace-mp-0-medium', 'uma-s-1p1'), "
+            "or a ':custom' entry (e.g. 'uma:custom') with --weights to run "
+            "your own fine-tune"
+        ),
     )
     serve_parser.add_argument(
         "--root",
@@ -533,6 +537,15 @@ def main():
         help=(
             "Extra kwarg passed to setup() (repeatable). Same JSON-then-string "
             "parsing as 'rootstock add'."
+        ),
+    )
+    serve_parser.add_argument(
+        "--weights",
+        metavar="PATH",
+        help=(
+            "Path to your own weights file (must be visible from the compute "
+            "nodes). Required with — and only valid with — a ':custom' "
+            "checkpoint id; loaded via the env's setup_from_path hook."
         ),
     )
     serve_parser.set_defaults(func=cmd_serve)

--- a/rootstock/commands/serve.py
+++ b/rootstock/commands/serve.py
@@ -23,7 +23,12 @@ def cmd_serve(args) -> int:
     """
     from pathlib import Path
 
-    from ..environment import CheckpointNotFoundError, get_env_python
+    from ..environment import (
+        CheckpointNotFoundError,
+        CustomWeightsError,
+        bind_custom_weights,
+        get_env_python,
+    )
     from ..local_checkpoints import resolve_checkpoint
     from ..manifest import now_iso
     from ..operations import parse_setup_kwargs
@@ -36,6 +41,7 @@ def cmd_serve(args) -> int:
     socket_path = args.socket
     checkpoint = args.checkpoint
     device = args.device
+    weights = getattr(args, "weights", None)
 
     try:
         cli_kwargs = parse_setup_kwargs(getattr(args, "kwarg", None))
@@ -51,6 +57,16 @@ def cmd_serve(args) -> int:
     env_name = resolved.env_name
     # Registered defaults for a local checkpoint; explicit --kwarg wins.
     setup_kwargs = {**resolved.setup_kwargs, **cli_kwargs}
+
+    # Enforce the ':custom' / --weights pairing (both directions) and, for a
+    # custom id, validate the file + the built env's setup_from_path hook —
+    # before the startup banner, not as an ImportError inside the worker.
+    try:
+        custom_path = bind_custom_weights(root, env_name, checkpoint, weights, cli_kwargs)
+    except CustomWeightsError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+    checkpoint_path = custom_path if custom_path is not None else resolved.path
 
     if resolved.is_local and "path" in cli_kwargs:
         # setup_from_path's first parameter — fail here, not as a TypeError
@@ -81,7 +97,9 @@ def cmd_serve(args) -> int:
 
     print("Starting rootstock worker:")
     print(f"  Env: {env_name}")
-    if resolved.is_local:
+    if resolved.is_custom:
+        print(f"  Checkpoint: {checkpoint} (weights: {checkpoint_path})")
+    elif resolved.is_local:
         print(f"  Checkpoint: {checkpoint} (local: {resolved.path})")
     else:
         print(f"  Checkpoint: {checkpoint}")
@@ -96,7 +114,7 @@ def cmd_serve(args) -> int:
         WORKER_WRAPPER,
         {
             "checkpoint": checkpoint,
-            "checkpoint_path": resolved.path,
+            "checkpoint_path": checkpoint_path,
             "device": device,
             "socket_path": socket_path,
             "setup_kwargs": setup_kwargs,

--- a/rootstock/environment.py
+++ b/rootstock/environment.py
@@ -23,6 +23,25 @@ class CheckpointNotFoundError(RootstockError, LookupError):
     """Raised when a canonical checkpoint id is not declared by any installed env."""
 
 
+class CustomWeightsError(RootstockError, ValueError):
+    """A ``:custom`` checkpoint / ``weights`` pairing is invalid. Messages are
+    user-presentable diagnoses that name the fix."""
+
+
+# A CHECKPOINTS key ending in ":custom" (value None) declares a custom
+# checkpoint for one model family: the id resolves to its hosting env like
+# any other, but there are no shipped weights — the user supplies theirs via
+# weights=, loaded through the env's setup_from_path hook. An env may declare
+# several (one per user-facing family). ":" is otherwise reserved in
+# checkpoint ids.
+CUSTOM_CHECKPOINT_SUFFIX = ":custom"
+
+
+def is_custom_checkpoint(checkpoint_id: str) -> bool:
+    """True when ``checkpoint_id`` names a ``<family>:custom`` entry."""
+    return checkpoint_id.endswith(CUSTOM_CHECKPOINT_SUFFIX)
+
+
 def get_user_cache_dir() -> Path:
     """
     Per-user directory for runtime write-back caches.
@@ -172,14 +191,9 @@ def list_environments(root: Path | str) -> list[tuple[str, Path]]:
     return result
 
 
-def parse_checkpoints_dict(env_source_path: Path) -> dict[str, str]:
-    """
-    Extract the module-level ``CHECKPOINTS: dict[str, str]`` literal from an env file.
-
-    The dict maps canonical checkpoint ids → upstream library strings. Both keys
-    and values must be string literals; anything else is an authoring error and
-    raises ValueError.
-    """
+def _parse_checkpoints(env_source_path: Path) -> tuple[dict[str, str], list[str]]:
+    """AST-extract the module-level ``CHECKPOINTS`` literal, split into
+    ``(canonical id -> upstream string, list of '<family>:custom' ids)``."""
     tree = ast.parse(env_source_path.read_text(), filename=str(env_source_path))
     for node in tree.body:
         targets = []
@@ -201,18 +215,63 @@ def parse_checkpoints_dict(env_source_path: Path) -> dict[str, str]:
         if not isinstance(value, ast.Dict):
             raise ValueError(f"{env_source_path}: CHECKPOINTS must be a dict literal.")
         result: dict[str, str] = {}
+        custom_ids: list[str] = []
         for k_node, v_node in zip(value.keys, value.values):
             if not (isinstance(k_node, ast.Constant) and isinstance(k_node.value, str)):
                 raise ValueError(f"{env_source_path}: CHECKPOINTS keys must be string literals.")
+            key = k_node.value
+            if ":" in key:
+                family = key.removesuffix(CUSTOM_CHECKPOINT_SUFFIX)
+                if not is_custom_checkpoint(key) or not family or ":" in family:
+                    raise ValueError(
+                        f"{env_source_path}: CHECKPOINTS key '{key}': ':' is "
+                        f"reserved in checkpoint ids — the only allowed form "
+                        f"is '<family>{CUSTOM_CHECKPOINT_SUFFIX}', declaring "
+                        f"that users may run their own weights for that "
+                        f"model family."
+                    )
+                if not (isinstance(v_node, ast.Constant) and v_node.value is None):
+                    raise ValueError(
+                        f"{env_source_path}: CHECKPOINTS key '{key}' must map "
+                        f"to None — a custom entry never names shipped "
+                        f"weights; the user supplies them (weights= in "
+                        f"Python, --weights on the CLI)."
+                    )
+                custom_ids.append(key)
+                continue
             if not (isinstance(v_node, ast.Constant) and isinstance(v_node.value, str)):
                 raise ValueError(f"{env_source_path}: CHECKPOINTS values must be string literals.")
-            result[k_node.value] = v_node.value
-        return result
+            result[key] = v_node.value
+        return result, custom_ids
     raise ValueError(
         f"{env_source_path}: missing module-level CHECKPOINTS dict. "
         f"Each env file must declare a `CHECKPOINTS: dict[str, str]` mapping "
         f"canonical checkpoint ids to upstream library strings."
     )
+
+
+def parse_checkpoints_dict(env_source_path: Path) -> dict[str, str]:
+    """
+    Extract the module-level ``CHECKPOINTS: dict[str, str]`` literal from an
+    env file — canonical entries only.
+
+    The dict maps canonical checkpoint ids → upstream library strings; both
+    sides must be string literals. ``<family>:custom`` entries (value
+    ``None``) are validated and stripped: they declare a capability, not a
+    downloadable checkpoint, and the consumers of this dict (``add``,
+    smoke-test, status) must never see them. Anything else is an authoring
+    error and raises ValueError.
+    """
+    return _parse_checkpoints(env_source_path)[0]
+
+
+def parse_custom_checkpoint_ids(env_source_path: Path) -> list[str]:
+    """
+    The ``<family>:custom`` ids declared by an env source, in declaration
+    order. Empty when the env doesn't declare support for user-supplied
+    weights.
+    """
+    return _parse_checkpoints(env_source_path)[1]
 
 
 def declares_setup_from_path(env_source_path: Path) -> bool:
@@ -226,10 +285,94 @@ def declares_setup_from_path(env_source_path: Path) -> bool:
     """
     tree = ast.parse(env_source_path.read_text(), filename=str(env_source_path))
     return any(
-        isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-        and node.name == "setup_from_path"
+        isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "setup_from_path"
         for node in tree.body
     )
+
+
+def _suggest_custom_entry(root: Path | str, env_name: str, checkpoint: str) -> str:
+    """Error text for ``weights`` arriving with a non-custom id: silently
+    ignoring the file would run the shipped weights — plausible results,
+    wrong model. Names the hosting env's ``:custom`` entry when it has one."""
+    msg = (
+        f"a weights file was supplied, but checkpoint '{checkpoint}' names "
+        f"shipped weights, so it would be ignored."
+    )
+    env_source = Path(root) / "envs" / env_name / "env_source.py"
+    custom_ids: list[str] = []
+    if env_source.exists():
+        try:
+            custom_ids = parse_custom_checkpoint_ids(env_source)
+        except ValueError:
+            pass
+    if len(custom_ids) == 1:
+        return f"{msg} To run your own fine-tune, use checkpoint='{custom_ids[0]}'."
+    if custom_ids:
+        return (
+            f"{msg} To run your own fine-tune, use the entry for its model "
+            f"family: {', '.join(repr(c) for c in custom_ids)}."
+        )
+    return (
+        f"{msg} Env '{env_name}' declares no '<family>{CUSTOM_CHECKPOINT_SUFFIX}' "
+        f"CHECKPOINTS entry, so it does not support user-supplied weights — "
+        f"ask the install maintainer."
+    )
+
+
+def bind_custom_weights(
+    root: Path | str,
+    env_name: str,
+    checkpoint: str,
+    weights: str | Path | None,
+    setup_kwargs: dict | None = None,
+) -> str | None:
+    """
+    Enforce the ``<family>:custom`` / ``weights`` pairing for a *resolved*
+    checkpoint and, for a custom id, return the validated weights path (as
+    ``str``) to hand to the worker as ``checkpoint_path``. Returns None for
+    a canonical id without weights — nothing to bind.
+
+    The pairing is structural typo-proofing: ASE's ``Calculator`` silently
+    absorbs unknown kwargs, so a misspelled weights kwarg leaves ``weights``
+    unset — with a ``:custom`` id there are no shipped weights to silently
+    fall back to, so the typo errors here instead of running the wrong model.
+
+    Custom-id checks, in order: weights supplied; no ``path`` in setup_kwargs
+    (it's ``setup_from_path``'s first parameter — fail here, not as a
+    TypeError inside the worker); the weights file exists; the *built* env
+    source declares the ``setup_from_path`` hook (otherwise the failure would
+    surface as an opaque ImportError inside the worker).
+    """
+    if not is_custom_checkpoint(checkpoint):
+        if weights is None:
+            return None
+        raise CustomWeightsError(_suggest_custom_entry(root, env_name, checkpoint))
+    if weights is None:
+        raise CustomWeightsError(
+            f"checkpoint '{checkpoint}' runs your own weights file — also "
+            f"supply it (weights= in Python, --weights on the CLI)."
+        )
+    if setup_kwargs and "path" in setup_kwargs:
+        raise CustomWeightsError(
+            f"setup_kwargs cannot contain 'path' for a "
+            f"'{CUSTOM_CHECKPOINT_SUFFIX}' checkpoint; the weights path is "
+            f"passed at the top level."
+        )
+    weights_path = Path(weights).expanduser()
+    if not weights_path.is_file():
+        raise CustomWeightsError(
+            f"weights file not found (or not a regular file): {weights_path}. "
+            f"The path must be visible from the compute nodes."
+        )
+    env_source = Path(root) / "envs" / env_name / "env_source.py"
+    if not (env_source.exists() and declares_setup_from_path(env_source)):
+        raise CustomWeightsError(
+            f"env '{env_name}' (hosting '{checkpoint}') does not declare "
+            f"setup_from_path(path, device, **kwargs), which is required to "
+            f"load user-supplied weights. Ask the install maintainer to "
+            f"refresh the env sources — see docs/environments.md."
+        )
+    return str(weights_path)
 
 
 def list_declared_checkpoints(root: Path | str) -> dict[str, dict[str, str]]:
@@ -255,6 +398,31 @@ def list_declared_checkpoints(root: Path | str) -> dict[str, dict[str, str]]:
             declared[env_dir.name] = parse_checkpoints_dict(source)
         except ValueError:
             continue
+    return declared
+
+
+def list_custom_checkpoints(root: Path | str) -> dict[str, list[str]]:
+    """
+    Walk ``{root}/envs/*/env_source.py`` and return
+    ``{env_name: [<family>:custom ids]}`` for every installed env that
+    declares at least one. Envs whose source is missing or malformed are
+    silently skipped, mirroring ``list_declared_checkpoints``.
+    """
+    root = Path(root)
+    envs_dir = root / "envs"
+    declared: dict[str, list[str]] = {}
+    if not envs_dir.exists():
+        return declared
+    for env_dir in sorted(envs_dir.iterdir()):
+        source = env_dir / "env_source.py"
+        if not source.exists():
+            continue
+        try:
+            custom_ids = parse_custom_checkpoint_ids(source)
+        except ValueError:
+            continue
+        if custom_ids:
+            declared[env_dir.name] = custom_ids
     return declared
 
 

--- a/rootstock/environment.py
+++ b/rootstock/environment.py
@@ -358,7 +358,11 @@ def bind_custom_weights(
             f"'{CUSTOM_CHECKPOINT_SUFFIX}' checkpoint; the weights path is "
             f"passed at the top level."
         )
-    weights_path = Path(weights).expanduser()
+    # Resolve against the caller's CWD now: the worker is spawned with
+    # cwd=env_dir, so a relative path passed through verbatim would be
+    # re-resolved there — failing, or worse, loading a same-named file
+    # inside the env dir.
+    weights_path = Path(weights).expanduser().resolve()
     if not weights_path.is_file():
         raise CustomWeightsError(
             f"weights file not found (or not a regular file): {weights_path}. "

--- a/rootstock/exceptions.py
+++ b/rootstock/exceptions.py
@@ -8,6 +8,8 @@ they historically subclassed, so existing ``except LookupError`` /
 
 - ``CheckpointNotFoundError`` (rootstock.environment) — no installed env
   declares the requested canonical checkpoint id.
+- ``CustomWeightsError`` (rootstock.environment) — a ``:custom`` checkpoint
+  id and its ``weights`` file were paired or bound invalidly.
 - ``WorkerDiedError`` (rootstock.server) — the worker process failed at the
   socket level; carries a post-mortem.
 - ``OperationError`` (rootstock.operations) — an install/add operation

--- a/rootstock/local_checkpoints.py
+++ b/rootstock/local_checkpoints.py
@@ -34,9 +34,12 @@ from pathlib import Path
 
 from .config import DEFAULT_CONFIG_DIR
 from .environment import (
+    CUSTOM_CHECKPOINT_SUFFIX,
     CheckpointNotFoundError,
     declares_setup_from_path,
     find_env_for_checkpoint,
+    is_custom_checkpoint,
+    list_custom_checkpoints,
     list_declared_checkpoints,
 )
 from .exceptions import RootstockError
@@ -93,12 +96,17 @@ class LocalCheckpointEntry:
 @dataclass(frozen=True)
 class ResolvedCheckpoint:
     """Where a checkpoint id points: hosting env, plus the weights path and
-    registered default setup kwargs when the id is a local checkpoint."""
+    registered default setup kwargs when the id is a local checkpoint.
+
+    A ``<family>:custom`` id resolves to its hosting env only — the weights
+    path is bound at the call site from the user-supplied ``weights``
+    argument, so ``path`` stays None and ``is_custom`` is the marker."""
 
     checkpoint: str
     env_name: str
-    path: str | None = None  # None => canonical id
+    path: str | None = None  # None => canonical or :custom id
     setup_kwargs: dict = field(default_factory=dict)
+    is_custom: bool = False
 
     @property
     def is_local(self) -> bool:
@@ -356,26 +364,62 @@ def record_local_verification(
     save_local_registry(roots, registry_path)
 
 
+def _resolve_custom(root: Path | str, checkpoint_id: str) -> ResolvedCheckpoint:
+    """
+    Resolve a ``<family>:custom`` checkpoint via the entries installed envs
+    declare in ``CHECKPOINTS``.
+
+    The entry carries no weights (its value is ``None``) — the user's
+    ``weights`` file is bound at the call site. Which env hosts the id is
+    determined by which env's dict declares it, exactly like a canonical id.
+    """
+    declared = list_custom_checkpoints(root)
+    for env_name, custom_ids in declared.items():
+        if checkpoint_id in custom_ids:
+            return ResolvedCheckpoint(checkpoint=checkpoint_id, env_name=env_name, is_custom=True)
+
+    if declared:
+        listing = "\n".join(f"  {env}: {', '.join(ids)}" for env, ids in declared.items())
+        msg = (
+            f"No installed env declares the custom checkpoint "
+            f"'{checkpoint_id}'.\nDeclared '{CUSTOM_CHECKPOINT_SUFFIX}' "
+            f"entries by env:\n{listing}"
+        )
+    else:
+        msg = (
+            f"No installed env declares a '<family>{CUSTOM_CHECKPOINT_SUFFIX}' "
+            f"CHECKPOINTS entry, so user-supplied weights are not available "
+            f"at {root}. Ask the install maintainer to refresh the env "
+            f"sources — see docs/environments.md."
+        )
+    raise CheckpointNotFoundError(msg)
+
+
 def resolve_checkpoint(
     root: Path | str,
     checkpoint_id: str,
     registry_path: Path | str | None = None,
 ) -> ResolvedCheckpoint:
     """
-    Resolve a checkpoint id to its hosting env, checking env-declared
-    canonical ids first, then the user's local-checkpoint registry.
+    Resolve a checkpoint id to its hosting env. Env-declared ids come first
+    — a ``<family>:custom`` id looks up the ``:custom`` entries, everything
+    else the canonical ids (the two can't collide: canonical ids may not
+    contain ``:``) — then the user's local-checkpoint registry.
 
-    Canonical ids win: registration rejects collisions in the other
-    direction, but an env installed *after* a local registration can
-    introduce one — the canonical id is authoritative and `status` surfaces
-    the shadowing.
+    Canonical ids win over the registry: registration rejects collisions in
+    the other direction, but an env installed *after* a local registration
+    can introduce one — the canonical id is authoritative and `status`
+    surfaces the shadowing.
 
     Deliberately does not check that the env is built or the weights file
     still exists — resolution is also used for metadata lookups; callers
     that spawn a worker check before spawning.
 
-    Raises CheckpointNotFoundError when neither namespace has the id.
+    Raises CheckpointNotFoundError when no namespace has the id.
     """
+    if is_custom_checkpoint(checkpoint_id):
+        return _resolve_custom(root, checkpoint_id)
+
     for env_name, ckpts in list_declared_checkpoints(root).items():
         if checkpoint_id in ckpts:
             return ResolvedCheckpoint(checkpoint=checkpoint_id, env_name=env_name)

--- a/rootstock/operations.py
+++ b/rootstock/operations.py
@@ -32,7 +32,12 @@ from pathlib import Path
 from .client import RootstockClient
 from .clusters import get_cluster_for_root
 from .config import load_config
-from .environment import find_env_for_checkpoint, parse_checkpoints_dict
+from .environment import (
+    declares_setup_from_path,
+    find_env_for_checkpoint,
+    parse_checkpoints_dict,
+    parse_custom_checkpoint_ids,
+)
 from .exceptions import RootstockError
 from .layout import resolve_cache_root
 from .manifest import (
@@ -518,6 +523,25 @@ def install_environment(
             parse_checkpoints_dict(source_path)
         except ValueError as exc:
             raise OperationError(str(exc)) from exc
+
+        # '<family>:custom' entries and the setup_from_path hook only work
+        # together: an entry without the hook would resolve (and be listed)
+        # but always fail to load.
+        custom_ids = parse_custom_checkpoint_ids(source_path)
+        declares_hook = declares_setup_from_path(source_path)
+        if custom_ids and not declares_hook:
+            raise OperationError(
+                f"{source_path} declares {', '.join(custom_ids)} in "
+                f"CHECKPOINTS but no setup_from_path() hook — add the hook "
+                f"or drop the entries."
+            )
+        if declares_hook and not custom_ids:
+            _say(
+                progress,
+                f"note: {env_name} declares setup_from_path() but no "
+                f"'<family>:custom' CHECKPOINTS entry — user-supplied "
+                f"weights stay unavailable until one is declared.",
+            )
 
         # If the source file is already the registered file (the natural flow
         # on a shared install: drop file into <root>/environments/ then run

--- a/rootstock/usage.py
+++ b/rootstock/usage.py
@@ -131,6 +131,9 @@ def record_session(
         env_name: Pre-built environment that hosted the session.
         checkpoint: Canonical checkpoint id. Replaced with ``(local)`` when
             ``is_local`` — user-chosen ids must not leak into the spool.
+            ``<family>:custom`` ids are exempt and recorded verbatim: the
+            marker already self-flags the run as user weights, and the id is
+            env-declared, not user-chosen.
         is_local: Whether the checkpoint was a user-registered weights file.
         device: Device string the worker ran on.
         client: Which entry point ran the session ("calculator", "serve").
@@ -154,6 +157,13 @@ def record_session(
 
         from . import __version__
         from .clusters import get_cluster_for_root
+        from .environment import is_custom_checkpoint
+
+        # <family>:custom is non-identifying (no user path; the id is
+        # env-declared, not user-chosen) and self-flags the run as user
+        # weights — record it verbatim so the fine-tuned *family* stays
+        # visible in the stats.
+        mask = is_local and not is_custom_checkpoint(checkpoint)
 
         record = {
             "schema_version": RECORD_SCHEMA_VERSION,
@@ -162,7 +172,7 @@ def record_session(
             "cluster": get_cluster_for_root(root),
             "root": str(root),
             "env": env_name,
-            "checkpoint": LOCAL_CHECKPOINT_LABEL if is_local else checkpoint,
+            "checkpoint": LOCAL_CHECKPOINT_LABEL if mask else checkpoint,
             "device": device,
             "client": client,
             "rootstock_version": __version__,

--- a/sample_model_configurations/amd_configs/chgnet.py
+++ b/sample_model_configurations/amd_configs/chgnet.py
@@ -22,6 +22,8 @@
 
 CHECKPOINTS = {
     "chgnet-default": "chgnet-default",
+    # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
+    "chgnet:custom": None,
 }
 
 

--- a/sample_model_configurations/amd_configs/mace.py
+++ b/sample_model_configurations/amd_configs/mace.py
@@ -33,6 +33,9 @@ CHECKPOINTS = {
     "mace-off23-small": "off:small",
     "mace-off23-medium": "off:medium",
     "mace-off23-large": "off:large",
+    # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
+    "mace-mp:custom": None,
+    "mace-off23:custom": None,
 }
 
 

--- a/sample_model_configurations/amd_configs/mattersim.py
+++ b/sample_model_configurations/amd_configs/mattersim.py
@@ -34,6 +34,8 @@
 CHECKPOINTS = {
     "mattersim-v1-0-0-5m": "MatterSim-v1.0.0-5M",
     "mattersim-v1-0-0-1m": "MatterSim-v1.0.0-1M",
+    # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
+    "mattersim:custom": None,
 }
 
 

--- a/sample_model_configurations/amd_configs/orb.py
+++ b/sample_model_configurations/amd_configs/orb.py
@@ -32,6 +32,8 @@ CHECKPOINTS = {
     "orb-v2": "orb-v2",
     "orb-d3-v2": "orb-d3-v2",
     "orb-mptraj-only-v2": "orb-mptraj-only-v2",
+    # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
+    "orb:custom": None,
 }
 
 

--- a/sample_model_configurations/amd_configs/uma.py
+++ b/sample_model_configurations/amd_configs/uma.py
@@ -29,6 +29,8 @@ CHECKPOINTS = {
     "uma-s-1p1": "uma-s-1p1",
     "uma-s-1p2": "uma-s-1p2",
     "uma-m-1p1": "uma-m-1p1",
+    # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
+    "uma:custom": None,
 }
 
 

--- a/sample_model_configurations/nvidia_configs/allscaip.py
+++ b/sample_model_configurations/nvidia_configs/allscaip.py
@@ -18,6 +18,8 @@ OMol checkpoints expect `charge` and `spin` in `atoms.info`.
 
 CHECKPOINTS = {
     "allscaip-md-conserving-all-omol": "allscaip-md-conserving-all-omol",
+    # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
+    "allscaip:custom": None,
 }
 
 

--- a/sample_model_configurations/nvidia_configs/chgnet.py
+++ b/sample_model_configurations/nvidia_configs/chgnet.py
@@ -18,6 +18,8 @@
 
 CHECKPOINTS = {
     "chgnet-default": "chgnet-default",
+    # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
+    "chgnet:custom": None,
 }
 
 

--- a/sample_model_configurations/nvidia_configs/dimenet.py
+++ b/sample_model_configurations/nvidia_configs/dimenet.py
@@ -35,6 +35,8 @@ CHECKPOINTS = {
     "dimenet-plus-plus-s2ef-oc20-20m": "DimeNet++-S2EF-OC20-20M",
     "dimenet-plus-plus-s2ef-oc20-2m": "DimeNet++-S2EF-OC20-2M",
     "dimenet-plus-plus-s2ef-oc20-200k": "DimeNet++-S2EF-OC20-200k",
+    # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
+    "dimenet:custom": None,
 }
 
 

--- a/sample_model_configurations/nvidia_configs/equiformer.py
+++ b/sample_model_configurations/nvidia_configs/equiformer.py
@@ -33,6 +33,8 @@ CHECKPOINTS = {
     "equiformer-v2-153m-s2ef-oc20-all-md": "EquiformerV2-153M-S2EF-OC20-All+MD",
     "equiformer-v2-31m-s2ef-oc20-all-md": "EquiformerV2-31M-S2EF-OC20-All+MD",
     "equiformer-v2-83m-s2ef-oc20-2m": "EquiformerV2-83M-S2EF-OC20-2M",
+    # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
+    "equiformer:custom": None,
 }
 
 

--- a/sample_model_configurations/nvidia_configs/escn.py
+++ b/sample_model_configurations/nvidia_configs/escn.py
@@ -35,6 +35,8 @@ CHECKPOINTS = {
     "escn-l6-m3-lay20-s2ef-oc20-all-md": "eSCN-L6-M3-Lay20-S2EF-OC20-All+MD",
     "escn-l6-m2-lay12-s2ef-oc20-2m": "eSCN-L6-M2-Lay12-S2EF-OC20-2M",
     "escn-l4-m2-lay12-s2ef-oc20-2m": "eSCN-L4-M2-Lay12-S2EF-OC20-2M",
+    # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
+    "escn:custom": None,
 }
 
 

--- a/sample_model_configurations/nvidia_configs/esen.py
+++ b/sample_model_configurations/nvidia_configs/esen.py
@@ -19,6 +19,8 @@ CHECKPOINTS = {
     "esen-md-direct-all-omol": "esen-md-direct-all-omol",
     "esen-sm-conserving-all-omol": "esen-sm-conserving-all-omol",
     "esen-sm-direct-all-omol": "esen-sm-direct-all-omol",
+    # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
+    "esen:custom": None,
 }
 
 

--- a/sample_model_configurations/nvidia_configs/gemnet.py
+++ b/sample_model_configurations/nvidia_configs/gemnet.py
@@ -32,6 +32,8 @@ CHECKPOINTS = {
     "gemnet-oc-s2ef-oc20-all-md": "GemNet-OC-S2EF-OC20-All+MD",
     "gemnet-oc-s2ef-oc20-all": "GemNet-OC-S2EF-OC20-All",
     "gemnet-dt-s2ef-oc20-all": "GemNet-dT-S2EF-OC20-All",
+    # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
+    "gemnet:custom": None,
 }
 
 

--- a/sample_model_configurations/nvidia_configs/mace.py
+++ b/sample_model_configurations/nvidia_configs/mace.py
@@ -20,6 +20,9 @@ CHECKPOINTS = {
     "mace-off23-small": "off:small",
     "mace-off23-medium": "off:medium",
     "mace-off23-large": "off:large",
+    # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
+    "mace-mp:custom": None,
+    "mace-off23:custom": None,
 }
 
 

--- a/sample_model_configurations/nvidia_configs/mattersim.py
+++ b/sample_model_configurations/nvidia_configs/mattersim.py
@@ -39,6 +39,8 @@ Models:
 CHECKPOINTS = {
     "mattersim-v1-0-0-5m": "MatterSim-v1.0.0-5M",
     "mattersim-v1-0-0-1m": "MatterSim-v1.0.0-1M",
+    # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
+    "mattersim:custom": None,
 }
 
 

--- a/sample_model_configurations/nvidia_configs/orb.py
+++ b/sample_model_configurations/nvidia_configs/orb.py
@@ -29,6 +29,8 @@ CHECKPOINTS = {
     "orb-v2": "orb-v2",
     "orb-d3-v2": "orb-d3-v2",
     "orb-mptraj-only-v2": "orb-mptraj-only-v2",
+    # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
+    "orb:custom": None,
 }
 
 

--- a/sample_model_configurations/nvidia_configs/painn.py
+++ b/sample_model_configurations/nvidia_configs/painn.py
@@ -29,6 +29,8 @@ Models:
 
 CHECKPOINTS = {
     "painn-s2ef-oc20-all": "PaiNN-S2EF-OC20-All",
+    # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
+    "painn:custom": None,
 }
 
 

--- a/sample_model_configurations/nvidia_configs/schnet.py
+++ b/sample_model_configurations/nvidia_configs/schnet.py
@@ -32,6 +32,8 @@ CHECKPOINTS = {
     "schnet-s2ef-oc20-20m": "SchNet-S2EF-OC20-20M",
     "schnet-s2ef-oc20-2m": "SchNet-S2EF-OC20-2M",
     "schnet-s2ef-oc20-200k": "SchNet-S2EF-OC20-200k",
+    # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
+    "schnet:custom": None,
 }
 
 

--- a/sample_model_configurations/nvidia_configs/scn.py
+++ b/sample_model_configurations/nvidia_configs/scn.py
@@ -33,6 +33,8 @@ CHECKPOINTS = {
     "scn-s2ef-oc20-all-md": "SCN-S2EF-OC20-All+MD",
     "scn-t4-b2-s2ef-oc20-2m": "SCN-t4-b2-S2EF-OC20-2M",
     "scn-s2ef-oc20-2m": "SCN-S2EF-OC20-2M",
+    # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
+    "scn:custom": None,
 }
 
 

--- a/sample_model_configurations/nvidia_configs/sevennet.py
+++ b/sample_model_configurations/nvidia_configs/sevennet.py
@@ -36,6 +36,8 @@ CHECKPOINTS = {
     "sevennet-omat": "7net-omat",
     "sevennet-mf-ompa": "7net-mf-ompa",
     "sevennet-omni": "7net-omni",
+    # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
+    "sevennet:custom": None,
 }
 
 

--- a/sample_model_configurations/nvidia_configs/uma.py
+++ b/sample_model_configurations/nvidia_configs/uma.py
@@ -17,6 +17,8 @@ CHECKPOINTS = {
     "uma-s-1p1": "uma-s-1p1",
     "uma-s-1p2": "uma-s-1p2",
     "uma-m-1p1": "uma-m-1p1",
+    # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
+    "uma:custom": None,
 }
 
 

--- a/tests/calculator/test_calculator_custom.py
+++ b/tests/calculator/test_calculator_custom.py
@@ -1,0 +1,168 @@
+"""Tests for RootstockCalculator's ':custom' checkpoint / weights= pairing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rootstock.calculator import RootstockCalculator
+from rootstock.environment import CheckpointNotFoundError, CustomWeightsError
+
+_UMA_ENV_SOURCE = '''\
+"""UMA env."""
+
+CHECKPOINTS = {
+    "uma-s-1p1": "uma-s-1p1",
+    "uma:custom": None,
+}
+
+
+def setup(checkpoint, device="cuda", task="omat"):
+    return None
+
+
+def setup_from_path(path, device="cuda", task="omat"):
+    return None
+'''
+
+# Authoring bug an install lint should have caught: the entry is declared but
+# the hook is missing. Construction must still fail with a maintainer hint.
+_ENTRY_NO_HOOK_ENV_SOURCE = """\
+CHECKPOINTS = {
+    "orb-v2": "orb-v2",
+    "orb:custom": None,
+}
+
+
+def setup(checkpoint, device="cuda"):
+    return None
+"""
+
+_NO_CUSTOM_ENV_SOURCE = """\
+CHECKPOINTS = {"orb-v2": "orb-v2"}
+
+
+def setup(checkpoint, device="cuda"):
+    return None
+"""
+
+
+def _make_root(tmp_path: Path, env_name: str, source: str) -> Path:
+    env_dir = tmp_path / "root" / "envs" / env_name
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+    (env_dir / "env_source.py").write_text(source)
+    return tmp_path / "root"
+
+
+@pytest.fixture
+def fake_root(tmp_path: Path) -> Path:
+    return _make_root(tmp_path, "uma", _UMA_ENV_SOURCE)
+
+
+@pytest.fixture
+def weights(tmp_path: Path) -> Path:
+    path = tmp_path / "ft.pt"
+    path.write_bytes(b"weights")
+    return path
+
+
+class _RecordingServer:
+    ctor_kwargs: dict = {}
+
+    def __init__(self, **kwargs):
+        _RecordingServer.ctor_kwargs = kwargs
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+
+@pytest.fixture
+def recording_server(monkeypatch):
+    _RecordingServer.ctor_kwargs = {}
+    monkeypatch.setattr("rootstock.calculator.RootstockServer", _RecordingServer)
+    return _RecordingServer
+
+
+def test_custom_id_binds_weights_as_checkpoint_path(fake_root, weights, recording_server):
+    calc = RootstockCalculator(
+        checkpoint="uma:custom", root=fake_root, weights=weights, device="cpu"
+    )
+    assert calc.env_name == "uma"
+    assert calc.checkpoint_path == str(weights)
+    calc._ensure_server()
+    kwargs = recording_server.ctor_kwargs
+    assert kwargs["checkpoint_path"] == str(weights)
+    assert kwargs["checkpoint"] == "uma:custom"
+
+
+def test_custom_without_weights_raises(fake_root):
+    with pytest.raises(CustomWeightsError, match="weights"):
+        RootstockCalculator(checkpoint="uma:custom", root=fake_root)
+
+
+def test_weights_without_custom_names_the_entry(fake_root, weights):
+    # The canonical id resolves to an env, and the env declares its ':custom'
+    # entries — so the error can name the exact id to use.
+    with pytest.raises(CustomWeightsError, match="uma:custom"):
+        RootstockCalculator(checkpoint="uma-s-1p1", root=fake_root, weights=weights)
+
+
+def test_weights_without_custom_no_entry_points_at_maintainer(tmp_path, weights):
+    root = _make_root(tmp_path, "orb", _NO_CUSTOM_ENV_SOURCE)
+    with pytest.raises(CustomWeightsError, match="maintainer"):
+        RootstockCalculator(checkpoint="orb-v2", root=root, weights=weights)
+
+
+def test_misspelled_weight_kwarg_raises_not_silently_absorbed(fake_root, weights):
+    """The ASE-absorption regression: Calculator.__init__ quietly accepts
+    unknown kwargs, so a misspelled weight= must still fail via the ':custom'
+    pairing guard — with a custom id there are no shipped weights to
+    silently run instead."""
+    with pytest.raises(CustomWeightsError):
+        RootstockCalculator(checkpoint="uma:custom", root=fake_root, weight=str(weights))
+
+
+def test_missing_weights_file_raises_at_construction(fake_root, weights, recording_server):
+    weights.unlink()
+    with pytest.raises(CustomWeightsError, match="not found"):
+        RootstockCalculator(checkpoint="uma:custom", root=fake_root, weights=weights)
+    assert recording_server.ctor_kwargs == {}
+
+
+def test_hookless_env_raises_at_construction(tmp_path, weights, recording_server):
+    """A built env whose entry lacks the setup_from_path hook must fail here
+    with a maintainer hint, not as an ImportError inside the worker ->
+    opaque WorkerDiedError."""
+    root = _make_root(tmp_path, "orb", _ENTRY_NO_HOOK_ENV_SOURCE)
+    with pytest.raises(CustomWeightsError, match="maintainer"):
+        RootstockCalculator(checkpoint="orb:custom", root=root, weights=weights)
+    assert recording_server.ctor_kwargs == {}
+
+
+def test_path_setup_kwarg_rejected_for_custom(fake_root, weights):
+    # "path" is setup_from_path's first parameter; fail at construction, not
+    # as a TypeError inside the worker.
+    with pytest.raises(CustomWeightsError, match="path"):
+        RootstockCalculator(
+            checkpoint="uma:custom",
+            root=fake_root,
+            weights=weights,
+            setup_kwargs={"path": "/x"},
+        )
+
+
+def test_undeclared_custom_id_raises_not_found(fake_root, weights):
+    with pytest.raises(CheckpointNotFoundError, match="umma:custom"):
+        RootstockCalculator(checkpoint="umma:custom", root=fake_root, weights=weights)
+
+
+def test_canonical_id_unaffected(fake_root, recording_server):
+    calc = RootstockCalculator(checkpoint="uma-s-1p1", root=fake_root, device="cpu")
+    assert calc.checkpoint_path is None
+    calc._ensure_server()
+    assert recording_server.ctor_kwargs["checkpoint_path"] is None

--- a/tests/calculator/test_calculator_custom.py
+++ b/tests/calculator/test_calculator_custom.py
@@ -100,6 +100,19 @@ def test_custom_id_binds_weights_as_checkpoint_path(fake_root, weights, recordin
     assert kwargs["checkpoint"] == "uma:custom"
 
 
+def test_relative_weights_path_resolved_at_construction(
+    fake_root, weights, recording_server, monkeypatch
+):
+    """The worker runs with cwd=env_dir, so a relative path passed through
+    verbatim would be re-resolved there — it must leave construction
+    absolute."""
+    monkeypatch.chdir(weights.parent)
+    calc = RootstockCalculator(
+        checkpoint="uma:custom", root=fake_root, weights=weights.name, device="cpu"
+    )
+    assert calc.checkpoint_path == str(weights.resolve())
+
+
 def test_custom_without_weights_raises(fake_root):
     with pytest.raises(CustomWeightsError, match="weights"):
         RootstockCalculator(checkpoint="uma:custom", root=fake_root)

--- a/tests/cli/test_benchmark_custom.py
+++ b/tests/cli/test_benchmark_custom.py
@@ -1,0 +1,89 @@
+"""Tests for benchmark guards on ':custom' checkpoints (--weights)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rootstock.benchmark import benchmark_one, main
+from rootstock.environment import CustomWeightsError
+
+_ENV_SOURCE = """\
+CHECKPOINTS = {
+    "uma-s-1p1": "uma-s-1p1",
+    "uma:custom": None,
+}
+
+
+def setup(checkpoint, device="cuda"):
+    return None
+
+
+def setup_from_path(path, device="cuda", **kwargs):
+    return None
+"""
+
+
+@pytest.fixture
+def fake_root(tmp_path: Path) -> Path:
+    env_dir = tmp_path / "root" / "envs" / "uma"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+    (env_dir / "env_source.py").write_text(_ENV_SOURCE)
+    return tmp_path / "root"
+
+
+def _run_one(fake_root, tmp_path, checkpoint, weights):
+    return benchmark_one(
+        checkpoint=checkpoint,
+        device="cpu",
+        root=fake_root,
+        cache_root=None,
+        cluster=None,
+        atoms=None,
+        frames=None,
+        n_warmup=0,
+        setup_kwargs={},
+        work_dir=tmp_path,
+        weights=weights,
+    )
+
+
+def test_benchmark_one_custom_without_weights(fake_root, tmp_path):
+    with pytest.raises(CustomWeightsError, match="weights"):
+        _run_one(fake_root, tmp_path, "uma:custom", None)
+
+
+def test_benchmark_one_weights_without_custom(fake_root, tmp_path):
+    weights = tmp_path / "ft.pt"
+    weights.write_bytes(b"weights")
+    with pytest.raises(CustomWeightsError, match="uma:custom"):
+        _run_one(fake_root, tmp_path, "uma-s-1p1", str(weights))
+
+
+def test_benchmark_one_custom_missing_weights_file(fake_root, tmp_path):
+    # Fails before either arm spawns, not as a raw subprocess traceback.
+    with pytest.raises(CustomWeightsError, match="not found"):
+        _run_one(fake_root, tmp_path, "uma:custom", str(tmp_path / "gone.pt"))
+
+
+def test_parser_accepts_weights_flag(fake_root, capsys):
+    # --weights parses on the public parser; a guard failure per checkpoint
+    # is recorded as an error row instead of aborting the run.
+    rc = main(
+        [
+            "--root",
+            str(fake_root),
+            "--checkpoints",
+            "uma:custom",
+            "--weights",
+            str(fake_root / "gone.pt"),
+            "--calls",
+            "1",
+            "--warmup",
+            "0",
+        ]
+    )
+    assert rc == 0
+    assert "ERROR" in capsys.readouterr().out

--- a/tests/cli/test_serve_custom.py
+++ b/tests/cli/test_serve_custom.py
@@ -1,0 +1,119 @@
+"""Tests for ``rootstock serve`` guards on ':custom' checkpoints (--weights)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rootstock import cli
+from rootstock.commands.serve import cmd_serve
+
+_ENV_SOURCE = """\
+CHECKPOINTS = {
+    "uma-s-1p1": "uma-s-1p1",
+    "uma:custom": None,
+}
+
+
+def setup(checkpoint, device="cuda"):
+    return None
+
+
+def setup_from_path(path, device="cuda", **kwargs):
+    return None
+"""
+
+_ENTRY_NO_HOOK_ENV_SOURCE = """\
+CHECKPOINTS = {
+    "orb-v2": "orb-v2",
+    "orb:custom": None,
+}
+
+
+def setup(checkpoint, device="cuda"):
+    return None
+"""
+
+
+@pytest.fixture
+def fake_root(tmp_path: Path) -> Path:
+    env_dir = tmp_path / "root" / "envs" / "uma"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+    (env_dir / "env_source.py").write_text(_ENV_SOURCE)
+    return tmp_path / "root"
+
+
+@pytest.fixture
+def weights(tmp_path: Path) -> Path:
+    path = tmp_path / "ft.pt"
+    path.write_bytes(b"weights")
+    return path
+
+
+def _make_args(root: Path, checkpoint: str, **overrides):
+    class _Args:
+        pass
+
+    args = _Args()
+    args.root = str(root)
+    args.checkpoint = checkpoint
+    args.socket = str(root / "sock")
+    args.device = overrides.get("device", "cpu")
+    args.kwarg = overrides.get("kwarg")
+    args.weights = overrides.get("weights")
+    return args
+
+
+def test_parser_accepts_weights_flag(monkeypatch):
+    seen = {}
+
+    def fake_serve(args):
+        seen["args"] = args
+        return 0
+
+    monkeypatch.setattr(cli, "cmd_serve", fake_serve)
+    monkeypatch.setattr(
+        "sys.argv",
+        ["rootstock", "serve", "uma:custom", "--socket", "/tmp/s", "--weights", "/x/ft.pt"],
+    )
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main()
+    assert excinfo.value.code == 0
+    assert seen["args"].weights == "/x/ft.pt"
+
+
+def test_serve_custom_without_weights(fake_root, capsys):
+    rc = cmd_serve(_make_args(fake_root, "uma:custom"))
+    assert rc == 2
+    assert "--weights" in capsys.readouterr().err
+
+
+def test_serve_weights_without_custom_names_the_entry(fake_root, weights, capsys):
+    rc = cmd_serve(_make_args(fake_root, "uma-s-1p1", weights=str(weights)))
+    assert rc == 2
+    assert "uma:custom" in capsys.readouterr().err
+
+
+def test_serve_custom_missing_weights_file(fake_root, weights, capsys):
+    weights.unlink()
+    rc = cmd_serve(_make_args(fake_root, "uma:custom", weights=str(weights)))
+    assert rc == 2
+    assert "not found" in capsys.readouterr().err
+
+
+def test_serve_custom_hookless_env(tmp_path, weights, capsys):
+    env_dir = tmp_path / "root" / "envs" / "orb"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+    (env_dir / "env_source.py").write_text(_ENTRY_NO_HOOK_ENV_SOURCE)
+    rc = cmd_serve(_make_args(tmp_path / "root", "orb:custom", weights=str(weights)))
+    assert rc == 2
+    assert "maintainer" in capsys.readouterr().err
+
+
+def test_serve_custom_rejects_path_kwarg(fake_root, weights, capsys):
+    rc = cmd_serve(_make_args(fake_root, "uma:custom", weights=str(weights), kwarg=["path=/x"]))
+    assert rc == 2
+    assert "path" in capsys.readouterr().err

--- a/tests/local/test_resolve_custom.py
+++ b/tests/local/test_resolve_custom.py
@@ -1,0 +1,179 @@
+"""Tests for '<family>:custom' CHECKPOINTS entries: resolution, the parse-time
+split that keeps them out of the canonical dict, and the colon lint."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rootstock.environment import (
+    CheckpointNotFoundError,
+    parse_checkpoints_dict,
+    parse_custom_checkpoint_ids,
+)
+from rootstock.local_checkpoints import register_local_checkpoint, resolve_checkpoint
+
+_ENV_SOURCE = """\
+CHECKPOINTS = {
+    "uma-s-1p1": "uma-s-1p1",
+    "uma:custom": None,
+}
+
+
+def setup(checkpoint, device="cuda"):
+    return None
+
+
+def setup_from_path(path, device="cuda", **kwargs):
+    return None
+"""
+
+_MULTI_FAMILY_ENV_SOURCE = """\
+CHECKPOINTS = {
+    "esen-sm-direct-all-omol": "esen-sm-direct-all-omol",
+    "allscaip-md-conserving-all-omol": "allscaip-md-conserving-all-omol",
+    "esen:custom": None,
+    "allscaip:custom": None,
+}
+
+
+def setup(checkpoint, device="cuda"):
+    return None
+
+
+def setup_from_path(path, device="cuda", **kwargs):
+    return None
+"""
+
+_NO_CUSTOM_ENV_SOURCE = """\
+CHECKPOINTS = {"orb-v2": "orb-v2"}
+
+
+def setup(checkpoint, device="cuda"):
+    return None
+"""
+
+
+def _make_env(root: Path, name: str, source: str) -> None:
+    env_dir = root / "envs" / name
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+    (env_dir / "env_source.py").write_text(source)
+
+
+@pytest.fixture
+def fake_root(tmp_path: Path) -> Path:
+    root = tmp_path / "root"
+    _make_env(root, "uma", _ENV_SOURCE)
+    return root
+
+
+@pytest.fixture
+def registry(tmp_path: Path) -> Path:
+    return tmp_path / "registry.json"
+
+
+# ---------- resolution ---------------------------------------------------------
+
+
+def test_custom_entry_resolves_to_declaring_env(fake_root, registry):
+    resolved = resolve_checkpoint(fake_root, "uma:custom", registry_path=registry)
+    assert resolved.env_name == "uma"
+    assert resolved.is_custom
+    # The weights path is bound at the call site, never during resolution.
+    assert resolved.path is None
+    assert not resolved.is_local
+    assert resolved.setup_kwargs == {}
+    assert resolved.checkpoint == "uma:custom"
+
+
+def test_multiple_families_resolve_to_the_same_env(tmp_path, registry):
+    # The key's family prefix is naming, not mechanism: which env hosts the
+    # id is determined by which env's dict declares it, so a multi-family
+    # env declares one entry per user-facing family.
+    root = tmp_path / "root"
+    _make_env(root, "fairchem_v2", _MULTI_FAMILY_ENV_SOURCE)
+    for checkpoint in ("esen:custom", "allscaip:custom"):
+        resolved = resolve_checkpoint(root, checkpoint, registry_path=registry)
+        assert resolved.env_name == "fairchem_v2"
+        assert resolved.is_custom
+
+
+def test_unknown_custom_id_lists_declared_entries(fake_root, registry):
+    with pytest.raises(CheckpointNotFoundError) as exc:
+        resolve_checkpoint(fake_root, "umma:custom", registry_path=registry)
+    msg = str(exc.value)
+    assert "umma:custom" in msg
+    assert "uma:custom" in msg  # the declared entries are the menu
+
+
+def test_no_custom_entries_anywhere_points_at_maintainer(tmp_path, registry):
+    root = tmp_path / "root"
+    _make_env(root, "orb", _NO_CUSTOM_ENV_SOURCE)
+    with pytest.raises(CheckpointNotFoundError, match="maintainer"):
+        resolve_checkpoint(root, "orb:custom", registry_path=registry)
+
+
+def test_custom_namespace_wins_over_registry(fake_root, tmp_path, registry):
+    # A registry id that happens to end in ":custom" can never shadow a
+    # declared entry — the suffix routes to the env-declared namespace
+    # before the registry overlay.
+    weights = tmp_path / "ft.pt"
+    weights.write_bytes(b"weights")
+    register_local_checkpoint(fake_root, "uma:custom", "uma", weights, registry_path=registry)
+    resolved = resolve_checkpoint(fake_root, "uma:custom", registry_path=registry)
+    assert resolved.is_custom
+    assert resolved.path is None
+
+
+# ---------- the parse-time split ----------------------------------------------
+
+
+def test_parse_strips_custom_entries_from_canonical_dict(tmp_path):
+    # add/smoke-test/status iterate the canonical dict; the sentinel must
+    # never leak into it.
+    source = tmp_path / "env.py"
+    source.write_text(_ENV_SOURCE)
+    assert parse_checkpoints_dict(source) == {"uma-s-1p1": "uma-s-1p1"}
+    assert parse_custom_checkpoint_ids(source) == ["uma:custom"]
+
+
+def test_parse_custom_ids_empty_without_entries(tmp_path):
+    source = tmp_path / "env.py"
+    source.write_text(_NO_CUSTOM_ENV_SOURCE)
+    assert parse_custom_checkpoint_ids(source) == []
+
+
+# ---------- colon lint ---------------------------------------------------------
+
+
+def _write_env(tmp_path: Path, checkpoints_literal: str) -> Path:
+    source = tmp_path / "env.py"
+    source.write_text(
+        f"CHECKPOINTS = {checkpoints_literal}\n\ndef setup(c, device='cuda'):\n    return None\n"
+    )
+    return source
+
+
+@pytest.mark.parametrize(
+    "key",
+    ["bad:id", ":custom", "a:b:custom", "custom:uma-s-1p1"],
+    ids=["arbitrary-colon", "empty-family", "nested-colon", "old-prefix-form"],
+)
+def test_colon_keys_other_than_family_custom_rejected(tmp_path, key):
+    source = _write_env(tmp_path, f'{{"{key}": "x"}}')
+    with pytest.raises(ValueError, match="reserved"):
+        parse_checkpoints_dict(source)
+
+
+def test_custom_entry_value_must_be_none(tmp_path):
+    source = _write_env(tmp_path, '{"uma:custom": "uma-s-1p1"}')
+    with pytest.raises(ValueError, match="None"):
+        parse_checkpoints_dict(source)
+
+
+def test_canonical_value_may_not_be_none(tmp_path):
+    source = _write_env(tmp_path, '{"uma-s-1p1": None}')
+    with pytest.raises(ValueError, match="string literals"):
+        parse_checkpoints_dict(source)

--- a/tests/sample_configs/test_setup_from_path_hooks.py
+++ b/tests/sample_configs/test_setup_from_path_hooks.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import pytest
 
-from rootstock.environment import declares_setup_from_path
+from rootstock.environment import declares_setup_from_path, parse_custom_checkpoint_ids
 
 _SAMPLES = Path(__file__).parent.parent.parent / "sample_model_configurations"
 _NVIDIA = _SAMPLES / "nvidia_configs"
@@ -31,12 +31,7 @@ _DUAL_VENDOR_ENVS = sorted(p.stem for p in _AMD.glob("*.py") if (_NVIDIA / p.nam
 # Every config that declares the hook, in either vendor dir — all of them
 # must honor the signature contract, dual-vendor or not.
 _HOOK_DECLARING_CONFIGS = sorted(
-    (
-        p
-        for vendor in (_NVIDIA, _AMD)
-        for p in vendor.glob("*.py")
-        if declares_setup_from_path(p)
-    ),
+    (p for vendor in (_NVIDIA, _AMD) for p in vendor.glob("*.py") if declares_setup_from_path(p)),
     key=lambda p: (p.parent.name, p.name),
 )
 
@@ -88,6 +83,44 @@ def test_hook_signature_matches_across_vendors(env):
     assert ast.dump(nvidia) == ast.dump(amd), (
         f"setup_from_path signature drifted between nvidia_configs/{env}.py "
         f"and amd_configs/{env}.py"
+    )
+
+
+# ---------- ':custom' entries <-> hook -----------------------------------------
+
+_ALL_CONFIGS = sorted(
+    (p for vendor in (_NVIDIA, _AMD) for p in vendor.glob("*.py")),
+    key=lambda p: (p.parent.name, p.name),
+)
+
+
+@pytest.mark.parametrize(
+    "config", _ALL_CONFIGS, ids=[f"{p.parent.name}/{p.stem}" for p in _ALL_CONFIGS]
+)
+def test_custom_entries_iff_hook(config):
+    """'<family>:custom' CHECKPOINTS entries and the setup_from_path hook
+    only work together: an entry without the hook would resolve (and be
+    listed) but always fail to load, and a hook without an entry is
+    invisible to users."""
+    custom_ids = parse_custom_checkpoint_ids(config)
+    if declares_setup_from_path(config):
+        assert custom_ids, (
+            f"{config.parent.name}/{config.name} declares setup_from_path "
+            f"but no '<family>:custom' CHECKPOINTS entry"
+        )
+    else:
+        assert not custom_ids, (
+            f"{config.parent.name}/{config.name} declares {custom_ids} "
+            f"without a setup_from_path hook"
+        )
+
+
+@pytest.mark.parametrize("env", _DUAL_VENDOR_ENVS)
+def test_custom_entries_match_across_vendors(env):
+    nvidia = parse_custom_checkpoint_ids(_NVIDIA / f"{env}.py")
+    amd = parse_custom_checkpoint_ids(_AMD / f"{env}.py")
+    assert nvidia == amd, (
+        f"':custom' entries drifted between nvidia_configs/{env}.py and amd_configs/{env}.py"
     )
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -5,14 +5,15 @@ from __future__ import annotations
 import pytest
 
 from rootstock import RootstockError
-from rootstock.environment import CheckpointNotFoundError
+from rootstock.environment import CheckpointNotFoundError, CustomWeightsError
 from rootstock.manifest import ManifestError
 from rootstock.operations import OperationError
 from rootstock.server import WorkerDiedError
 
 
 @pytest.mark.parametrize(
-    "exc", [CheckpointNotFoundError, WorkerDiedError, OperationError, ManifestError]
+    "exc",
+    [CheckpointNotFoundError, CustomWeightsError, WorkerDiedError, OperationError, ManifestError],
 )
 def test_domain_errors_share_the_base(exc):
     assert issubclass(exc, RootstockError)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -18,6 +18,7 @@ BLESSED = {
     "RootstockError",
     "list_declared_checkpoints",
     "CheckpointNotFoundError",
+    "CustomWeightsError",
     "CLUSTER_REGISTRY",
     "Cluster",
     "get_cluster",

--- a/tests/usage/test_usage_record.py
+++ b/tests/usage/test_usage_record.py
@@ -97,6 +97,16 @@ def test_local_checkpoint_id_is_masked(tmp_path):
     assert json.loads(path.read_text())["checkpoint"] == LOCAL_CHECKPOINT_LABEL
 
 
+def test_custom_checkpoint_id_recorded_verbatim(tmp_path):
+    """<family>:custom is exempt from the mask — the marker already
+    self-flags the run as user weights and the id is env-declared, not
+    user-chosen. Exempt even when the entry point reports is_local (the
+    server flags any session with a checkpoint_path)."""
+    usage_dir(tmp_path).mkdir()
+    path = _write(tmp_path, checkpoint="uma:custom", is_local=True)
+    assert json.loads(path.read_text())["checkpoint"] == "uma:custom"
+
+
 def test_env_var_opt_out(tmp_path, monkeypatch):
     usage_dir(tmp_path).mkdir()
     monkeypatch.setenv(DISABLE_ENV_VAR, "1")

--- a/tests/worker/test_wrapper_local_e2e.py
+++ b/tests/worker/test_wrapper_local_e2e.py
@@ -85,6 +85,16 @@ def test_local_mode_uses_setup_from_path(staged):
     assert record["kwargs"] == {"task": "omol"}
 
 
+def test_custom_mode_uses_setup_from_path(staged):
+    # A '<family>:custom' id travels the same plumbing as a registry local:
+    # the calculator binds weights= to checkpoint_path, and the wrapper
+    # never inspects the id itself.
+    record = staged(_spec(checkpoint="canon:custom", checkpoint_path="/scratch/me/ft.pt"))
+    assert record["fn"] == "setup_from_path"
+    assert record["target"] == "/scratch/me/ft.pt"
+    assert record["kwargs"] == {"task": "omol"}
+
+
 def test_null_checkpoint_path_is_canonical(staged):
     # The server always includes the key; null must mean canonical.
     record = staged(_spec(checkpoint_path=None))


### PR DESCRIPTION
## What

Users run their own fine-tuned weights by picking the `:custom` entry for the model family they fine-tuned (shown by `rootstock list`) and passing the weights file:

```python
RootstockCalculator(
    cluster="frontier",
    checkpoint="uma:custom",         # env-declared entry; no shipped weights involved
    weights="/scratch/me/uma-ft.pt", # required with a :custom id
)
```

A custom checkpoint is a real `CHECKPOINTS` entry with value `None`:

```python
CHECKPOINTS = {
    "uma-s-1p1": "uma-s-1p1",
    "uma-s-1p2": "uma-s-1p2",
    "uma-m-1p1": "uma-m-1p1",
    "uma:custom": None,
}
```

`checkpoint=` always does two things — select an env and select a set of weights — and the `None` value makes it visible that the second half is user-supplied here. The id resolves to its hosting env exactly like a canonical id (whichever env declares it wins), so there's no prefix grammar to learn and discoverability is structural: the entry shows up in listings, only on installs whose built envs actually support it.

**Per-family entries, not per-env:** an env hosting several model families declares one entry each (`mace-mp:custom` and `mace-off23:custom` in the mace env). The key's family prefix is naming, not mechanism — resolution maps key→env by which dict declares it — but per-family entries keep the user's vocabulary at the family level and keep usage-stats buckets per family.

## Design notes

- `parse_checkpoints_dict` validates `:custom` entries and **strips them** into a separate capability signal (`parse_custom_checkpoint_ids`), so every canonical-dict consumer (`add`, smoke-test, status) never sees the sentinel.
- `:` is otherwise **reserved** in CHECKPOINTS keys; the value of a `:custom` key must be `None`; the install lint rejects entries without a `setup_from_path` hook and notes a hook without entries.
- The pairing is enforced both directions after resolution (new exported `CustomWeightsError`): a `:custom` id without `weights=` errors, and `weights=` with a canonical id errors **naming the exact entry** ("use checkpoint='uma:custom'"). This is structural typo-proofing: ASE's `Calculator` silently absorbs unknown kwargs, so a misspelled weights kwarg leaves `weights` unset — with a custom id there are no shipped weights to silently fall back to.
- Construction also checks the weights file exists and the *built* env source declares `setup_from_path` — a hook-less env fails with a maintainer hint, not an opaque `WorkerDiedError`.
- The path rides the existing `checkpoint_path` plumbing into `WORKER_WRAPPER`'s `setup_from_path` branch; the env-hook layer from #158 is untouched.
- `rootstock serve` / `rootstock benchmark` mirror with `--weights`. Usage records carry `<family>:custom` verbatim (self-flags user weights, non-identifying, keeps the family visible).
- All hook-declaring sample configs gain their entries, with entry⟺hook and dual-vendor parity tests.

Additive: the `add-local` registry coexists unchanged; its removal lands in #174.

## Rollout

Same constraint as `add-local`: the *built* env's `env_source.py` must declare the entry + hook, so per-cluster env-source refresh gates availability — and gates the listing too, which keeps discoverability honest per install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)