### PR TITLE
avoid calling out to hugging face at job time

### DIFF
--- a/rootstock/server.py
+++ b/rootstock/server.py
@@ -213,6 +213,7 @@ class RootstockServer:
                     "setup_kwargs": self.setup_kwargs,
                 },
                 cache_root=self.cache_root,
+                offline=True,
             )
         )
 

--- a/rootstock/spawn.py
+++ b/rootstock/spawn.py
@@ -115,6 +115,7 @@ def spawn_in_env(
     wrapper_source: str,
     payload: dict,
     cache_root: Path | None = None,
+    offline: bool = False,
 ) -> Iterator[SpawnCommand]:
     """
     Stage ``wrapper_source`` + a JSON sidecar for ``payload`` and yield the
@@ -127,6 +128,11 @@ def spawn_in_env(
         payload: JSON-serializable values the wrapper reads from the sidecar.
             ``env_dir`` is filled in here; everything else is the caller's.
         cache_root: Optional split cache root (see get_model_cache_env).
+        offline: Forbid HuggingFace Hub network access (HF_HUB_OFFLINE=1).
+            Workers serve weights pre-fetched by ``rootstock add`` and often
+            run on compute nodes with no internet, where the hub's freshness
+            HEAD request can crash setup() instead of falling back to the
+            cached file. Downloads leave this off.
 
     Raises:
         RuntimeError: the environment is not built.
@@ -137,6 +143,8 @@ def spawn_in_env(
 
     env = os.environ.copy()
     env.update(get_model_cache_env(root, cache_root))
+    if offline:
+        env["HF_HUB_OFFLINE"] = "1"
 
     tmp_dir = tempfile.mkdtemp(prefix="rootstock_spawn_")
     try:

--- a/tests/cache/test_cache_root.py
+++ b/tests/cache/test_cache_root.py
@@ -237,6 +237,22 @@ def test_spawn_in_env_default_cache_root_uses_install_root(tmp_path: Path):
         assert spec.env["XDG_CACHE_HOME"] == str(tmp_path / "cache")
 
 
+def test_spawn_in_env_offline_sets_hf_hub_offline(tmp_path: Path):
+    """Workers must not touch the network — hub freshness checks on no-internet
+    compute nodes can crash setup() instead of falling back to the cache."""
+    _make_fake_env(tmp_path)
+    with spawn_in_env(tmp_path, "fake_env", WORKER_WRAPPER, {}, offline=True) as spec:
+        assert spec.env["HF_HUB_OFFLINE"] == "1"
+
+
+def test_spawn_in_env_online_by_default(tmp_path: Path, monkeypatch):
+    """The download wrapper needs the network — offline must be opt-in."""
+    monkeypatch.delenv("HF_HUB_OFFLINE", raising=False)
+    _make_fake_env(tmp_path)
+    with spawn_in_env(tmp_path, "fake_env", WORKER_WRAPPER, {}) as spec:
+        assert "HF_HUB_OFFLINE" not in spec.env
+
+
 # ---------- RootstockCalculator wiring ------------------------------------
 
 

--- a/tests/server/test_worker_payload.py
+++ b/tests/server/test_worker_payload.py
@@ -19,8 +19,9 @@ def captured_payload(monkeypatch):
     captured = {}
 
     @contextmanager
-    def fake_spawn(root, env_name, wrapper_source, payload, cache_root=None):
+    def fake_spawn(root, env_name, wrapper_source, payload, cache_root=None, offline=False):
         captured.update(payload)
+        captured["_offline"] = offline
         raise _StopSpawn("payload captured")
         yield  # pragma: no cover
 
@@ -57,3 +58,15 @@ def test_payload_checkpoint_path_defaults_to_none(captured_payload, tmp_path: Pa
     )
     _start(server)
     assert captured_payload["checkpoint_path"] is None
+
+
+def test_worker_spawns_offline(captured_payload, tmp_path: Path):
+    """Workers serve pre-fetched weights — hub network access is forbidden."""
+    server = RootstockServer(
+        env_name="uma",
+        checkpoint="uma-s-1p1",
+        device="cpu",
+        root=tmp_path,
+    )
+    _start(server)
+    assert captured_payload["_offline"] is True


### PR DESCRIPTION
Some weird behavior deep in the hugging face hub library is causing the worker process to crash when it can't check for newer versions of a checkpoint that is cached locally. Lots of compute nodes don't have outbound access, so this will cause lots of runs to fail