### PR TITLE
Advertise :custom entries in listings; retire add-local framing in docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -34,6 +34,7 @@ with RootstockCalculator(
 | `device` | `str` | No | `"cuda"` (default) or `"cpu"` |
 | `setup_kwargs` | `dict` | No | Extra keyword arguments forwarded to the env's `setup()` function (e.g., `{"task": "omol"}`). Cannot contain `checkpoint` or `device`. For a `:custom` checkpoint they go to `setup_from_path()` instead and cannot contain `path` |
 | `timeout` | `float` | No | Socket timeout in seconds for worker operations (default 600, matching checkpoint verification — so the first real force call, which may pay for `torch.compile` or large neighbor lists, runs under the envelope verification exercised) |
+| `weights` | `str \| Path` | With `:custom` | Path to your own weights file (e.g. a fine-tune of one of the family's shipped checkpoints). Required with — and only valid with — a `<family>:custom` checkpoint id. Must be visible from the compute nodes; loaded through the env's `setup_from_path()` hook. No shipped weights are involved |
 
 *`cluster` and `root` are mutually exclusive. When neither is given, the calculator falls back to the `ROOTSTOCK_ROOT` environment variable and then the `root` in `~/.config/rootstock/config.toml` — the same resolution the CLI uses — so on a configured machine `RootstockCalculator(checkpoint=...)` alone works.
 
@@ -45,6 +46,13 @@ RootstockCalculator(cluster="delta", checkpoint="mace-mp-0-medium")
 
 # Custom install root
 RootstockCalculator(root="/scratch/gpfs/specific/install/rootstock", checkpoint="mace-mp-0-medium")
+
+# Your own fine-tuned weights (see "Custom checkpoints" below)
+RootstockCalculator(
+    cluster="delta",
+    checkpoint="uma:custom",
+    weights="/scratch/me/my-uma-ft.pt",
+)
 ```
 
 ### Context manager

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -129,13 +129,18 @@ Signature: `setup(checkpoint: str, device: str = "cuda", **extra)`.
 
 Return: an ASE-compatible calculator.
 
-### `setup_from_path()` function (optional — enables local checkpoints)
+### `setup_from_path()` function (optional — enables custom checkpoints)
 
-Declaring a module-level `setup_from_path` opts the env into **local
-checkpoints**: user-supplied weights files (e.g. fine-tunes) registered with
-`rootstock add-local`. Envs without it don't support them, and registration
-fails with a clear error. Like `CHECKPOINTS`, presence is detected by parsing
-the source — the module is not executed.
+Declaring a module-level `setup_from_path` opts the env into **custom
+checkpoints**: user-supplied weights files (e.g. fine-tunes) run via a
+`"<family>:custom": None` entry in `CHECKPOINTS` plus `weights=` (or
+`--weights` on the CLI). Declare one entry per user-facing model family —
+a multi-family env declares several (e.g. `mace-mp:custom` and
+`mace-off23:custom`), all routing to the same hook. The entry and the hook
+must arrive together: the install lint rejects an entry without the hook,
+and envs without an entry don't advertise or accept user weights — the
+calculator fails at construction with a clear error. Like `CHECKPOINTS`,
+presence is detected by parsing the source — the module is not executed.
 
 Signature: `setup_from_path(path: str, device: str = "cuda", **extra)`.
 
@@ -144,9 +149,9 @@ Signature: `setup_from_path(path: str, device: str = "cuda", **extra)`.
   FAIRChem's `load_predict_unit(path)` vs `get_predict_unit(name)` — which is
   why this is a separate function rather than a path-shaped `checkpoint`.
 - `device`, extra kwargs: as for `setup()`. Give extras defaults where
-  possible; a fine-tune needing a required kwarg still works (the kwarg is
-  recorded at `rootstock add-local --kwarg ...` time), but defaults make
-  registration friendlier.
+  possible; a fine-tune needing a required kwarg still works (users pass it
+  via `setup_kwargs=` / `--kwarg`), but defaults make the common case
+  friendlier.
 
 Return: an ASE-compatible calculator.
 
@@ -159,12 +164,10 @@ def setup_from_path(path: str, device: str = "cuda", task: str = "omat"):
     return FAIRChemCalculator(predictor, task_name=task)
 ```
 
-One rebuild hazard to know about: registration checks the env source at
-registration time. If the env is later rebuilt (`rootstock install --force`)
-from a source that dropped `setup_from_path`, existing registrations break at
-worker startup. `rootstock status` flags registered checkpoints as stale
-after any env rebuild, and `rootstock smoke-test` re-verifies them — that's
-the detection path.
+The hook is checked against the *built* env's `env_source.py` at calculator
+construction, so a rebuild (`rootstock install --force`) from a source that
+dropped `setup_from_path` fails immediately with a maintainer-facing hint —
+never as an opaque error inside the worker.
 
 ## Examples
 

--- a/rootstock/benchmark.py
+++ b/rootstock/benchmark.py
@@ -201,8 +201,9 @@ def run_worker_mode(args) -> int:
 
     setup_kwargs = json.loads(args.setup_kwargs) if args.setup_kwargs else {}
 
-    # Mirror the real worker wrapper's branch: local checkpoints load through
-    # the env's setup_from_path hook, canonical ids through setup().
+    # Mirror the real worker wrapper's branch: user-supplied weights (:custom
+    # checkpoints) load through the env's setup_from_path hook, canonical ids
+    # through setup().
     t0 = time.perf_counter()
     if getattr(args, "checkpoint_path", None):
         from env_source import setup_from_path  # type: ignore
@@ -416,17 +417,21 @@ def print_table(results: list[dict]) -> None:
 
 
 def list_available(root: Path) -> int:
-    from rootstock.environment import list_declared_checkpoints
+    from rootstock.environment import list_custom_checkpoints, list_declared_checkpoints
 
     declared = list_declared_checkpoints(root)
     if not declared:
         print(f"No envs installed at {root}. Run `rootstock install` first.")
         return 1
+    custom = list_custom_checkpoints(root)
     print(f"Checkpoints declared by installed envs at {root}:\n")
     for env, ckpts in declared.items():
-        ids = ", ".join(ckpts) if ckpts else "(none)"
+        all_ids = [*ckpts, *custom.get(env, [])]
+        ids = ", ".join(all_ids) if all_ids else "(none)"
         print(f"  {env:<16} {ids}")
     print("\nPass a few of these to --checkpoints.")
+    if custom:
+        print("The ':custom' entries benchmark your own fine-tune — pass --weights.")
     return 0
 
 

--- a/rootstock/commands/status.py
+++ b/rootstock/commands/status.py
@@ -174,7 +174,11 @@ def _cmd_status_json(state: InstallState) -> int:
 
 def cmd_list(args) -> int:
     """List registered environments."""
-    from ..environment import list_built_environments, list_environments
+    from ..environment import (
+        list_built_environments,
+        list_custom_checkpoints,
+        list_environments,
+    )
 
     root = get_root_or_exit(args)
 
@@ -190,5 +194,14 @@ def cmd_list(args) -> int:
     for name, path in sources:
         status = "built" if name in built_names else "source only"
         print(f"  {name:<20} [{status}]")
+
+    custom = list_custom_checkpoints(root)
+    if custom:
+        entries = ", ".join(cid for ids in custom.values() for cid in ids)
+        print(
+            f"\nTo run your own fine-tuned weights, use its family's "
+            f"':custom' checkpoint ({entries}) and pass your weights file "
+            f"(weights= in Python, --weights on the CLI)."
+        )
 
     return 0

--- a/rootstock/environment.py
+++ b/rootstock/environment.py
@@ -447,15 +447,26 @@ def find_env_for_checkpoint(root: Path | str, checkpoint_id: str) -> tuple[str, 
             return env_name, ckpts
 
     if declared:
+        # The ':custom' entries are part of the menu — list them alongside
+        # the canonical ids so user-weights support is discoverable exactly
+        # where installed support exists.
+        custom = list_custom_checkpoints(root)
         listing = "\n".join(
-            f"  {env}: {', '.join(ids) if ids else '(none)'}" for env, ids in declared.items()
+            f"  {env}: {', '.join([*ids, *custom.get(env, [])]) or '(none)'}"
+            for env, ids in declared.items()
         )
         msg = (
             f"No installed env declares checkpoint '{checkpoint_id}'.\n"
-            f"Declared canonical ids by env:\n{listing}\n"
+            f"Declared checkpoint ids by env:\n{listing}\n"
             f"If '{checkpoint_id}' belongs to an env you haven't installed yet, "
             f"run `rootstock install <env-file> --root {root}`."
         )
+        if custom:
+            msg += (
+                f"\nThe '{CUSTOM_CHECKPOINT_SUFFIX}' entries run your own "
+                f"weights file — pass it via weights= in Python or --weights "
+                f"on the CLI."
+            )
     else:
         msg = (
             f"No envs are installed at {root}. "

--- a/rootstock/prewarm.py
+++ b/rootstock/prewarm.py
@@ -51,7 +51,7 @@ def iter_prewarm_files(spec: dict):
       volume, but imports also open thousands of small ``.py``/``.pyc``
       files whose cold reads are just as latency-bound — covering them adds
       little data and removes the residual small-file tail),
-    - the local checkpoint weights file, when the spec names one,
+    - the user-supplied (:custom) weights file, when the spec names one,
     - any extra files or directory trees a client lists in
       ``spec["prewarm_paths"]`` (reserved for future use; directories are
       walked recursively).

--- a/rootstock/spawn.py
+++ b/rootstock/spawn.py
@@ -54,7 +54,7 @@ finally:
 sys.path.insert(0, spec["env_dir"])
 from rootstock.worker import run_worker
 
-# Local checkpoints (user-supplied weights) load through the env's opt-in
+# User-supplied weights (:custom checkpoints) load through the env's opt-in
 # setup_from_path hook; the path travels through run_worker's existing
 # checkpoint parameter, so workers frozen inside built envs need no change.
 # The imports are one-sided: canonical mode must not require the hook.

--- a/sample_model_configurations/amd_configs/chgnet.py
+++ b/sample_model_configurations/amd_configs/chgnet.py
@@ -36,7 +36,7 @@ def setup(checkpoint: str, device: str = "cuda"):
 
 
 def setup_from_path(path: str, device: str = "cuda"):
-    # Local checkpoints (`rootstock add-local`): a weights *file* loads through
+    # Custom checkpoints (`:custom` ids with user weights): a weights *file* loads through
     # CHGNet.from_file, not the named-model CHGNet.load() setup() uses.
     from chgnet.model import CHGNet, CHGNetCalculator
 

--- a/sample_model_configurations/amd_configs/mace.py
+++ b/sample_model_configurations/amd_configs/mace.py
@@ -51,7 +51,7 @@ def setup(checkpoint: str, device: str = "cuda"):
 
 
 def setup_from_path(path: str, device: str = "cuda"):
-    # Local checkpoints (`rootstock add-local`): fine-tunes load through
+    # Custom checkpoints (`:custom` ids with user weights): fine-tunes load through
     # MACECalculator directly — the mp/off dispatch in setup() only exists
     # to pick which pretrained file to download.
     from mace.calculators import MACECalculator

--- a/sample_model_configurations/amd_configs/mattersim.py
+++ b/sample_model_configurations/amd_configs/mattersim.py
@@ -46,7 +46,7 @@ def setup(checkpoint: str, device: str = "cuda"):
 
 
 def setup_from_path(path: str, device: str = "cuda"):
-    # Local checkpoints (`rootstock add-local`): load_path accepts a filesystem
+    # Custom checkpoints (`:custom` ids with user weights): load_path accepts a filesystem
     # path as well as a model name, so this is setup() minus the name mapping.
     from mattersim.forcefield import MatterSimCalculator
 

--- a/sample_model_configurations/amd_configs/orb.py
+++ b/sample_model_configurations/amd_configs/orb.py
@@ -83,10 +83,10 @@ def setup(checkpoint: str, device: str = "cuda"):
 
 
 def setup_from_path(path: str, device: str = "cuda", arch: str = "orb-v2"):
-    # Local checkpoints (`rootstock add-local`). A weights file doesn't say
+    # Custom checkpoints (`:custom` ids with user weights). A weights file doesn't say
     # which orb architecture produced it, so `arch` names the pretrained
-    # loader to instantiate — register the right one at add-local time
-    # (--kwarg arch=...). Handing the loader a local path also means no
+    # loader to instantiate — pass the right one at call time
+    # (setup_kwargs={"arch": ...} / --kwarg arch=...). Handing the loader a local path also means no
     # network and no cached_path locking (see setup()).
     import torch
     from orb_models.forcefield import pretrained

--- a/sample_model_configurations/amd_configs/uma.py
+++ b/sample_model_configurations/amd_configs/uma.py
@@ -42,7 +42,7 @@ def setup(checkpoint: str, device: str = "cuda", task: str = "omat"):
 
 
 def setup_from_path(path: str, device: str = "cuda", task: str = "omat"):
-    # Local checkpoints (`rootstock add-local`): a weights *file* loads through
+    # Custom checkpoints (`:custom` ids with user weights): a weights *file* loads through
     # load_predict_unit, not the registry-name lookup setup() uses.
     from fairchem.core import FAIRChemCalculator
     from fairchem.core.units.mlip_unit import load_predict_unit

--- a/sample_model_configurations/nvidia_configs/allscaip.py
+++ b/sample_model_configurations/nvidia_configs/allscaip.py
@@ -31,7 +31,7 @@ def setup(checkpoint: str, device: str = "cuda"):
 
 
 def setup_from_path(path: str, device: str = "cuda"):
-    # Local checkpoints (`rootstock add-local`): a weights *file* loads through
+    # Custom checkpoints (`:custom` ids with user weights): a weights *file* loads through
     # load_predict_unit, not the registry-name lookup setup() uses.
     from fairchem.core import FAIRChemCalculator
     from fairchem.core.units.mlip_unit import load_predict_unit

--- a/sample_model_configurations/nvidia_configs/chgnet.py
+++ b/sample_model_configurations/nvidia_configs/chgnet.py
@@ -42,7 +42,7 @@ def setup(checkpoint: str, device: str = "cuda"):
 
 
 def setup_from_path(path: str, device: str = "cuda"):
-    # Local checkpoints (`rootstock add-local`): a weights *file* loads through
+    # Custom checkpoints (`:custom` ids with user weights): a weights *file* loads through
     # CHGNet.from_file, not the named-model CHGNet.load() setup() uses.
     from chgnet.model import CHGNet, CHGNetCalculator
 

--- a/sample_model_configurations/nvidia_configs/dimenet.py
+++ b/sample_model_configurations/nvidia_configs/dimenet.py
@@ -62,7 +62,7 @@ def setup(checkpoint: str, device: str = "cuda"):
 
 
 def setup_from_path(path: str, device: str = "cuda"):
-    # Local checkpoints (`rootstock add-local`): OCPCalculator loads a
+    # Custom checkpoints (`:custom` ids with user weights): OCPCalculator loads a
     # checkpoint file natively — this is setup() minus the registry download.
     from fairchem.core import OCPCalculator
 

--- a/sample_model_configurations/nvidia_configs/equiformer.py
+++ b/sample_model_configurations/nvidia_configs/equiformer.py
@@ -60,7 +60,7 @@ def setup(checkpoint: str, device: str = "cuda"):
 
 
 def setup_from_path(path: str, device: str = "cuda"):
-    # Local checkpoints (`rootstock add-local`): OCPCalculator loads a
+    # Custom checkpoints (`:custom` ids with user weights): OCPCalculator loads a
     # checkpoint file natively — this is setup() minus the registry download.
     from fairchem.core import OCPCalculator
 

--- a/sample_model_configurations/nvidia_configs/escn.py
+++ b/sample_model_configurations/nvidia_configs/escn.py
@@ -62,7 +62,7 @@ def setup(checkpoint: str, device: str = "cuda"):
 
 
 def setup_from_path(path: str, device: str = "cuda"):
-    # Local checkpoints (`rootstock add-local`): OCPCalculator loads a
+    # Custom checkpoints (`:custom` ids with user weights): OCPCalculator loads a
     # checkpoint file natively — this is setup() minus the registry download.
     from fairchem.core import OCPCalculator
 

--- a/sample_model_configurations/nvidia_configs/esen.py
+++ b/sample_model_configurations/nvidia_configs/esen.py
@@ -32,7 +32,7 @@ def setup(checkpoint: str, device: str = "cuda"):
 
 
 def setup_from_path(path: str, device: str = "cuda"):
-    # Local checkpoints (`rootstock add-local`): a weights *file* loads through
+    # Custom checkpoints (`:custom` ids with user weights): a weights *file* loads through
     # load_predict_unit, not the registry-name lookup setup() uses.
     from fairchem.core import FAIRChemCalculator
     from fairchem.core.units.mlip_unit import load_predict_unit

--- a/sample_model_configurations/nvidia_configs/gemnet.py
+++ b/sample_model_configurations/nvidia_configs/gemnet.py
@@ -59,7 +59,7 @@ def setup(checkpoint: str, device: str = "cuda"):
 
 
 def setup_from_path(path: str, device: str = "cuda"):
-    # Local checkpoints (`rootstock add-local`): OCPCalculator loads a
+    # Custom checkpoints (`:custom` ids with user weights): OCPCalculator loads a
     # checkpoint file natively — this is setup() minus the registry download.
     from fairchem.core import OCPCalculator
 

--- a/sample_model_configurations/nvidia_configs/mace.py
+++ b/sample_model_configurations/nvidia_configs/mace.py
@@ -38,7 +38,7 @@ def setup(checkpoint: str, device: str = "cuda"):
 
 
 def setup_from_path(path: str, device: str = "cuda"):
-    # Local checkpoints (`rootstock add-local`): fine-tunes load through
+    # Custom checkpoints (`:custom` ids with user weights): fine-tunes load through
     # MACECalculator directly — the mp/off dispatch in setup() only exists
     # to pick which pretrained file to download.
     from mace.calculators import MACECalculator

--- a/sample_model_configurations/nvidia_configs/mattersim.py
+++ b/sample_model_configurations/nvidia_configs/mattersim.py
@@ -61,7 +61,7 @@ def setup(checkpoint: str, device: str = "cuda"):
 
 
 def setup_from_path(path: str, device: str = "cuda"):
-    # Local checkpoints (`rootstock add-local`): load_path accepts a filesystem
+    # Custom checkpoints (`:custom` ids with user weights): load_path accepts a filesystem
     # path as well as a model name, so this is setup() minus the name mapping.
     from mattersim.forcefield import MatterSimCalculator
 

--- a/sample_model_configurations/nvidia_configs/orb.py
+++ b/sample_model_configurations/nvidia_configs/orb.py
@@ -90,10 +90,10 @@ def setup(checkpoint: str, device: str = "cuda"):
 
 
 def setup_from_path(path: str, device: str = "cuda", arch: str = "orb-v2"):
-    # Local checkpoints (`rootstock add-local`). A weights file doesn't say
+    # Custom checkpoints (`:custom` ids with user weights). A weights file doesn't say
     # which orb architecture produced it, so `arch` names the pretrained
-    # loader to instantiate — register the right one at add-local time
-    # (--kwarg arch=...). Handing the loader a local path also means no
+    # loader to instantiate — pass the right one at call time
+    # (setup_kwargs={"arch": ...} / --kwarg arch=...). Handing the loader a local path also means no
     # network and no cached_path locking (see setup()).
     import torch
     from orb_models.forcefield import pretrained

--- a/sample_model_configurations/nvidia_configs/painn.py
+++ b/sample_model_configurations/nvidia_configs/painn.py
@@ -56,7 +56,7 @@ def setup(checkpoint: str, device: str = "cuda"):
 
 
 def setup_from_path(path: str, device: str = "cuda"):
-    # Local checkpoints (`rootstock add-local`): OCPCalculator loads a
+    # Custom checkpoints (`:custom` ids with user weights): OCPCalculator loads a
     # checkpoint file natively — this is setup() minus the registry download.
     from fairchem.core import OCPCalculator
 

--- a/sample_model_configurations/nvidia_configs/schnet.py
+++ b/sample_model_configurations/nvidia_configs/schnet.py
@@ -59,7 +59,7 @@ def setup(checkpoint: str, device: str = "cuda"):
 
 
 def setup_from_path(path: str, device: str = "cuda"):
-    # Local checkpoints (`rootstock add-local`): OCPCalculator loads a
+    # Custom checkpoints (`:custom` ids with user weights): OCPCalculator loads a
     # checkpoint file natively — this is setup() minus the registry download.
     from fairchem.core import OCPCalculator
 

--- a/sample_model_configurations/nvidia_configs/scn.py
+++ b/sample_model_configurations/nvidia_configs/scn.py
@@ -60,7 +60,7 @@ def setup(checkpoint: str, device: str = "cuda"):
 
 
 def setup_from_path(path: str, device: str = "cuda"):
-    # Local checkpoints (`rootstock add-local`): OCPCalculator loads a
+    # Custom checkpoints (`:custom` ids with user weights): OCPCalculator loads a
     # checkpoint file natively — this is setup() minus the registry download.
     from fairchem.core import OCPCalculator
 

--- a/sample_model_configurations/nvidia_configs/sevennet.py
+++ b/sample_model_configurations/nvidia_configs/sevennet.py
@@ -71,9 +71,10 @@ def setup(checkpoint: str, device: str = "cuda", modal: str | None = None):
 
 
 def setup_from_path(path: str, device: str = "cuda", modal: str | None = None):
-    # Local checkpoints (`rootstock add-local`): SevenNetCalculator loads a
-    # checkpoint file directly. A multi-fidelity fine-tune must register its
-    # fidelity (--kwarg modal=mpa); single-fidelity ones need no kwargs.
+    # Custom checkpoints (`:custom` ids with user weights): SevenNetCalculator loads a
+    # checkpoint file directly. A multi-fidelity fine-tune must pass its
+    # fidelity (setup_kwargs={"modal": "mpa"} / --kwarg modal=mpa);
+    # single-fidelity ones need no kwargs.
     from sevenn.calculator import SevenNetCalculator
 
     kwargs = {"modal": modal} if modal is not None else {}

--- a/sample_model_configurations/nvidia_configs/uma.py
+++ b/sample_model_configurations/nvidia_configs/uma.py
@@ -30,7 +30,7 @@ def setup(checkpoint: str, device: str = "cuda", task: str = "omat"):
 
 
 def setup_from_path(path: str, device: str = "cuda", task: str = "omat"):
-    # Local checkpoints (`rootstock add-local`): a weights *file* loads through
+    # Custom checkpoints (`:custom` ids with user weights): a weights *file* loads through
     # load_predict_unit, not the registry-name lookup setup() uses.
     from fairchem.core import FAIRChemCalculator
     from fairchem.core.units.mlip_unit import load_predict_unit

--- a/tests/cli/test_custom_hints.py
+++ b/tests/cli/test_custom_hints.py
@@ -1,0 +1,77 @@
+"""':custom' entries are the discoverability surface: listings show them
+verbatim, plus one pattern line — and only when an installed env actually
+declares an entry."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from rootstock.benchmark import list_available
+from rootstock.commands.status import cmd_list
+
+_CUSTOM_ENV_SOURCE = """\
+CHECKPOINTS = {
+    "uma-s-1p1": "uma-s-1p1",
+    "uma:custom": None,
+}
+
+
+def setup(checkpoint, device="cuda"):
+    return None
+
+
+def setup_from_path(path, device="cuda", **kwargs):
+    return None
+"""
+
+# Declares the hook but no ':custom' entry (e.g. a built env predating the
+# entries): user weights are unavailable there, so nothing may be advertised.
+_HOOK_ONLY_ENV_SOURCE = """\
+CHECKPOINTS = {"orb-v2": "orb-v2"}
+
+
+def setup(checkpoint, device="cuda"):
+    return None
+
+
+def setup_from_path(path, device="cuda", **kwargs):
+    return None
+"""
+
+
+def _make_root(tmp_path: Path, source: str) -> Path:
+    root = tmp_path / "root"
+    env_dir = root / "envs" / "env1"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+    (env_dir / "env_source.py").write_text(source)
+    return root
+
+
+@pytest.mark.parametrize(
+    ("source", "hinted"),
+    [(_CUSTOM_ENV_SOURCE, True), (_HOOK_ONLY_ENV_SOURCE, False)],
+    ids=["custom-entry-env", "hook-only-env"],
+)
+def test_cmd_list_hint_follows_entry_availability(tmp_path, capsys, source, hinted):
+    root = _make_root(tmp_path, source)
+    rc = cmd_list(SimpleNamespace(root=str(root)))
+    assert rc == 0
+    assert ("uma:custom" in capsys.readouterr().out) is hinted
+
+
+@pytest.mark.parametrize(
+    ("source", "hinted"),
+    [(_CUSTOM_ENV_SOURCE, True), (_HOOK_ONLY_ENV_SOURCE, False)],
+    ids=["custom-entry-env", "hook-only-env"],
+)
+def test_benchmark_list_shows_custom_entries(tmp_path, capsys, source, hinted):
+    root = _make_root(tmp_path, source)
+    rc = list_available(root)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert ("uma:custom" in out) is hinted
+    assert ("--weights" in out) is hinted

--- a/tests/local/test_resolve_checkpoint.py
+++ b/tests/local/test_resolve_checkpoint.py
@@ -47,6 +47,33 @@ def test_miss_lists_canonical_ids(fake_root):
     assert "rootstock install" in msg  # hint for not-yet-installed envs
 
 
+def test_miss_lists_custom_entries_when_declared(tmp_path):
+    # A declared ':custom' entry is part of the menu: the not-found listing
+    # shows it verbatim, plus the weights= pattern line, once.
+    root = tmp_path / "root"
+    env_dir = root / "envs" / "uma"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+    with_entry = _ENV_SOURCE.replace(
+        '"uma-s-1p1": "uma-s-1p1"', '"uma-s-1p1": "uma-s-1p1", "uma:custom": None'
+    )
+    (env_dir / "env_source.py").write_text(with_entry)
+    with pytest.raises(CheckpointNotFoundError) as exc:
+        resolve_checkpoint(root, "typo")
+    msg = str(exc.value)
+    assert "uma:custom" in msg
+    assert "weights" in msg
+
+
+def test_miss_omits_custom_hint_without_entries(fake_root):
+    # The fixture env declares the hook but no ':custom' entry (a built env
+    # predating the entries): user weights are unavailable, so nothing may
+    # be advertised.
+    with pytest.raises(CheckpointNotFoundError) as exc:
+        resolve_checkpoint(fake_root, "typo")
+    assert ":custom" not in str(exc.value)
+
+
 def test_miss_on_empty_root(tmp_path):
     with pytest.raises(CheckpointNotFoundError, match="No envs are installed"):
         resolve_checkpoint(tmp_path / "root", "uma-s-1p1")

--- a/tests/sample_configs/test_setup_from_path_hooks.py
+++ b/tests/sample_configs/test_setup_from_path_hooks.py
@@ -1,8 +1,9 @@
-"""Tests for the sample configs' ``setup_from_path`` hooks (local checkpoints).
+"""Tests for the sample configs' ``setup_from_path`` hooks (custom checkpoints).
 
 The envs shipped for both vendors (present in nvidia_configs *and*
-amd_configs) are the canonical set for `rootstock add-local`: both copies
-must declare the hook, with the contract signature
+amd_configs) are the canonical set for ``:custom`` checkpoints (user-supplied
+weights via ``weights=`` / ``--weights``): both copies must declare the hook,
+with the contract signature
 ``setup_from_path(path, device="cuda", **extras-with-defaults)``, and the
 signatures must not drift between vendor copies.
 
@@ -57,7 +58,7 @@ def test_dual_vendor_set_is_nonempty():
 def test_dual_vendor_envs_declare_hook(env, vendor_dir):
     assert declares_setup_from_path(vendor_dir / f"{env}.py"), (
         f"{vendor_dir.name}/{env}.py must declare setup_from_path — every "
-        f"dual-vendor env supports local checkpoints"
+        f"dual-vendor env supports custom checkpoints"
     )
 
 
@@ -68,7 +69,7 @@ def test_dual_vendor_envs_declare_hook(env, vendor_dir):
 )
 def test_hook_signature_contract(config):
     """First param `path`, then `device` with a default, extras all defaulted
-    — so `add-local` without --kwarg works for every env."""
+    — so a `:custom` checkpoint without setup_kwargs works for every env."""
     args = _hook_args(config)
     names = [a.arg for a in args.args]
     assert names[:2] == ["path", "device"]


### PR DESCRIPTION
## What

Discoverability + polish for `<family>:custom` checkpoints (#173, #174). The entries are themselves the discoverability surface — they appear verbatim wherever checkpoint ids are listed, exactly on the installs whose built envs declare them:

- `CheckpointNotFoundError`'s listing includes each env's `:custom` entries alongside its canonical ids, plus one pattern line naming `weights=`.
- `rootstock benchmark --list` includes the entries in each env row; `rootstock list` appends one line naming the declared entries. Both gate on **declared entries** (not the hook): a built env with the hook but no entry predates the feature and must not advertise what it can't deliver.
- `docs/api.md` gains the `weights` parameter row and a `:custom` example; `docs/environments.md` keeps the `setup_from_path` section (it documents the hook everything routes to) but reframes it around declaring the `"<family>:custom": None` entries — one per user-facing family — and the entry⟺hook pairing the install lint enforces.
- The ~20 sample-config `setup_from_path` comments, spawn/prewarm/benchmark docstrings, and `tests/sample_configs` docstrings drop the add-local framing. orb's `arch` kwarg and sevennet's `modal` kwarg are passed at call time (`setup_kwargs=` / `--kwarg`) instead of recorded at registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)