### PR TITLE
Pass through charge and spin info

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,12 @@ with RootstockCalculator(
 ) as calc:
     ...
 
+# atoms.info is forwarded to the worker every calculation (JSON-safe subset;
+# numpy converted, non-serializable values dropped with a debug log), so
+# OMol/POLAR checkpoints see charge/spin/external_field as if in-process.
+# An info-only change invalidates the cached result (check_state override).
+atoms.info["charge"] = 1
+
 # User-supplied weights (e.g. a fine-tune): use the "<family>:custom"
 # CHECKPOINTS entry for the model family (shown by `rootstock list`) and
 # pass the weights file. The entry only selects the hosting env (no shipped

--- a/docs/api.md
+++ b/docs/api.md
@@ -55,6 +55,26 @@ RootstockCalculator(
 )
 ```
 
+### Model inputs via `atoms.info`
+
+Keys set on `atoms.info` are forwarded to the worker on every calculation,
+so checkpoints that read calculate-time inputs from it — `charge` and `spin`
+for the OMol-era models (`uma-*` with `task="omol"`, `esen-*-all-omol`,
+`mace-omol-*`), plus `external_field` for `mace-polar-*` — behave exactly as
+they would in-process:
+
+```python
+atoms.info["charge"] = 1
+atoms.info["spin"] = 2
+energy_cation = atoms.get_potential_energy()  # differs from the neutral result
+```
+
+All JSON-serializable values are forwarded (numpy scalars and arrays are
+converted; numeric vectors arrive at the model as numpy arrays). Values that
+cannot be represented in JSON are dropped with a debug log. Changing only
+`atoms.info` on identical geometry correctly triggers a fresh calculation.
+LAMMPS-driven runs (`fix rootstock`) do not carry `atoms.info`.
+
 ### Context manager
 
 `RootstockCalculator` should be used as a context manager to ensure proper cleanup of the worker subprocess:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,12 +45,18 @@ the server packs the species into the INIT message's free-form init string
 as UTF-8 JSON:
 
 ```json
