### PR TITLE
Add more requested model configs

### DIFF
--- a/sample_model_configurations/_agent/failure_modes.md
+++ b/sample_model_configurations/_agent/failure_modes.md
@@ -309,6 +309,9 @@ were already resolved under the strict `explicit` rules.
 ROCm math libraries: ~2x the CUDA wheel. One venv is ~15-17 GB installed.
 **Fix:** Put the venv root AND the uv cache on a large volume, not the
 container/boot disk. Budget ~15-17 GB per env plus ~20 GB of shared wheel cache.
+On filesystems without reflink support (overlayfs), uv's default clone mode
+falls back to full copies — set `UV_LINK_MODE=hardlink` so venvs hardlink from
+the cache and each extra env costs ~nothing on top of it.
 
 ## torch-scatter / torch-sparse on ROCm: no wheels, must source-build
 

--- a/sample_model_configurations/amd_configs/allscaip.py
+++ b/sample_model_configurations/amd_configs/allscaip.py
@@ -1,0 +1,53 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "fairchem-core>=2.20",
+#     "ase>=3.22",
+#     "torch>=2.4.0",
+#     # torch's ROCm wheels depend on this; it lives only on the ROCm
+#     # index, so it must be a direct dep for [tool.uv.sources] to route it.
+#     "pytorch-triton-rocm",
+# ]
+#
+# [tool.uv.sources]
+# torch = { index = "pytorch-rocm" }
+# pytorch-triton-rocm = { index = "pytorch-rocm" }
+#
+# [[tool.uv.index]]
+# name = "pytorch-rocm"
+# url = "https://download.pytorch.org/whl/rocm6.4"
+# explicit = true
+# ///
+"""AllScAIP env (ROCm) — FAIRChem scalable attention MLIP trained on OMol25.
+
+Identical to nvidia_configs/allscaip.py except torch resolves from the ROCm
+wheel index. fairchem-core v2 is a plain PyPI install (no
+torch-geometric/pyg-find-links), and AllScAIP's all-to-all attention lives
+in-package with no flash-attention or custom CUDA kernels — so the only ROCm
+change is the torch wheel index.
+
+OMol checkpoints expect `charge` and `spin` in `atoms.info`.
+"""
+
+CHECKPOINTS = {
+    "allscaip-md-conserving-all-omol": "allscaip-md-conserving-all-omol",
+    # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
+    "allscaip:custom": None,
+}
+
+
+def setup(checkpoint: str, device: str = "cuda"):
+    from fairchem.core import FAIRChemCalculator, pretrained_mlip
+
+    predictor = pretrained_mlip.get_predict_unit(CHECKPOINTS[checkpoint], device=device)
+    return FAIRChemCalculator(predictor)
+
+
+def setup_from_path(path: str, device: str = "cuda"):
+    # Custom checkpoints (`:custom` ids with user weights): a weights *file* loads through
+    # load_predict_unit, not the registry-name lookup setup() uses.
+    from fairchem.core import FAIRChemCalculator
+    from fairchem.core.units.mlip_unit import load_predict_unit
+
+    predictor = load_predict_unit(path, device=device)
+    return FAIRChemCalculator(predictor)

--- a/sample_model_configurations/amd_configs/allscaip.py
+++ b/sample_model_configurations/amd_configs/allscaip.py
@@ -21,18 +21,16 @@
 """AllScAIP env (ROCm) — FAIRChem scalable attention MLIP trained on OMol25.
 
 Identical to nvidia_configs/allscaip.py except torch resolves from the ROCm
-wheel index. fairchem-core v2 is a plain PyPI install (no
-torch-geometric/pyg-find-links), and AllScAIP's all-to-all attention lives
-in-package with no flash-attention or custom CUDA kernels — so the only ROCm
-change is the torch wheel index. On ROCm fairchem logs "Fallback to math
-attention for gradient based force prediction": same numbers, slower
-attention path.
+wheel index; AllScAIP has no flash-attention or custom CUDA kernels, so
+nothing else changes. On ROCm fairchem falls back to math attention for
+gradient-based forces: same numbers, slower attention path.
 
 OMol checkpoints expect `charge` and `spin` in `atoms.info`.
 """
 
 CHECKPOINTS = {
     "allscaip-md-conserving-all-omol": "allscaip-md-conserving-all-omol",
+    "allscaip-md-direct-all-omol": "allscaip-md-direct-all-omol",
     # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
     "allscaip:custom": None,
 }

