### PR TITLE
Split add_checkpoint into fetch/verify phase operations

### DIFF
--- a/rootstock/operations.py
+++ b/rootstock/operations.py
@@ -92,6 +92,26 @@ class AddResult:
     verified_device: str | None
 
 
+@dataclass
+class FetchResult:
+    """Outcome of a successful :func:`fetch_checkpoint`."""
+
+    env_name: str
+    checkpoint: str
+    fetched_at: str
+    already_fetched: bool  # download skipped: weights were already cached
+
+
+@dataclass
+class VerifyResult:
+    """Outcome of a successful :func:`verify_fetched_checkpoint`."""
+
+    env_name: str
+    checkpoint: str
+    verified_at: str
+    verified_device: str
+
+
 def _say(progress: Progress | None, message: str) -> None:
     if progress is not None:
         progress(message)
@@ -953,43 +973,52 @@ def _ensure_manifest_entry(
     return env, env.checkpoints[checkpoint]
 
 
-def add_checkpoint(
-    root: Path,
-    checkpoint: str,
-    *,
-    device: str = "cuda",
-    verify: bool = True,
-    push: bool = True,
-    setup_kwargs: dict | None = None,
-    cache_root: Path | None = None,
-    progress: Progress | None = None,
-) -> AddResult:
-    """
-    Idempotent download-or-verify for a checkpoint by canonical id.
-
-    The hosting env is resolved by matching the id against each installed
-    env's CHECKPOINTS table. Downloads happen on CPU (the cache-aware path);
-    verification runs on ``device`` unless ``verify`` is False.
-
-    Raises CheckpointNotFoundError when no installed env declares the id,
-    and OperationError for download/verify failures (the failure is also
-    recorded in the manifest's ``last_error`` for the checkpoint).
-    """
-    root = Path(root)
-    setup_kwargs = setup_kwargs or {}
-    if cache_root is None:
-        cache_root = resolve_cache_root(root)
-
+def _resolve_built_env(root: Path, checkpoint: str) -> str:
+    """Resolve the hosting env for a checkpoint id, failing fast when it
+    isn't built (checked again inside each transaction by
+    :func:`_ensure_manifest_entry`, whose refresh needs it too)."""
     env_name, _ = find_env_for_checkpoint(root, checkpoint)
-
-    # Fail fast before any long-running work (checked again inside each
-    # transaction by _ensure_manifest_entry, whose refresh needs it too).
     env_dir = root / "envs" / env_name
     if not (env_dir / "bin" / "python").exists():
         raise OperationError(
             f"environment '{env_name}' is not built at {env_dir}.\n"
             f"Run: rootstock install <path-to-{env_name}.py> --root {root}"
         )
+    return env_name
+
+
+def fetch_checkpoint(
+    root: Path,
+    checkpoint: str,
+    *,
+    setup_kwargs: dict | None = None,
+    cache_root: Path | None = None,
+    refresh: bool = True,
+    push: bool = True,
+    progress: Progress | None = None,
+) -> FetchResult:
+    """
+    Idempotent CPU-side download of a checkpoint by canonical id.
+
+    The download half of :func:`add_checkpoint`, usable on its own: it needs
+    no GPU (so it can run on a login node), and downloads parallelize freely
+    — HF hub uses its own file locks, and distinct checkpoints touch distinct
+    cache files — where verification must stay bounded by GPU memory.
+
+    Records ``fetched_at``/``last_error`` in the manifest. ``refresh=False``
+    skips the trailing full manifest refresh (+ push): a batch driver running
+    many fetches refreshes once at the end instead of once per checkpoint.
+
+    Raises CheckpointNotFoundError when no installed env declares the id,
+    and OperationError when the download fails (also recorded in the
+    manifest's ``last_error``).
+    """
+    root = Path(root)
+    setup_kwargs = setup_kwargs or {}
+    if cache_root is None:
+        cache_root = resolve_cache_root(root)
+
+    env_name = _resolve_built_env(root, checkpoint)
 
     # Unlocked peek for idempotence; every write below loads fresh inside
     # its own transaction, so a racing writer costs at most a redundant
@@ -998,12 +1027,9 @@ def add_checkpoint(
     peek_env = peek.environments.get(env_name) if peek else None
     peek_ckpt = peek_env.checkpoints.get(checkpoint) if peek_env else None
     already_fetched = peek_ckpt is not None and peek_ckpt.fetched_at is not None
-
     fetched_at = peek_ckpt.fetched_at if peek_ckpt else None
-    verified_at: str | None = None
-    verified_device: str | None = None
 
-    # ---- Download phase (runs outside the lock) ------------------------
+    # ---- Download (runs outside the lock) -------------------------------
     if not already_fetched:
         _say(progress, f"Downloading {env_name}/{checkpoint} on CPU...")
         ok, err = _run_download(root, env_name, checkpoint, setup_kwargs, cache_root=cache_root)
@@ -1021,38 +1047,149 @@ def add_checkpoint(
     else:
         _say(progress, f"{env_name}/{checkpoint} already fetched at {fetched_at}")
 
-    # ---- Verify phase (runs outside the lock) --------------------------
+    if refresh:
+        # Refresh + push (takes the lock for its own load -> refresh -> save)
+        update_and_push_manifest(root, quiet=True, push=push)
+
+    return FetchResult(
+        env_name=env_name,
+        checkpoint=checkpoint,
+        fetched_at=fetched_at,
+        already_fetched=already_fetched,
+    )
+
+
+def verify_fetched_checkpoint(
+    root: Path,
+    checkpoint: str,
+    *,
+    device: str = "cuda",
+    setup_kwargs: dict | None = None,
+    cache_root: Path | None = None,
+    refresh: bool = True,
+    push: bool = True,
+    progress: Progress | None = None,
+) -> VerifyResult:
+    """
+    Verify a checkpoint on ``device`` and record the outcome in the manifest.
+
+    The verify half of :func:`add_checkpoint`, usable on its own — typically
+    after :func:`fetch_checkpoint` (a prior fetch isn't a hard precondition;
+    verification loads through the same cache-aware path and would download
+    missing weights itself). Each verification loads the full model onto
+    ``device``, so a batch driver must bound its concurrency, unlike the
+    freely-parallel fetch.
+
+    Success stamps ``verified_at``/``verified_device`` and clears
+    ``last_error``; failure clears the verified stamps and records the error.
+    ``refresh=False`` skips the trailing full manifest refresh (+ push), for
+    batch drivers that refresh once at the end.
+
+    Raises CheckpointNotFoundError when no installed env declares the id,
+    and OperationError when verification fails.
+    """
+    root = Path(root)
+    setup_kwargs = setup_kwargs or {}
+    if cache_root is None:
+        cache_root = resolve_cache_root(root)
+
+    env_name = _resolve_built_env(root, checkpoint)
+
+    # ---- Verify (runs outside the lock) ---------------------------------
+    _say(progress, f"Verifying {env_name}/{checkpoint} on {device}...")
+    ok, err = verify_checkpoint(
+        root, env_name, checkpoint, device, setup_kwargs, cache_root=cache_root
+    )
+    with _manifest_transaction(root) as manifest:
+        _, ckpt = _ensure_manifest_entry(manifest, root, env_name, checkpoint)
+        if ok:
+            ckpt.verified_at = now_iso()
+            ckpt.verified_device = device
+            ckpt.last_error = None
+            verified_at = ckpt.verified_at
+        else:
+            ckpt.verified_at = None
+            ckpt.verified_device = None
+            ckpt.last_error = f"verify: {err}"
+    if not ok:
+        raise OperationError(f"verify failed: {err}")
+    _say(progress, f"  verified_at = {verified_at} ({device})")
+
+    if refresh:
+        # Refresh + push (takes the lock for its own load -> refresh -> save)
+        update_and_push_manifest(root, quiet=True, push=push)
+
+    return VerifyResult(
+        env_name=env_name,
+        checkpoint=checkpoint,
+        verified_at=verified_at,
+        verified_device=device,
+    )
+
+
+def add_checkpoint(
+    root: Path,
+    checkpoint: str,
+    *,
+    device: str = "cuda",
+    verify: bool = True,
+    push: bool = True,
+    setup_kwargs: dict | None = None,
+    cache_root: Path | None = None,
+    progress: Progress | None = None,
+) -> AddResult:
+    """
+    Idempotent download-or-verify for a checkpoint by canonical id.
+
+    The composition of :func:`fetch_checkpoint` and
+    :func:`verify_fetched_checkpoint` (batch drivers call those directly to
+    parallelize the two phases independently), with a single manifest
+    refresh at the end. The hosting env is resolved by matching the id
+    against each installed env's CHECKPOINTS table. Downloads happen on CPU
+    (the cache-aware path); verification runs on ``device`` unless
+    ``verify`` is False.
+
+    Raises CheckpointNotFoundError when no installed env declares the id,
+    and OperationError for download/verify failures (the failure is also
+    recorded in the manifest's ``last_error`` for the checkpoint; a failure
+    skips the trailing refresh, exactly as before the split).
+    """
+    root = Path(root)
+    setup_kwargs = setup_kwargs or {}
+    if cache_root is None:
+        cache_root = resolve_cache_root(root)
+
+    fetched = fetch_checkpoint(
+        root,
+        checkpoint,
+        setup_kwargs=setup_kwargs,
+        cache_root=cache_root,
+        refresh=False,
+        progress=progress,
+    )
+
+    verified: VerifyResult | None = None
     if not verify:
         _say(progress, "(skipping verify per --no-verify)")
     else:
-        _say(progress, f"Verifying {env_name}/{checkpoint} on {device}...")
-        ok, err = verify_checkpoint(
-            root, env_name, checkpoint, device, setup_kwargs, cache_root=cache_root
+        verified = verify_fetched_checkpoint(
+            root,
+            checkpoint,
+            device=device,
+            setup_kwargs=setup_kwargs,
+            cache_root=cache_root,
+            refresh=False,
+            progress=progress,
         )
-        with _manifest_transaction(root) as manifest:
-            _, ckpt = _ensure_manifest_entry(manifest, root, env_name, checkpoint)
-            if ok:
-                ckpt.verified_at = now_iso()
-                ckpt.verified_device = device
-                ckpt.last_error = None
-                verified_at = ckpt.verified_at
-                verified_device = ckpt.verified_device
-            else:
-                ckpt.verified_at = None
-                ckpt.verified_device = None
-                ckpt.last_error = f"verify: {err}"
-        if not ok:
-            raise OperationError(f"verify failed: {err}")
-        _say(progress, f"  verified_at = {verified_at} ({device})")
 
     # Refresh + push (takes the lock for its own load -> refresh -> save)
     update_and_push_manifest(root, quiet=True, push=push)
 
     return AddResult(
-        env_name=env_name,
+        env_name=fetched.env_name,
         checkpoint=checkpoint,
-        fetched_at=fetched_at,
-        already_fetched=already_fetched,
-        verified_at=verified_at if verify else None,
-        verified_device=verified_device if verify else None,
+        fetched_at=fetched.fetched_at,
+        already_fetched=fetched.already_fetched,
+        verified_at=verified.verified_at if verified else None,
+        verified_device=verified.verified_device if verified else None,
     )

--- a/tests/commands/test_add_split.py
+++ b/tests/commands/test_add_split.py
@@ -1,0 +1,233 @@
+"""The fetch/verify split of ``add_checkpoint``.
+
+``fetch_checkpoint`` (CPU download, freely parallel) and
+``verify_fetched_checkpoint`` (GPU model load, bounded) are usable on their
+own so a batch driver can run the two phases at different times, in different
+jobs, with different concurrency. ``add_checkpoint`` is their composition and
+must behave exactly as before the split — including refreshing the manifest
+once, at the end, and not at all on failure.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rootstock import operations
+from rootstock.manifest import load_manifest
+from rootstock.operations import (
+    OperationError,
+    add_checkpoint,
+    fetch_checkpoint,
+    verify_fetched_checkpoint,
+)
+
+_MACE_ENV_SOURCE = '''\
+"""MACE env."""
+
+CHECKPOINTS = {
+    "mace-mp-0-medium": "medium",
+}
+
+
+def setup(checkpoint, device="cuda"):
+    return None
+'''
+
+
+@pytest.fixture
+def fake_root(tmp_path: Path) -> Path:
+    """A minimal rootstock root with a fake mace env and a manifest."""
+    root = tmp_path
+    env_dir = root / "envs" / "mace"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+    (env_dir / "env_source.py").write_text(_MACE_ENV_SOURCE)
+
+    from rootstock.config import UserConfig
+    from rootstock.manifest import create_manifest, save_manifest
+
+    cfg = UserConfig(name="t", email="t@t.t")
+    save_manifest(create_manifest(root, "test", cfg), root)
+    return root
+
+
+@pytest.fixture
+def refresh_calls(monkeypatch) -> list:
+    """Stub update_and_push_manifest, recording each call."""
+    calls: list = []
+
+    def fake_refresh(*args, **kwargs):
+        calls.append((args, kwargs))
+        return True
+
+    monkeypatch.setattr(operations, "update_and_push_manifest", fake_refresh)
+    return calls
+
+
+def _ckpt(root: Path):
+    return load_manifest(root).environments["mace"].checkpoints["mace-mp-0-medium"]
+
+
+# ---------- fetch_checkpoint ------------------------------------------------
+
+
+def test_fetch_records_fetched_at(fake_root, refresh_calls, monkeypatch):
+    monkeypatch.setattr(operations, "_run_download", lambda *a, **kw: (True, None))
+
+    result = fetch_checkpoint(fake_root, "mace-mp-0-medium")
+
+    assert result.env_name == "mace"
+    assert result.fetched_at is not None
+    assert not result.already_fetched
+    ckpt = _ckpt(fake_root)
+    assert ckpt.fetched_at == result.fetched_at
+    assert ckpt.verified_at is None
+    assert ckpt.last_error is None
+
+
+def test_fetch_is_idempotent(fake_root, refresh_calls, monkeypatch):
+    downloads = []
+    monkeypatch.setattr(
+        operations, "_run_download", lambda *a, **kw: (downloads.append(a), (True, None))[1]
+    )
+
+    first = fetch_checkpoint(fake_root, "mace-mp-0-medium")
+    second = fetch_checkpoint(fake_root, "mace-mp-0-medium")
+
+    assert len(downloads) == 1, "download should only happen once"
+    assert second.already_fetched
+    assert second.fetched_at == first.fetched_at
+
+
+def test_fetch_failure_records_last_error_and_raises(fake_root, refresh_calls, monkeypatch):
+    monkeypatch.setattr(
+        operations, "_run_download", lambda *a, **kw: (False, "ConnectionError: hub unreachable")
+    )
+
+    with pytest.raises(OperationError, match="download failed"):
+        fetch_checkpoint(fake_root, "mace-mp-0-medium")
+
+    ckpt = _ckpt(fake_root)
+    assert ckpt.fetched_at is None
+    assert ckpt.last_error.startswith("download:")
+
+
+def test_fetch_refresh_knob(fake_root, refresh_calls, monkeypatch):
+    monkeypatch.setattr(operations, "_run_download", lambda *a, **kw: (True, None))
+
+    fetch_checkpoint(fake_root, "mace-mp-0-medium", refresh=False)
+    assert refresh_calls == [], "refresh=False must skip update_and_push_manifest"
+
+    fetch_checkpoint(fake_root, "mace-mp-0-medium")
+    assert len(refresh_calls) == 1
+
+
+def test_fetch_fails_fast_when_env_not_built(tmp_path, refresh_calls):
+    from rootstock.config import UserConfig
+    from rootstock.manifest import create_manifest, save_manifest
+
+    save_manifest(create_manifest(tmp_path, "test", UserConfig(name="t", email="t@t.t")), tmp_path)
+    env_dir = tmp_path / "envs" / "mace"
+    env_dir.mkdir(parents=True)
+    (env_dir / "env_source.py").write_text(_MACE_ENV_SOURCE)  # declared but not built
+
+    with pytest.raises(OperationError, match="not built"):
+        fetch_checkpoint(tmp_path, "mace-mp-0-medium")
+
+
+# ---------- verify_fetched_checkpoint ----------------------------------------
+
+
+def test_verify_records_outcome(fake_root, refresh_calls, monkeypatch):
+    monkeypatch.setattr(operations, "verify_checkpoint", lambda *a, **kw: (True, None))
+
+    result = verify_fetched_checkpoint(fake_root, "mace-mp-0-medium", device="cuda")
+
+    assert result.env_name == "mace"
+    assert result.verified_device == "cuda"
+    ckpt = _ckpt(fake_root)
+    assert ckpt.verified_at == result.verified_at
+    assert ckpt.verified_device == "cuda"
+    assert ckpt.last_error is None
+
+
+def test_verify_failure_clears_stamps_and_raises(fake_root, refresh_calls, monkeypatch):
+    monkeypatch.setattr(
+        operations, "verify_checkpoint", lambda *a, **kw: (False, "RuntimeError: CUDA OOM")
+    )
+
+    with pytest.raises(OperationError, match="verify failed"):
+        verify_fetched_checkpoint(fake_root, "mace-mp-0-medium")
+
+    ckpt = _ckpt(fake_root)
+    assert ckpt.verified_at is None
+    assert ckpt.verified_device is None
+    assert "CUDA OOM" in ckpt.last_error
+    assert ckpt.last_error.startswith("verify:")
+
+
+def test_verify_refresh_knob(fake_root, refresh_calls, monkeypatch):
+    monkeypatch.setattr(operations, "verify_checkpoint", lambda *a, **kw: (True, None))
+
+    verify_fetched_checkpoint(fake_root, "mace-mp-0-medium", refresh=False)
+    assert refresh_calls == [], "refresh=False must skip update_and_push_manifest"
+
+    verify_fetched_checkpoint(fake_root, "mace-mp-0-medium")
+    assert len(refresh_calls) == 1
+
+
+def test_verify_forwards_device_and_kwargs(fake_root, refresh_calls, monkeypatch):
+    captured = {}
+
+    def fake_verify(root, env_name, checkpoint, device, setup_kwargs, **_):
+        captured["device"] = device
+        captured["setup_kwargs"] = setup_kwargs
+        return True, None
+
+    monkeypatch.setattr(operations, "verify_checkpoint", fake_verify)
+
+    verify_fetched_checkpoint(
+        fake_root, "mace-mp-0-medium", device="cuda:1", setup_kwargs={"task": "omat"}
+    )
+
+    assert captured["device"] == "cuda:1"
+    assert captured["setup_kwargs"] == {"task": "omat"}
+    assert _ckpt(fake_root).verified_device == "cuda:1"
+
+
+# ---------- add_checkpoint (the composition) ---------------------------------
+
+
+def test_add_refreshes_manifest_exactly_once(fake_root, refresh_calls, monkeypatch):
+    monkeypatch.setattr(operations, "_run_download", lambda *a, **kw: (True, None))
+    monkeypatch.setattr(operations, "verify_checkpoint", lambda *a, **kw: (True, None))
+
+    result = add_checkpoint(fake_root, "mace-mp-0-medium")
+
+    assert len(refresh_calls) == 1, "add must refresh once, at the end"
+    assert result.fetched_at is not None
+    assert result.verified_at is not None
+    assert result.verified_device == "cuda"
+
+
+def test_add_no_verify_skips_verify_fields(fake_root, refresh_calls, monkeypatch):
+    monkeypatch.setattr(operations, "_run_download", lambda *a, **kw: (True, None))
+
+    result = add_checkpoint(fake_root, "mace-mp-0-medium", verify=False)
+
+    assert result.verified_at is None
+    assert result.verified_device is None
+    assert len(refresh_calls) == 1
+
+
+def test_add_failure_skips_the_trailing_refresh(fake_root, refresh_calls, monkeypatch):
+    """Pre-split behavior: a failed add records last_error but never reaches
+    the final refresh."""
+    monkeypatch.setattr(operations, "_run_download", lambda *a, **kw: (False, "boom"))
+
+    with pytest.raises(OperationError):
+        add_checkpoint(fake_root, "mace-mp-0-medium")
+
+    assert refresh_calls == []


### PR DESCRIPTION
Closes #184. Part of the `rootstock sync` batch-admin work (#182).

## What

`add_checkpoint` did download + verify + full manifest refresh as one unit. The sync executor (#185) needs the halves as separately drivable operations — downloads parallelize freely on CPU (login-node-safe), while each verify loads a full model onto the GPU and must stay concurrency-bounded — potentially running in different jobs (`--phases download` on a login node, `--phases verify` in a GPU allocation).

## How

Behavior-preserving refactor of the existing internals (both halves already ran outside the manifest lock and recorded through `_manifest_transaction`):

- **`fetch_checkpoint(root, checkpoint, *, setup_kwargs, cache_root, refresh, push, progress) -> FetchResult`** — the download half: unlocked idempotence peek, CPU-side `_run_download`, records `fetched_at`/`last_error` in its own transaction.
- **`verify_fetched_checkpoint(root, checkpoint, *, device, setup_kwargs, cache_root, refresh, push, progress) -> VerifyResult`** — the verify half: runs `verify_checkpoint` on `device`, stamps `verified_at`/`verified_device` and clears `last_error` on success, clears the stamps and records the error on failure. (A prior fetch isn't a hard precondition — verification loads through the same cache-aware path.)
- Both take **`refresh=False`** to skip the trailing full `update_and_push_manifest`, so a batch of N operations doesn't re-run the full refresh N times; the driver refreshes once at the end.
- **`add_checkpoint` is now their composition** with `refresh=False` internally and the single refresh+push at the end — CLI behavior, manifest recording semantics, and the failure-skips-refresh property are all unchanged (pinned by tests).
- The shared resolve-and-fail-fast preamble is extracted as `_resolve_built_env`.

The op-level verify function is deliberately *not* named `verify_checkpoint`: that name in the operations namespace is the low-level in-env verifier (and existing tests monkeypatch it there), so reusing it would silently change what those patches intercept.

## Tests

`tests/commands/test_add_split.py`: fetch records/idempotence/failure/refresh-knob/fail-fast, verify records/failure/refresh-knob/device+kwargs forwarding, and composition pins (exactly one refresh, `--no-verify` fields, failure skips the refresh). Full suite green (627 passed, 2 skipped) across four runs; one unrelated test flaked once in a fifth run before pytest's lastfailed cache was overwritten — I couldn't recover its name, mentioning it for transparency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)