-{"numbers": [1, 1, 8], "pbc": [true, true, true]}
+{"numbers": [1, 1, 8], "pbc": [true, true, true], "info": {"charge": 1, "spin": 2}}
 ```
 
 A worker that has not received this payload fails at the first POSDATA.
 Unknown keys in the JSON object are ignored, which makes new keys a
 sanctioned forward-compatible extension channel.
+
+The `info` object carries the JSON-serializable subset of the client's
+`atoms.info` — model inputs like `charge`, `spin`, and `external_field`
+that OMol-era and POLAR checkpoints read at calculate-time. The worker
+applies it to its Atoms each cycle (numeric vectors become numpy arrays);
+the calculator drops non-serializable values with a debug log.
 
 **The worker demands INIT before every force evaluation.** After each
 FORCEREADY the worker returns to NEEDINIT rather than READY, and the server
@@ -65,7 +71,10 @@ Consequences:
 - The supported protocol peers are exactly `RootstockServer` (the ASE
   calculator path and `rootstock serve`'s counterpart) and
   `lammps/fix_rootstock.cpp` (which implements the dialect natively,
-  including the per-cycle INIT).
+  including the per-cycle INIT). `fix_rootstock` does not send the `info`
+  object, so LAMMPS-driven runs cannot carry `charge`/`spin`/
+  `external_field` — the worker sees an empty info and the model uses its
+  defaults.
 - This is a deliberate, documented limitation of 1.0. The worker side of the
   protocol is frozen inside every built environment, so the requirement
   cannot be relaxed for environments that have already been deployed.

--- a/rootstock/calculator.py
+++ b/rootstock/calculator.py
@@ -6,6 +6,7 @@ This is the main user-facing interface for Rootstock.
 
 from __future__ import annotations
 
+import json
 import logging
 import uuid
 from pathlib import Path
@@ -21,6 +22,40 @@ from .layout import ensure_layout_compatible, resolve_cache_root
 from .server import RootstockServer, WorkerDiedError
 
 logger = logging.getLogger("rootstock.calculator")
+
+
+def _json_safe_info(info: dict) -> dict:
+    """Extract the JSON-serializable subset of an ``atoms.info`` dict.
+
+    This is what crosses the socket in the INIT payload. Model-input keys
+    (``charge``, ``spin``, ``external_field``, ...) are scalars or small
+    numeric vectors, so all JSON-safe values are forwarded rather than a
+    whitelist — key names are model-ecosystem-dependent, and a whitelist
+    would silently drop the next model family's key. numpy scalars and
+    arrays are converted to native types; values that can't be represented
+    in JSON (and non-string keys) are dropped with a debug log, never a
+    crash.
+    """
+    safe = {}
+    for key, value in info.items():
+        if not isinstance(key, str):
+            logger.debug("Dropping atoms.info key %r: non-string key", key)
+            continue
+        if isinstance(value, np.generic):
+            value = value.item()
+        elif isinstance(value, np.ndarray):
+            value = value.tolist()
+        try:
+            json.dumps(value)
+        except (TypeError, ValueError):
+            logger.debug(
+                "Dropping atoms.info[%r]: %s is not JSON-serializable",
+                key,
+                type(value).__name__,
+            )
+            continue
+        safe[key] = value
+    return safe
 
 
 class RootstockCalculator(Calculator):
@@ -225,6 +260,25 @@ class RootstockCalculator(Calculator):
             server.start()
         return server
 
+    def check_state(self, atoms, tol=1e-15):
+        """Like ASE's, but an ``atoms.info`` change also invalidates results.
+
+        ASE's ``compare_atoms`` looks only at geometry (positions, numbers,
+        cell, pbc, initial charges/magmoms) — without this override, changing
+        only e.g. ``info["charge"]`` on identical geometry would serve the
+        cached result instead of reaching the worker. Only the forwarded
+        (JSON-safe) subset is compared: a key that can't cross the socket
+        can't change the result either.
+        """
+        system_changes = super().check_state(atoms, tol=tol)
+        if (
+            not system_changes
+            and self.atoms is not None
+            and _json_safe_info(atoms.info) != _json_safe_info(self.atoms.info)
+        ):
+            system_changes = ["info"]
+        return system_changes
+
     def calculate(
         self,
         atoms=None,
@@ -256,6 +310,7 @@ class RootstockCalculator(Calculator):
                 cell=np.array(calc_atoms.cell),
                 atomic_numbers=calc_atoms.numbers,
                 pbc=list(calc_atoms.pbc),
+                info=_json_safe_info(calc_atoms.info),
             )
         except WorkerDiedError:
             # A dead worker can't serve the next call either. Tear the server

--- a/rootstock/server.py
+++ b/rootstock/server.py
@@ -160,11 +160,6 @@ class RootstockServer:
         self._stdout_file = None
         self._stderr_file = None
 
-        # Track INIT state
-        self._init_sent = False
-        self._init_numbers: list[int] | None = None
-        self._init_pbc: list[bool] | None = None
-
         # Holds the spawn_in_env context (staged wrapper + sidecar) open for
         # the life of the worker process; stop() closes it.
         self._spawn_stack: contextlib.ExitStack | None = None
@@ -371,15 +366,23 @@ class RootstockServer:
         cell: np.ndarray,
         atomic_numbers: np.ndarray | None = None,
         pbc: list[bool] | None = None,
+        info: dict | None = None,
     ) -> tuple[float, np.ndarray, np.ndarray]:
         """
         Calculate energy and forces for given atomic configuration.
 
+        The worker returns to NEEDINIT after every force call, so the INIT
+        payload (species, pbc, info) is re-sent each cycle — mid-run changes
+        to any of them reach the worker.
+
         Args:
             positions: Nx3 array of atomic positions in Angstrom
             cell: 3x3 cell matrix in Angstrom
-            atomic_numbers: Atomic numbers array (sent in INIT on first call)
-            pbc: Periodic boundary conditions [x, y, z] (sent in INIT on first call)
+            atomic_numbers: Atomic numbers array (sent in INIT)
+            pbc: Periodic boundary conditions [x, y, z] (sent in INIT)
+            info: JSON-serializable ``atoms.info`` subset (sent in INIT) —
+                model inputs like ``charge``/``spin``/``external_field`` that
+                the worker applies to its Atoms.
 
         Returns:
             energy: Potential energy in eV
@@ -402,14 +405,9 @@ class RootstockServer:
                 # Send INIT with atomic species info
                 numbers = atomic_numbers.tolist() if atomic_numbers is not None else None
                 pbc_list = [bool(p) for p in pbc] if pbc is not None else [True, True, True]
-                init_data = {"numbers": numbers, "pbc": pbc_list}
+                init_data = {"numbers": numbers, "pbc": pbc_list, "info": info or {}}
                 init_bytes = json.dumps(init_data).encode("utf-8")
                 self._protocol.send_init(bead_index=0, init_string=init_bytes)
-
-                # Track what we sent
-                self._init_sent = True
-                self._init_numbers = numbers
-                self._init_pbc = pbc_list
 
                 self._protocol.send_status()
                 status = self._protocol.recv_status()

--- a/rootstock/worker.py
+++ b/rootstock/worker.py
@@ -29,6 +29,23 @@ if TYPE_CHECKING:
     from ase.calculators.calculator import Calculator
 
 
+def _info_value(value):
+    """Convert a JSON-decoded info value to what models expect on Atoms.
+
+    Numeric vectors (e.g. ``external_field``) arrive as JSON arrays; in-process
+    users store them on ``atoms.info`` as numpy arrays, so match that. Anything
+    non-numeric (or ragged) is kept as-is.
+    """
+    if isinstance(value, list) and value:
+        try:
+            arr = np.asarray(value)
+        except ValueError:
+            return value
+        if arr.dtype.kind in "biuf":
+            return arr
+    return value
+
+
 class MLIPWorker:
     """
     Worker that runs an MLIP calculator and communicates via i-PI protocol.
@@ -68,6 +85,11 @@ class MLIPWorker:
         # Atomic species info from INIT message
         self._atomic_numbers: list[int] | None = None
         self._pbc: list[bool] | None = None
+        # atoms.info payload from INIT; _applied_info is the raw JSON form
+        # last applied to the cached Atoms, kept for change detection (the
+        # applied values may be numpy arrays, which don't compare with ==).
+        self._info: dict = {}
+        self._applied_info: dict | None = None
 
     def _log(self, msg):
         if self.log:
@@ -101,6 +123,11 @@ class MLIPWorker:
         (not just the atom count) matters: the server re-sends INIT every
         cycle, so a same-count composition or PBC change must not silently
         reuse the old system.
+
+        The INIT-supplied atoms.info payload is applied on both paths. When
+        only the info changed, the attached calculator's result cache is
+        reset: ASE's compare_atoms looks at geometry only, so without the
+        reset an info-only change (e.g. charge) would serve stale results.
         """
         from ase import Atoms
 
@@ -123,11 +150,19 @@ class MLIPWorker:
                 cell=cell,
                 pbc=pbc,
             )
+            self._atoms.info = {k: _info_value(v) for k, v in self._info.items()}
+            self._applied_info = self._info
             self._atoms.calc = self._calculator
         else:
             # Update existing object (faster - reuses neighbor lists etc.)
             self._atoms.positions = positions
             self._atoms.cell = cell
+            if self._info != self._applied_info:
+                self._atoms.info = {k: _info_value(v) for k, v in self._info.items()}
+                self._applied_info = self._info
+                reset = getattr(self._calculator, "reset", None)
+                if reset is not None:
+                    reset()
 
         return self._atoms
 
@@ -210,6 +245,8 @@ class MLIPWorker:
                             init_data = json.loads(init_bytes.decode("utf-8"))
                             self._atomic_numbers = init_data.get("numbers")
                             self._pbc = init_data.get("pbc", [True, True, True])
+                            info = init_data.get("info")
+                            self._info = info if isinstance(info, dict) else {}
                             self._log(
                                 f"Received INIT (bead={bead_index}, "
                                 f"atoms={len(self._atomic_numbers) if self._atomic_numbers else 0})"

--- a/tests/calculator/test_info_forwarding.py
+++ b/tests/calculator/test_info_forwarding.py
@@ -1,0 +1,104 @@
+"""Client-side atoms.info handling: JSON-safe extraction and cache invalidation.
+
+ASE's compare_atoms ignores atoms.info, so RootstockCalculator overrides
+check_state — an info-only change (charge, spin, external_field) must reach
+the worker, not be served from the cached result.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from ase import Atoms
+
+from rootstock.calculator import RootstockCalculator, _json_safe_info
+
+_MACE_ENV_SOURCE = '''\
+"""MACE env."""
+
+CHECKPOINTS = {
+    "mace-mp-0-medium": "medium",
+}
+
+
+def setup(checkpoint, device="cuda"):
+    return None
+'''
+
+
+@pytest.fixture
+def fake_root(tmp_path: Path) -> Path:
+    """A fake install root with one env (mace) declaring mace-mp-0-medium."""
+    env_dir = tmp_path / "envs" / "mace"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+    (env_dir / "env_source.py").write_text(_MACE_ENV_SOURCE)
+    return tmp_path
+
+
+def _calc_with_state(fake_root: Path, atoms: Atoms) -> RootstockCalculator:
+    """A calculator that behaves as if it already calculated `atoms`."""
+    calc = RootstockCalculator(checkpoint="mace-mp-0-medium", root=fake_root)
+    calc.atoms = atoms.copy()
+    return calc
+
+
+def _h2(**info) -> Atoms:
+    atoms = Atoms("H2", positions=[[0, 0, 0], [0, 0, 0.74]])
+    atoms.info.update(info)
+    return atoms
+
+
+class TestJsonSafeInfo:
+    def test_plain_values_pass_through(self):
+        info = {"charge": 1, "spin": 2, "name": "x", "flag": True, "temp": 0.5, "none": None}
+        assert _json_safe_info(info) == info
+
+    def test_numpy_scalar_converted(self):
+        safe = _json_safe_info({"charge": np.int64(1), "temp": np.float64(0.5)})
+        assert safe == {"charge": 1, "temp": 0.5}
+        assert type(safe["charge"]) is int
+        assert type(safe["temp"]) is float
+
+    def test_numpy_array_converted_to_list(self):
+        safe = _json_safe_info({"external_field": np.array([0.0, 0.0, 0.5])})
+        assert safe == {"external_field": [0.0, 0.0, 0.5]}
+
+    def test_unserializable_value_dropped(self):
+        safe = _json_safe_info({"charge": 1, "obj": object()})
+        assert safe == {"charge": 1}
+
+    def test_non_string_key_dropped(self):
+        safe = _json_safe_info({("a", "b"): 1, "charge": 1})
+        assert safe == {"charge": 1}
+
+
+class TestCheckStateInfo:
+    def test_info_change_invalidates(self, fake_root: Path):
+        calc = _calc_with_state(fake_root, _h2(charge=0))
+        assert calc.check_state(_h2(charge=1)) == ["info"]
+
+    def test_added_info_key_invalidates(self, fake_root: Path):
+        calc = _calc_with_state(fake_root, _h2())
+        assert calc.check_state(_h2(charge=1)) == ["info"]
+
+    def test_identical_info_is_cached(self, fake_root: Path):
+        calc = _calc_with_state(fake_root, _h2(charge=1))
+        assert calc.check_state(_h2(charge=1)) == []
+
+    def test_equal_array_values_are_cached(self, fake_root: Path):
+        calc = _calc_with_state(fake_root, _h2(external_field=np.array([0.0, 0.0, 0.5])))
+        assert calc.check_state(_h2(external_field=np.array([0.0, 0.0, 0.5]))) == []
+
+    def test_unserializable_values_do_not_invalidate(self, fake_root: Path):
+        # A value that can't cross the socket can't change the result either.
+        calc = _calc_with_state(fake_root, _h2(obj=object()))
+        assert calc.check_state(_h2(obj=object())) == []
+
+    def test_geometry_change_still_reported(self, fake_root: Path):
+        calc = _calc_with_state(fake_root, _h2(charge=0))
+        moved = _h2(charge=1)
+        moved.positions[1, 2] = 1.0
+        assert "positions" in calc.check_state(moved)

--- a/tests/worker/test_atoms_cache.py
+++ b/tests/worker/test_atoms_cache.py
@@ -13,10 +13,27 @@ import pytest
 from rootstock.worker import MLIPWorker
 
 
-def _make_worker(numbers: list[int] | None, pbc: list[bool] | None = None) -> MLIPWorker:
-    worker = MLIPWorker(calculator=None, socket_path="/tmp/unused")
+class _RecordingCalculator:
+    """Stands in for the inner ASE calculator; records reset() calls."""
+
+    def __init__(self):
+        self.resets = 0
+
+    def reset(self):
+        self.resets += 1
+
+
+def _make_worker(
+    numbers: list[int] | None,
+    pbc: list[bool] | None = None,
+    info: dict | None = None,
+    calculator=None,
+) -> MLIPWorker:
+    worker = MLIPWorker(calculator=calculator, socket_path="/tmp/unused")
     worker._atomic_numbers = numbers
     worker._pbc = pbc
+    if info is not None:
+        worker._info = info
     return worker
 
 
@@ -75,3 +92,63 @@ def test_missing_numbers_raises():
     worker = _make_worker(None)
     with pytest.raises(RuntimeError, match="No atomic numbers"):
         worker._create_atoms(_positions(2), CELL)
+
+
+def test_info_applied_on_build():
+    worker = _make_worker([1, 8], info={"charge": 1, "spin": 2})
+    atoms = worker._create_atoms(_positions(2), CELL)
+    assert atoms.info["charge"] == 1
+    assert atoms.info["spin"] == 2
+
+
+def test_numeric_list_info_becomes_array():
+    worker = _make_worker([1, 8], info={"external_field": [0.0, 0.0, 0.5], "label": ["a", "b"]})
+    atoms = worker._create_atoms(_positions(2), CELL)
+    field = atoms.info["external_field"]
+    assert isinstance(field, np.ndarray)
+    np.testing.assert_allclose(field, [0.0, 0.0, 0.5])
+    assert atoms.info["label"] == ["a", "b"]  # non-numeric lists stay lists
+
+
+def test_info_change_updates_atoms_and_resets_calculator():
+    calc = _RecordingCalculator()
+    worker = _make_worker([1, 1], info={"charge": 0}, calculator=calc)
+    atoms1 = worker._create_atoms(_positions(2), CELL)
+    assert calc.resets == 0
+
+    worker._info = {"charge": 1}
+    atoms2 = worker._create_atoms(_positions(2), CELL)
+    assert atoms2 is atoms1  # info alone must not force a rebuild
+    assert atoms2.info["charge"] == 1
+    assert calc.resets == 1  # geometry is unchanged, so only reset() forces a recompute
+
+
+def test_unchanged_info_does_not_reset():
+    calc = _RecordingCalculator()
+    worker = _make_worker([1, 1], info={"charge": 1}, calculator=calc)
+    worker._create_atoms(_positions(2), CELL)
+
+    worker._info = {"charge": 1}  # fresh dict, equal content
+    worker._create_atoms(_positions(2) + 1.0, CELL)
+    assert calc.resets == 0
+
+
+def test_removed_info_key_is_dropped():
+    calc = _RecordingCalculator()
+    worker = _make_worker([1, 1], info={"charge": 1}, calculator=calc)
+    worker._create_atoms(_positions(2), CELL)
+
+    worker._info = {}
+    atoms = worker._create_atoms(_positions(2), CELL)
+    assert "charge" not in atoms.info
+    assert calc.resets == 1
+
+
+def test_rebuild_carries_new_info():
+    worker = _make_worker([1, 1], info={"charge": 0})
+    worker._create_atoms(_positions(2), CELL)
+
+    worker._atomic_numbers = [1, 8]  # composition change forces a rebuild
+    worker._info = {"charge": -1}
+    atoms = worker._create_atoms(_positions(2), CELL)
+    assert atoms.info["charge"] == -1

--- a/tests/worker/test_info_roundtrip.py
+++ b/tests/worker/test_info_roundtrip.py
@@ -1,0 +1,144 @@
+"""atoms.info crosses the socket in the per-cycle INIT payload.
+
+Drives a real RootstockServer.calculate() against a real MLIPWorker.run()
+over a socketpair — the full protocol path, minus process spawning — and
+asserts the worker's Atoms carries the forwarded info on every cycle,
+including across an Atoms rebuild, and that workers tolerate INIT payloads
+from servers that predate the field.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from rootstock.protocol import IPIProtocol
+from rootstock.server import RootstockServer
+from rootstock.worker import MLIPWorker
+
+CELL = np.eye(3) * 10.0
+
+
+class InfoRecordingCalculator:
+    """Snapshots atoms.info at each energy evaluation."""
+
+    def __init__(self):
+        self.seen: list[dict] = []
+
+    def get_potential_energy(self, atoms=None, **kwargs):
+        self.seen.append(
+            {k: (v.copy() if isinstance(v, np.ndarray) else v) for k, v in atoms.info.items()}
+        )
+        return 1.0
+
+    def get_forces(self, atoms=None):
+        return np.zeros((len(atoms), 3))
+
+    def reset(self):
+        pass
+
+
+@pytest.fixture
+def linked_pair(tmp_path: Path):
+    """A connected (server, worker-thread, calculator) triple."""
+    server_sock, worker_sock = socket.socketpair()
+    server_sock.settimeout(10.0)
+    worker_sock.settimeout(10.0)
+
+    calc = InfoRecordingCalculator()
+    worker = MLIPWorker(calculator=calc, socket_path="/tmp/unused")
+    worker._socket = worker_sock
+    worker._protocol = IPIProtocol(worker_sock)
+    worker._connect = lambda: worker._protocol
+
+    server = RootstockServer(
+        env_name="fake",
+        checkpoint="fake-1",
+        device="cpu",
+        root=tmp_path,
+        usage_client=None,
+    )
+    server._protocol = IPIProtocol(server_sock)
+    server._connected = True
+
+    thread = threading.Thread(target=worker.run, daemon=True)
+    thread.start()
+    try:
+        yield server, calc
+    finally:
+        try:
+            server._protocol.sendmsg("EXIT")
+        except OSError:
+            pass
+        thread.join(timeout=10.0)
+        server_sock.close()
+
+
+def test_info_reaches_worker_and_updates_per_cycle(linked_pair):
+    server, calc = linked_pair
+    positions = np.zeros((2, 3))
+    numbers = np.array([1, 1])
+
+    server.calculate(positions, CELL, numbers, [True] * 3, info={"charge": 0, "spin": 1})
+    server.calculate(
+        positions,
+        CELL,
+        numbers,
+        [True] * 3,
+        info={"charge": 1, "spin": 2, "external_field": [0.0, 0.0, 0.5]},
+    )
+
+    assert calc.seen[0] == {"charge": 0, "spin": 1}
+    assert calc.seen[1]["charge"] == 1
+    assert calc.seen[1]["spin"] == 2
+    field = calc.seen[1]["external_field"]
+    assert isinstance(field, np.ndarray)
+    np.testing.assert_allclose(field, [0.0, 0.0, 0.5])
+
+
+def test_info_survives_atoms_rebuild(linked_pair):
+    server, calc = linked_pair
+    positions = np.zeros((2, 3))
+
+    server.calculate(positions, CELL, np.array([1, 1]), [True] * 3, info={"charge": 1})
+    # Same-count composition change forces the worker to rebuild its Atoms
+    server.calculate(positions, CELL, np.array([1, 8]), [True] * 3, info={"charge": 1})
+
+    assert calc.seen[0] == {"charge": 1}
+    assert calc.seen[1] == {"charge": 1}
+
+
+def test_omitted_info_is_empty(linked_pair):
+    server, calc = linked_pair
+    positions = np.zeros((2, 3))
+
+    server.calculate(positions, CELL, np.array([1, 1]), [True] * 3)
+    assert calc.seen[0] == {}
+
+
+def test_worker_tolerates_init_without_info_field():
+    """An INIT from a server that predates the info field must still work."""
+    server_sock, worker_sock = socket.socketpair()
+    calc = InfoRecordingCalculator()
+    worker = MLIPWorker(calculator=calc, socket_path="/tmp/unused")
+    worker._socket = worker_sock
+    worker._protocol = IPIProtocol(worker_sock)
+    worker._connect = lambda: worker._protocol
+
+    server = IPIProtocol(server_sock)
+    old_init = json.dumps({"numbers": [1, 1], "pbc": [True, True, True]}).encode("utf-8")
+    server.send_init(bead_index=0, init_string=old_init)
+    server.send_posdata(CELL, np.zeros((2, 3)))
+    server.send_getforce()
+    server.sendmsg("EXIT")
+
+    worker.run()
+
+    energy, _, _, _ = server.recv_forceready()
+    assert energy == pytest.approx(1.0)
+    assert calc.seen[0] == {}


### PR DESCRIPTION
This PR makes sure that Rootstock respects `charge`, `spin`, and `external_field` parameters set on atoms.info. (Recent models trained on OMol tend to accept charge and spin).