### PR TITLE
Publish downloaded interpreters via staged copy + atomic rename

### DIFF
--- a/rootstock/operations.py
+++ b/rootstock/operations.py
@@ -24,6 +24,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 from collections.abc import Callable
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -484,6 +485,58 @@ def _precompile_environment(env_python: Path, env_target: Path) -> None:
             print(f"    ... and {len(output) - 10} more lines")
 
 
+def _publish_python_interpreter(
+    tmp_python_dir: Path,
+    python_install_dir: Path,
+    progress: Progress | None,
+) -> None:
+    """Move a freshly downloaded interpreter into the shared ``.python/`` dir.
+
+    Parallel builds race here (uv downloads each build's interpreter to a
+    private tempdir; publication into the shared dir is ours to make safe):
+    each item is copied to a unique staging name *inside* ``.python/`` (same
+    filesystem) and atomically renamed into place, so a concurrent reader —
+    another build's ``uv venv`` — can never see a half-copied interpreter
+    tree. Losing the rename race to another build is fine: its copy is as
+    good as ours, so the staging copy is simply discarded.
+
+    Once the destination exists, leftover staging entries for that item
+    (from builds that crashed mid-copy) are swept. Sweeping a *live* loser's
+    staging is harmless: its copy or rename fails, it sees the destination
+    exists, and it carries on.
+    """
+    if not tmp_python_dir.exists():
+        return
+
+    for item in tmp_python_dir.iterdir():
+        dest = python_install_dir / item.name
+        if not dest.exists():
+            _say(progress, f"  Copying Python to {dest}")
+            # pid alone is not unique enough: parallel builds may be threads
+            # of one process (a batch driver), so salt with the thread id.
+            staging = python_install_dir / (
+                f"{item.name}.installing.{os.getpid()}.{threading.get_ident()}"
+            )
+            try:
+                if item.is_dir():
+                    shutil.copytree(item, staging)
+                else:
+                    shutil.copy2(item, staging)
+                staging.rename(dest)
+            except OSError:
+                # Tolerable only when another build actually won the race.
+                if not dest.exists():
+                    raise
+        # dest exists now — ours or another build's. Anything still staged
+        # for this item is dead weight (a crashed build's leftover, or our
+        # own copy after losing the race); reclaim the space.
+        for stale in python_install_dir.glob(f"{item.name}.installing.*"):
+            if stale.is_dir():
+                shutil.rmtree(stale, ignore_errors=True)
+            else:
+                stale.unlink(missing_ok=True)
+
+
 def install_environment(
     root: Path,
     source: str | Path,
@@ -695,16 +748,9 @@ def _build_and_swap(
         if result.returncode != 0:
             raise OperationError(f"Error downloading Python: {result.stderr}")
 
-        # Copy downloaded Python to root directory (if not already there)
-        if tmp_python_dir.exists():
-            for item in tmp_python_dir.iterdir():
-                dest = python_install_dir / item.name
-                if not dest.exists():
-                    if item.is_dir():
-                        _say(progress, f"  Copying Python to {dest}")
-                        shutil.copytree(item, dest)
-                    else:
-                        shutil.copy2(item, dest)
+        # Publish the downloaded Python into the shared root (if not already
+        # there) — staged-copy + atomic rename, safe against parallel builds.
+        _publish_python_interpreter(tmp_python_dir, python_install_dir, progress)
 
     # Phase 2: Create venv using the Python we just installed
     uv_env = os.environ.copy()

--- a/tests/commands/test_install_python_race.py
+++ b/tests/commands/test_install_python_race.py
@@ -1,0 +1,164 @@
+"""Publishing downloaded interpreters into the shared ``.python/`` dir.
+
+Each build downloads its interpreter to a private tempdir, then publishes it
+into ``{root}/.python/``. The old code copied straight to the destination
+behind a check-then-act ``exists()`` guard, so two parallel builds wanting the
+same interpreter collided: the loser's ``copytree`` raised, and a concurrent
+reader could see a half-copied tree. Publication now stages under a unique
+name inside ``.python/`` and atomically renames into place.
+"""
+
+from __future__ import annotations
+
+import shutil
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from rootstock.operations import _publish_python_interpreter
+
+INTERP = "cpython-3.11.9-linux-x86_64-gnu"
+
+
+def _make_download(tmp_path: Path, name: str = "download") -> Path:
+    """A fake `uv python install` result: one interpreter dir + one loose file."""
+    tmp_python_dir = tmp_path / name / ".python"
+    interp = tmp_python_dir / INTERP
+    (interp / "bin").mkdir(parents=True)
+    (interp / "bin" / "python").write_text("#!fake\n")
+    (tmp_python_dir / ".lock").write_text("")
+    return tmp_python_dir
+
+
+def test_fresh_publish_lands_in_place(tmp_path):
+    download = _make_download(tmp_path)
+    install_dir = tmp_path / ".python"
+    install_dir.mkdir()
+
+    _publish_python_interpreter(download, install_dir, None)
+
+    assert (install_dir / INTERP / "bin" / "python").exists()
+    assert (install_dir / ".lock").is_file()
+    assert not list(install_dir.glob("*.installing.*"))
+
+
+def test_existing_interpreter_is_left_alone(tmp_path):
+    download = _make_download(tmp_path)
+    install_dir = tmp_path / ".python"
+    existing = install_dir / INTERP
+    existing.mkdir(parents=True)
+    (existing / "already-here").touch()
+
+    _publish_python_interpreter(download, install_dir, None)
+
+    assert (existing / "already-here").exists()
+    assert not (existing / "bin").exists()
+
+
+def test_missing_download_dir_is_a_noop(tmp_path):
+    install_dir = tmp_path / ".python"
+    install_dir.mkdir()
+
+    _publish_python_interpreter(tmp_path / "nope" / ".python", install_dir, None)
+
+    assert list(install_dir.iterdir()) == []
+
+
+def test_losing_the_rename_race_is_tolerated(tmp_path, monkeypatch):
+    """Another build renames a complete copy in while ours is staging: our
+    rename fails, but the winner's copy is as good as ours — no error, and
+    our staging copy is swept."""
+    download = _make_download(tmp_path)
+    install_dir = tmp_path / ".python"
+    install_dir.mkdir()
+
+    real_copytree = shutil.copytree
+
+    def racing_copytree(src, dst, *args, **kwargs):
+        # copytree recurses through shutil.copytree for subdirectories; only
+        # the top-level interpreter copy simulates the racing winner.
+        result = real_copytree(src, dst, *args, **kwargs)
+        if Path(src).name == INTERP:
+            winner = install_dir / INTERP
+            if not winner.exists():
+                winner.mkdir()
+                (winner / "winner-marker").touch()
+        return result
+
+    monkeypatch.setattr("rootstock.operations.shutil.copytree", racing_copytree)
+
+    _publish_python_interpreter(download, install_dir, None)
+
+    assert (install_dir / INTERP / "winner-marker").exists()
+    assert not list(install_dir.glob("*.installing.*"))
+
+
+def test_staging_deleted_underfoot_is_tolerated(tmp_path, monkeypatch):
+    """A winner's sweep may delete a live loser's staging mid-copy: the
+    loser's copytree fails, but the destination exists, so it carries on."""
+    download = _make_download(tmp_path)
+    install_dir = tmp_path / ".python"
+    install_dir.mkdir()
+
+    def swept_copytree(src, dst, **kwargs):
+        winner = install_dir / Path(src).name
+        winner.mkdir(parents=True, exist_ok=True)
+        (winner / "winner-marker").touch()
+        raise FileNotFoundError(f"{dst} deleted by a concurrent sweep")
+
+    monkeypatch.setattr("rootstock.operations.shutil.copytree", swept_copytree)
+
+    _publish_python_interpreter(download, install_dir, None)
+
+    assert (install_dir / INTERP / "winner-marker").exists()
+
+
+def test_real_failure_still_raises(tmp_path, monkeypatch):
+    """OSErrors are only swallowed when another build actually won."""
+    download = _make_download(tmp_path)
+    install_dir = tmp_path / ".python"
+    install_dir.mkdir()
+
+    def broken_copytree(src, dst, **kwargs):
+        raise PermissionError("disk on fire")
+
+    monkeypatch.setattr("rootstock.operations.shutil.copytree", broken_copytree)
+
+    with pytest.raises(PermissionError, match="disk on fire"):
+        _publish_python_interpreter(download, install_dir, None)
+
+
+def test_crashed_build_leftovers_are_swept(tmp_path):
+    """Staging dirs abandoned by a killed build are reclaimed once the
+    interpreter is in place."""
+    download = _make_download(tmp_path)
+    install_dir = tmp_path / ".python"
+    stale = install_dir / f"{INTERP}.installing.99999"
+    stale.mkdir(parents=True)
+    (stale / "half-copied").touch()
+    (install_dir / ".lock.installing.99999").touch()
+
+    _publish_python_interpreter(download, install_dir, None)
+
+    assert (install_dir / INTERP / "bin" / "python").exists()
+    assert not stale.exists()
+    assert not list(install_dir.glob("*.installing.*"))
+
+
+def test_concurrent_publishes_of_same_interpreter(tmp_path):
+    """N builds publishing the same interpreter at once: all succeed, one
+    complete copy lands, no staging garbage remains."""
+    install_dir = tmp_path / ".python"
+    install_dir.mkdir()
+    downloads = [_make_download(tmp_path, name=f"download{i}") for i in range(8)]
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        futures = [
+            pool.submit(_publish_python_interpreter, d, install_dir, None) for d in downloads
+        ]
+        for future in futures:
+            future.result()  # raises if any publish blew up
+
+    assert (install_dir / INTERP / "bin" / "python").exists()
+    assert not list(install_dir.glob("*.installing.*"))


### PR DESCRIPTION
Closes #183. Part of the `rootstock sync` batch-admin work (#182).

## Problem

`_build_and_swap` copied the freshly downloaded Python interpreter into the shared `{root}/.python/` behind a check-then-act `exists()` guard. Two parallel builds wanting the same interpreter both pass the check; the loser's `copytree` raises `FileExistsError` — or worse, a concurrent reader (another build's `uv venv`) sees a half-copied interpreter tree. Today this only bites people running two `rootstock install` processes by hand; the `sync` executor (#185) will fan builds out deliberately, making it a guaranteed collision on any fresh root.

## Fix

Publication is extracted into `_publish_python_interpreter()`:

- Each item is copied to a unique staging name **inside** `.python/` (same filesystem — the download tempdir generally isn't), then atomically renamed into place. A reader can never observe a partial tree.
- Losing the rename race is tolerated: the winner's copy is as good as ours, so the staging copy is discarded. Real failures (destination still absent) re-raise.
- Once the destination exists, leftover `*.installing.*` staging entries are swept — reclaiming multi-GB leftovers from builds that crashed mid-copy. Sweeping a *live* loser's staging is harmless: its copy/rename fails, it sees the destination exists, and it carries on (covered by a test).
- Staging names are salted with the thread id as well as the pid: parallel builds may be threads of a single batch-driver process (the #185 executor), where pid alone would collide.

The file branch (`copy2`, e.g. uv's `.lock`) gets the same treatment; plain-file renames atomically replace, so that branch was only ever exposed to partial reads, not crashes.

## Tests

`tests/commands/test_install_python_race.py`: fresh publish, existing-interpreter no-op, rename-race loser, staging-swept-underfoot survivor, genuine-failure re-raise, crashed-build sweep, and an 8-thread concurrent publish of the same interpreter. Full suite: 623 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)