--- a/sample_model_configurations/amd_configs/allscaip.py
+++ b/sample_model_configurations/amd_configs/allscaip.py
@@ -24,7 +24,9 @@ Identical to nvidia_configs/allscaip.py except torch resolves from the ROCm
 wheel index. fairchem-core v2 is a plain PyPI install (no
 torch-geometric/pyg-find-links), and AllScAIP's all-to-all attention lives
 in-package with no flash-attention or custom CUDA kernels — so the only ROCm
-change is the torch wheel index.
+change is the torch wheel index. On ROCm fairchem logs "Fallback to math
+attention for gradient based force prediction": same numbers, slower
+attention path.
 
 OMol checkpoints expect `charge` and `spin` in `atoms.info`.
 """

--- a/sample_model_configurations/amd_configs/mace.py
+++ b/sample_model_configurations/amd_configs/mace.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.11"
 # dependencies = [
 #     # 0.3.15+ needed for the mh-1 registry entry (matpes needs 0.3.13,
-#     # mpa-0 needs 0.3.10).
+#     # omol needs 0.3.14, mpa-0 needs 0.3.10).
 #     "mace-torch>=0.3.15",
 #     "ase>=3.22",
 #     # 2.4.1 is explicitly unsupported by mace-torch.
@@ -29,11 +29,13 @@ unchanged. cuEquivariance acceleration is CUDA-only and is not used here  -
 MACE falls back to the pure e3nn/torch path.
 
 Upstream-string routing in CHECKPOINTS: an `off:` prefix routes to mace_off()
-instead of mace_mp(); a `@head` suffix selects a head of a multi-head model
-(loaded in float64, per the MACE-MH-1 model card).
+and an `omol:` prefix to mace_omol() (float64, molecules only, reads `charge`
+and `spin` from atoms.info); a `@head` suffix selects a head of a multi-head
+model (loaded in float64, per the MACE-MH-1 model card).
 
-License: mace-matpes-r2scan-0 and mace-mh-1 heads are under the Academic
-Software License (ASL) — academic/non-commercial use only. The rest are MIT.
+License: mace-matpes-r2scan-0, mace-mh-1 heads, and mace-omol-0 are under the
+Academic Software License (ASL) — academic/non-commercial use only. The rest
+are MIT.
 """
 
 CHECKPOINTS = {
@@ -48,9 +50,10 @@ CHECKPOINTS = {
     "mace-mpa-0-medium": "medium-mpa-0",
     "mace-matpes-r2scan-0": "mace-matpes-r2scan-0",
     "mace-mh-1-matpes-r2scan": "mh-1@matpes_r2scan",
+    # Only the extra-large OMOL model has been released.
+    "mace-omol-0-extra-large": "omol:extra_large",
     # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
-    "mace-mp:custom": None,
-    "mace-off23:custom": None,
+    "mace:custom": None,
 }
 
 
@@ -60,6 +63,10 @@ def setup(checkpoint: str, device: str = "cuda"):
         from mace.calculators import mace_off
 
         return mace_off(model=arg[4:], device=device, default_dtype="float32")
+    if arg.startswith("omol:"):
+        from mace.calculators import mace_omol
+
+        return mace_omol(model=arg[5:], device=device, default_dtype="float64")
     from mace.calculators import mace_mp
 
     if "@" in arg:

--- a/sample_model_configurations/amd_configs/mace.py
+++ b/sample_model_configurations/amd_configs/mace.py
@@ -29,13 +29,11 @@ unchanged. cuEquivariance acceleration is CUDA-only and is not used here  -
 MACE falls back to the pure e3nn/torch path.
 
 Upstream-string routing in CHECKPOINTS: an `off:` prefix routes to mace_off()
-and an `omol:` prefix to mace_omol() (float64, molecules only, reads `charge`
-and `spin` from atoms.info); a `@head` suffix selects a head of a multi-head
-model (loaded in float64, per the MACE-MH-1 model card).
+and an `omol:` prefix to mace_omol() (float64, molecules only); a `@head`
+suffix selects a head of a multi-head model (loaded in float64, per the
+MACE-MH-1 model card).
 
-License: mace-matpes-r2scan-0, mace-mh-1 heads, and mace-omol-0 are under the
-Academic Software License (ASL) — academic/non-commercial use only. The rest
-are MIT.
+The OMOL checkpoint expects `charge` and `spin` in `atoms.info`.
 """
 
 CHECKPOINTS = {

--- a/sample_model_configurations/amd_configs/mace.py
+++ b/sample_model_configurations/amd_configs/mace.py
@@ -1,9 +1,12 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#     "mace-torch>=0.3.0",
+#     # 0.3.15+ needed for the mh-1 registry entry (matpes needs 0.3.13,
+#     # mpa-0 needs 0.3.10).
+#     "mace-torch>=0.3.15",
 #     "ase>=3.22",
-#     "torch>=2.4.0,<2.10",
+#     # 2.4.1 is explicitly unsupported by mace-torch.
+#     "torch>=2.4.0,!=2.4.1,<2.10",
 #     # torch's ROCm wheels depend on this; it lives only on the ROCm
 #     # index, so it must be a direct dep for [tool.uv.sources] to route it.
 #     "pytorch-triton-rocm",
@@ -18,12 +21,19 @@
 # url = "https://download.pytorch.org/whl/rocm6.4"
 # explicit = true
 # ///
-"""MACE env (ROCm) - MACE-MP-0 and MACE-OFF23 on AMD GPUs.
+"""MACE env (ROCm) - MACE checkpoints on AMD GPUs.
 
 Identical to nvidia_configs/mace.py except torch resolves from the ROCm wheel
 index. PyTorch ROCm builds expose AMD GPUs as device="cuda", so setup() is
 unchanged. cuEquivariance acceleration is CUDA-only and is not used here  -
 MACE falls back to the pure e3nn/torch path.
+
+Upstream-string routing in CHECKPOINTS: an `off:` prefix routes to mace_off()
+instead of mace_mp(); a `@head` suffix selects a head of a multi-head model
+(loaded in float64, per the MACE-MH-1 model card).
+
+License: mace-matpes-r2scan-0 and mace-mh-1 heads are under the Academic
+Software License (ASL) — academic/non-commercial use only. The rest are MIT.
 """
 
 CHECKPOINTS = {
@@ -33,6 +43,11 @@ CHECKPOINTS = {
     "mace-off23-small": "off:small",
     "mace-off23-medium": "off:medium",
     "mace-off23-large": "off:large",
+    # Only a medium MPA-0 has been released, but upstream names the weights
+    # file mace-mpa-0-medium.model — keep the size explicit like mace-mp-0.
+    "mace-mpa-0-medium": "medium-mpa-0",
+    "mace-matpes-r2scan-0": "mace-matpes-r2scan-0",
+    "mace-mh-1-matpes-r2scan": "mh-1@matpes_r2scan",
     # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
     "mace-mp:custom": None,
     "mace-off23:custom": None,
@@ -47,6 +62,9 @@ def setup(checkpoint: str, device: str = "cuda"):
         return mace_off(model=arg[4:], device=device, default_dtype="float32")
     from mace.calculators import mace_mp
 
+    if "@" in arg:
+        model, head = arg.split("@", 1)
+        return mace_mp(model=model, device=device, default_dtype="float64", head=head)
     return mace_mp(model=arg, device=device, default_dtype="float32")
 
 

--- a/sample_model_configurations/amd_configs/mace_polar.py
+++ b/sample_model_configurations/amd_configs/mace_polar.py
@@ -26,8 +26,7 @@
 
 Identical to nvidia_configs/mace_polar.py except torch resolves from the ROCm
 wheel index. Kept separate from the stable `mace` env because of the extra
-git-only graph-longrange dependency. Loaded via mace_polar(), a separate
-route from the mace_mp()/mace_off() loaders.
+git-only graph-longrange dependency.
 
 POLAR checkpoints expect `charge`, `spin`, and `external_field` in atoms.info.
 """

--- a/sample_model_configurations/amd_configs/mace_polar.py
+++ b/sample_model_configurations/amd_configs/mace_polar.py
@@ -8,13 +8,26 @@
 #     # PolarMACE imports graph_longrange at runtime; the distribution is named
 #     # graph-longrange and exists only as this git repo (no PyPI release).
 #     "graph-longrange @ git+https://github.com/WillBaldwin0/graph_electrostatics.git",
+#     # torch's ROCm wheels depend on this; it lives only on the ROCm
+#     # index, so it must be a direct dep for [tool.uv.sources] to route it.
+#     "pytorch-triton-rocm",
 # ]
+#
+# [tool.uv.sources]
+# torch = { index = "pytorch-rocm" }
+# pytorch-triton-rocm = { index = "pytorch-rocm" }
+#
+# [[tool.uv.index]]
+# name = "pytorch-rocm"
+# url = "https://download.pytorch.org/whl/rocm6.4"
+# explicit = true
 # ///
-"""MACE-POLAR env — electrostatic/polarizable MACE foundation models (OMol25).
+"""MACE-POLAR env (ROCm) — electrostatic/polarizable MACE foundation models.
 
-Kept separate from the stable `mace` env because of the extra git-only
-graph-longrange dependency. Loaded via mace_polar(), a separate route from
-the mace_mp()/mace_off() loaders.
+Identical to nvidia_configs/mace_polar.py except torch resolves from the ROCm
+wheel index. Kept separate from the stable `mace` env because of the extra
+git-only graph-longrange dependency. Loaded via mace_polar(), a separate
+route from the mace_mp()/mace_off() loaders.
 
 POLAR checkpoints expect `charge`, `spin`, and `external_field` in atoms.info.
 """

--- a/sample_model_configurations/amd_configs/mace_polar.py
+++ b/sample_model_configurations/amd_configs/mace_polar.py
@@ -35,6 +35,8 @@ CHECKPOINTS = {
     "mace-polar-1-s": "polar-1-s",
     "mace-polar-1-m": "polar-1-m",
     "mace-polar-1-l": "polar-1-l",
+    # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
+    "mace-polar:custom": None,
 }
 
 
@@ -42,3 +44,11 @@ def setup(checkpoint: str, device: str = "cuda"):
     from mace.calculators import mace_polar
 
     return mace_polar(model=CHECKPOINTS[checkpoint], device=device, default_dtype="float32")
+
+
+def setup_from_path(path: str, device: str = "cuda"):
+    # Custom checkpoints (`:custom` ids with user weights): mace_polar() accepts a
+    # weights file directly, keeping the PolarMACE model-type wiring.
+    from mace.calculators import mace_polar
+
+    return mace_polar(model=path, device=device, default_dtype="float32")

--- a/sample_model_configurations/nvidia_configs/allscaip.py
+++ b/sample_model_configurations/nvidia_configs/allscaip.py
@@ -18,6 +18,7 @@ OMol checkpoints expect `charge` and `spin` in `atoms.info`.
 
 CHECKPOINTS = {
     "allscaip-md-conserving-all-omol": "allscaip-md-conserving-all-omol",
+    "allscaip-md-direct-all-omol": "allscaip-md-direct-all-omol",
     # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
     "allscaip:custom": None,
 }

--- a/sample_model_configurations/nvidia_configs/grace.py
+++ b/sample_model_configurations/nvidia_configs/grace.py
@@ -7,17 +7,11 @@
 # ///
 """GRACE env — hosts GRACE foundation checkpoints via tensorpotential.
 
-GRACE runs on TensorFlow, not torch — tensorpotential pulls
-tensorflow[and-cuda] itself (pip-shipped CUDA/cuDNN, so the node's NVIDIA
-driver must be compatible). TPCalculator has no device argument: TF grabs
-whatever GPU it sees, so device selection happens via CUDA_VISIBLE_DEVICES,
-and both it and TF_USE_LEGACY_KERAS must be set before the first TF import.
-Weights download ungated from the AMS-ICAMS-RUB HF repo into ~/.cache/grace
-under the redirected HOME. The first calculation triggers an XLA compile —
+GRACE runs on TensorFlow, not torch. TPCalculator has no device argument:
+TF grabs whatever GPU it sees, so device selection happens via
+CUDA_VISIBLE_DEVICES, and both it and TF_USE_LEGACY_KERAS must be set
+before the first TF import. The first calculation triggers an XLA compile —
 a slow first step is expected.
-
-License: code and all GRACE foundation models are under the Academic
-Software License (ASL) — academic/non-commercial use only.
 """
 
 CHECKPOINTS = {

--- a/sample_model_configurations/nvidia_configs/grace.py
+++ b/sample_model_configurations/nvidia_configs/grace.py
@@ -1,0 +1,40 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "tensorpotential>=0.6.0",
+#     "ase>=3.22",
+# ]
+# ///
+"""GRACE env — hosts GRACE foundation checkpoints via tensorpotential.
+
+GRACE runs on TensorFlow, not torch — tensorpotential pulls
+tensorflow[and-cuda] itself (pip-shipped CUDA/cuDNN, so the node's NVIDIA
+driver must be compatible). TPCalculator has no device argument: TF grabs
+whatever GPU it sees, so device selection happens via CUDA_VISIBLE_DEVICES,
+and both it and TF_USE_LEGACY_KERAS must be set before the first TF import.
+Weights download ungated from the AMS-ICAMS-RUB HF repo into ~/.cache/grace
+under the redirected HOME. The first calculation triggers an XLA compile —
+a slow first step is expected.
+
+License: code and all GRACE foundation models are under the Academic
+Software License (ASL) — academic/non-commercial use only.
+"""
+
+CHECKPOINTS = {
+    "grace-2l-smax-omat-large": "GRACE-2L-SMAX-OMAT-large",
+    "grace-3l-omat-large-ft-am": "GRACE-3L-OMAT-large-ft-AM",
+}
+
+
+def setup(checkpoint: str, device: str = "cuda"):
+    import os
+
+    os.environ["TF_USE_LEGACY_KERAS"] = "1"
+    if device == "cpu":
+        os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
+    elif device.startswith("cuda:"):
+        os.environ["CUDA_VISIBLE_DEVICES"] = device.split(":", 1)[1]
+
+    from tensorpotential.calculator import grace_fm
+
+    return grace_fm(CHECKPOINTS[checkpoint])

--- a/sample_model_configurations/nvidia_configs/mace.py
+++ b/sample_model_configurations/nvidia_configs/mace.py
@@ -1,16 +1,23 @@
 # /// script
 # requires-python = ">=3.11"
 # dependencies = [
-#     "mace-torch>=0.3.0",
+#     # 0.3.15+ needed for the mh-1 registry entry (matpes needs 0.3.13,
+#     # mpa-0 needs 0.3.10).
+#     "mace-torch>=0.3.15",
 #     "ase>=3.22",
-#     "torch>=2.4.0,<2.10",
+#     # 2.4.1 is explicitly unsupported by mace-torch.
+#     "torch>=2.4.0,!=2.4.1,<2.10",
 # ]
 # ///
-"""MACE env — hosts MACE-MP-0 and MACE-OFF23 checkpoints.
+"""MACE env — hosts MACE-MP-0, MACE-OFF23, MPA-0, MATPES, and MH-1 checkpoints.
 
-Both ship in the same `mace-torch` package, so they share an environment.
-The `off:` prefix on the upstream string in CHECKPOINTS routes to mace_off()
-instead of mace_mp().
+All ship in the same `mace-torch` package, so they share an environment.
+Upstream-string routing in CHECKPOINTS: an `off:` prefix routes to mace_off()
+instead of mace_mp(); a `@head` suffix selects a head of a multi-head model
+(loaded in float64, per the MACE-MH-1 model card).
+
+License: mace-matpes-r2scan-0 and mace-mh-1 heads are under the Academic
+Software License (ASL) — academic/non-commercial use only. The rest are MIT.
 """
 
 CHECKPOINTS = {
@@ -20,6 +27,11 @@ CHECKPOINTS = {
     "mace-off23-small": "off:small",
     "mace-off23-medium": "off:medium",
     "mace-off23-large": "off:large",
+    # Only a medium MPA-0 has been released, but upstream names the weights
+    # file mace-mpa-0-medium.model — keep the size explicit like mace-mp-0.
+    "mace-mpa-0-medium": "medium-mpa-0",
+    "mace-matpes-r2scan-0": "mace-matpes-r2scan-0",
+    "mace-mh-1-matpes-r2scan": "mh-1@matpes_r2scan",
     # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
     "mace-mp:custom": None,
     "mace-off23:custom": None,
@@ -34,6 +46,9 @@ def setup(checkpoint: str, device: str = "cuda"):
         return mace_off(model=arg[4:], device=device, default_dtype="float32")
     from mace.calculators import mace_mp
 
+    if "@" in arg:
+        model, head = arg.split("@", 1)
+        return mace_mp(model=model, device=device, default_dtype="float64", head=head)
     return mace_mp(model=arg, device=device, default_dtype="float32")
 
 

--- a/sample_model_configurations/nvidia_configs/mace.py
+++ b/sample_model_configurations/nvidia_configs/mace.py
@@ -13,13 +13,11 @@
 
 All ship in the same `mace-torch` package, so they share an environment.
 Upstream-string routing in CHECKPOINTS: an `off:` prefix routes to mace_off()
-and an `omol:` prefix to mace_omol() (float64, molecules only, reads `charge`
-and `spin` from atoms.info); a `@head` suffix selects a head of a multi-head
-model (loaded in float64, per the MACE-MH-1 model card).
+and an `omol:` prefix to mace_omol() (float64, molecules only); a `@head`
+suffix selects a head of a multi-head model (loaded in float64, per the
+MACE-MH-1 model card).
 
-License: mace-matpes-r2scan-0, mace-mh-1 heads, and mace-omol-0 are under the
-Academic Software License (ASL) — academic/non-commercial use only. The rest
-are MIT.
+The OMOL checkpoint expects `charge` and `spin` in `atoms.info`.
 """
 
 CHECKPOINTS = {

--- a/sample_model_configurations/nvidia_configs/mace.py
+++ b/sample_model_configurations/nvidia_configs/mace.py
@@ -33,8 +33,7 @@ CHECKPOINTS = {
     "mace-matpes-r2scan-0": "mace-matpes-r2scan-0",
     "mace-mh-1-matpes-r2scan": "mh-1@matpes_r2scan",
     # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
-    "mace-mp:custom": None,
-    "mace-off23:custom": None,
+    "mace:custom": None,
 }
 
 

--- a/sample_model_configurations/nvidia_configs/mace.py
+++ b/sample_model_configurations/nvidia_configs/mace.py
@@ -2,22 +2,24 @@
 # requires-python = ">=3.11"
 # dependencies = [
 #     # 0.3.15+ needed for the mh-1 registry entry (matpes needs 0.3.13,
-#     # mpa-0 needs 0.3.10).
+#     # omol needs 0.3.14, mpa-0 needs 0.3.10).
 #     "mace-torch>=0.3.15",
 #     "ase>=3.22",
 #     # 2.4.1 is explicitly unsupported by mace-torch.
 #     "torch>=2.4.0,!=2.4.1,<2.10",
 # ]
 # ///
-"""MACE env — hosts MACE-MP-0, MACE-OFF23, MPA-0, MATPES, and MH-1 checkpoints.
+"""MACE env — hosts MACE-MP-0, MACE-OFF23, MPA-0, MATPES, MH-1, and OMOL checkpoints.
 
 All ship in the same `mace-torch` package, so they share an environment.
 Upstream-string routing in CHECKPOINTS: an `off:` prefix routes to mace_off()
-instead of mace_mp(); a `@head` suffix selects a head of a multi-head model
-(loaded in float64, per the MACE-MH-1 model card).
+and an `omol:` prefix to mace_omol() (float64, molecules only, reads `charge`
+and `spin` from atoms.info); a `@head` suffix selects a head of a multi-head
+model (loaded in float64, per the MACE-MH-1 model card).
 
-License: mace-matpes-r2scan-0 and mace-mh-1 heads are under the Academic
-Software License (ASL) — academic/non-commercial use only. The rest are MIT.
+License: mace-matpes-r2scan-0, mace-mh-1 heads, and mace-omol-0 are under the
+Academic Software License (ASL) — academic/non-commercial use only. The rest
+are MIT.
 """
 
 CHECKPOINTS = {
@@ -32,6 +34,8 @@ CHECKPOINTS = {
     "mace-mpa-0-medium": "medium-mpa-0",
     "mace-matpes-r2scan-0": "mace-matpes-r2scan-0",
     "mace-mh-1-matpes-r2scan": "mh-1@matpes_r2scan",
+    # Only the extra-large OMOL model has been released.
+    "mace-omol-0-extra-large": "omol:extra_large",
     # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
     "mace:custom": None,
 }
@@ -43,6 +47,10 @@ def setup(checkpoint: str, device: str = "cuda"):
         from mace.calculators import mace_off
 
         return mace_off(model=arg[4:], device=device, default_dtype="float32")
+    if arg.startswith("omol:"):
+        from mace.calculators import mace_omol
+
+        return mace_omol(model=arg[5:], device=device, default_dtype="float64")
     from mace.calculators import mace_mp
 
     if "@" in arg:

--- a/sample_model_configurations/nvidia_configs/mace_polar.py
+++ b/sample_model_configurations/nvidia_configs/mace_polar.py
@@ -22,6 +22,8 @@ CHECKPOINTS = {
     "mace-polar-1-s": "polar-1-s",
     "mace-polar-1-m": "polar-1-m",
     "mace-polar-1-l": "polar-1-l",
+    # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
+    "mace-polar:custom": None,
 }
 
 
@@ -29,3 +31,11 @@ def setup(checkpoint: str, device: str = "cuda"):
     from mace.calculators import mace_polar
 
     return mace_polar(model=CHECKPOINTS[checkpoint], device=device, default_dtype="float32")
+
+
+def setup_from_path(path: str, device: str = "cuda"):
+    # Custom checkpoints (`:custom` ids with user weights): mace_polar() accepts a
+    # weights file directly, keeping the PolarMACE model-type wiring.
+    from mace.calculators import mace_polar
+
+    return mace_polar(model=path, device=device, default_dtype="float32")

--- a/sample_model_configurations/nvidia_configs/mace_polar.py
+++ b/sample_model_configurations/nvidia_configs/mace_polar.py
@@ -13,8 +13,7 @@
 """MACE-POLAR env — electrostatic/polarizable MACE foundation models (OMol25).
 
 Kept separate from the stable `mace` env because of the extra git-only
-graph-longrange dependency. Loaded via mace_polar(), a separate route from
-the mace_mp()/mace_off() loaders.
+graph-longrange dependency.
 
 POLAR checkpoints expect `charge`, `spin`, and `external_field` in atoms.info.
 """

--- a/sample_model_configurations/nvidia_configs/pet.py
+++ b/sample_model_configurations/nvidia_configs/pet.py
@@ -14,7 +14,7 @@
 The upstream string encodes model@version; versions are pinned rather than
 "latest" so rebuilds serve the same weights. pet-omatpes-l is trained at the
 r2SCAN level of theory — its energies are not comparable to the PBE-level
-pet-oam models. Weights download ungated from the lab-cosmo/upet HF repo.
+pet-oam models.
 """
 
 CHECKPOINTS = {

--- a/sample_model_configurations/nvidia_configs/pet.py
+++ b/sample_model_configurations/nvidia_configs/pet.py
@@ -1,0 +1,30 @@
+# /// script
+# requires-python = ">=3.11,<3.15"
+# dependencies = [
+#     "upet>=0.2.6",
+#     "ase>=3.22",
+#     # upet pulls nvalchemi-toolkit-ops unpinned; 0.4+ needs torch>=2.8 at
+#     # runtime but only declares the constraint on its extras, so the
+#     # resolver won't catch it (same trap as the tensornet env).
+#     "torch>=2.8,<2.14",
+# ]
+# ///
+"""PET env — hosts lab-cosmo's UPET foundation checkpoints (PET-MAD successor).
+
+The upstream string encodes model@version; versions are pinned rather than
+"latest" so rebuilds serve the same weights. pet-omatpes-l is trained at the
+r2SCAN level of theory — its energies are not comparable to the PBE-level
+pet-oam models. Weights download ungated from the lab-cosmo/upet HF repo.
+"""
+
+CHECKPOINTS = {
+    "pet-oam-xl": "pet-oam-xl@1.0.0",
+    "pet-omatpes-l": "pet-omatpes-l@0.1.0",
+}
+
+
+def setup(checkpoint: str, device: str = "cuda"):
+    from upet.calculator import UPETCalculator
+
+    model, version = CHECKPOINTS[checkpoint].split("@", 1)
+    return UPETCalculator(model=model, version=version, device=device)

--- a/sample_model_configurations/nvidia_configs/tace.py
+++ b/sample_model_configurations/nvidia_configs/tace.py
@@ -1,0 +1,35 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "tace",
+#     "ase>=3.22",
+#     "torch>=2.4,<2.14",
+# ]
+#
+# # The TECE architecture and its foundation registry ship in tace 0.2.0,
+# # which is not on PyPI (latest release there is 0.1.0). This is the commit
+# # the Matbench Discovery submission pinned.
+# [tool.uv.sources.tace]
+# git = "https://github.com/xvzemin/tace"
+# rev = "81f65a4c188bd09cec8d1419388f7afdcc1b6fd0"
+# ///
+"""TACE env — hosts TECE/TACE foundation checkpoints (Xu, Xie & Hu).
+
+Weights download ungated from the xvzemin/tace-foundations HF repo
+(CC-BY-4.0) into ~/.cache/tace, which lands in the shared cache via the
+redirected HOME. openequivariance CUDA-kernel acceleration is optional and
+sdist-only on PyPI, so it is not used here — TACE falls back to the e3nn
+path.
+"""
+
+CHECKPOINTS = {
+    "tece-oam-rra-1.0": "TECE-OAM-RRA-1.0",
+}
+
+
+def setup(checkpoint: str, device: str = "cuda"):
+    from tace.foundations import tace_foundations
+    from tace.interface.ase import TACEAseCalc
+
+    model_path = tace_foundations[CHECKPOINTS[checkpoint]]
+    return TACEAseCalc(model_path, device=device, dtype="float32")

--- a/sample_model_configurations/nvidia_configs/tace.py
+++ b/sample_model_configurations/nvidia_configs/tace.py
@@ -15,11 +15,8 @@
 # ///
 """TACE env — hosts TECE/TACE foundation checkpoints (Xu, Xie & Hu).
 
-Weights download ungated from the xvzemin/tace-foundations HF repo
-(CC-BY-4.0) into ~/.cache/tace, which lands in the shared cache via the
-redirected HOME. openequivariance CUDA-kernel acceleration is optional and
-sdist-only on PyPI, so it is not used here — TACE falls back to the e3nn
-path.
+openequivariance CUDA-kernel acceleration is optional upstream and not
+installed here — TACE runs on the e3nn path.
 """
 
 CHECKPOINTS = {


### PR DESCRIPTION
This PR adds some configurations requested by ORNL and Princeton collaborators.

One breaking-ish change: this PR changes the two mace custom ids to just one "mace:custom".