### PR TITLE
Tweak MACE mh1 head handling

### DIFF
--- a/sample_model_configurations/amd_configs/mace.py
+++ b/sample_model_configurations/amd_configs/mace.py
@@ -29,9 +29,12 @@ unchanged. cuEquivariance acceleration is CUDA-only and is not used here  -
 MACE falls back to the pure e3nn/torch path.
 
 Upstream-string routing in CHECKPOINTS: an `off:` prefix routes to mace_off()
-and an `omol:` prefix to mace_omol() (float64, molecules only); a `@head`
-suffix selects a head of a multi-head model (loaded in float64, per the
-MACE-MH-1 model card).
+and an `omol:` prefix to mace_omol() (float64, molecules only); an `mh:`
+prefix marks a multi-head model (float64, per the MACE-MH-1 model card).
+
+Multi-head checkpoints select a head via the `head` kwarg on setup()
+(setup_kwargs={"head": ...} / --kwarg head=...), named by upstream's training
+corpus — see MH1_HEADS; omat_pbe is the default.
 
 The OMOL checkpoint expects `charge` and `spin` in `atoms.info`.
 """
@@ -47,16 +50,40 @@ CHECKPOINTS = {
     # file mace-mpa-0-medium.model — keep the size explicit like mace-mp-0.
     "mace-mpa-0-medium": "medium-mpa-0",
     "mace-matpes-r2scan-0": "mace-matpes-r2scan-0",
-    "mace-mh-1-matpes-r2scan": "mh-1@matpes_r2scan",
+    # One entry per weights file: MH-1's heads are selected by setup(head=...).
+    "mace-mh-1": "mh:mh-1",
     # Only the extra-large OMOL model has been released.
     "mace-omol-0-extra-large": "omol:extra_large",
     # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
     "mace:custom": None,
 }
 
+# MH-1's heads, named by training corpus. The released weights file is the
+# authority (mace_select_head --list_heads; the model card also lists a
+# rgd1_b3lyp head, but that shipped only in mh-0 — ACEsuit/mace#1462).
+# Validated here because upstream only warns on an unknown head and silently
+# falls back to the last one.
+MH1_HEADS = (
+    "omat_pbe",
+    "omol",
+    "spice_wB97M",
+    "oc20_usemppbe",
+    "mp_pbe_refit_add",
+    "matpes_r2scan",
+)
 
-def setup(checkpoint: str, device: str = "cuda"):
+
+def setup(checkpoint: str, device: str = "cuda", head: str | None = None):
     arg = CHECKPOINTS[checkpoint]
+    if arg.startswith("mh:"):
+        head = head or "omat_pbe"
+        if head not in MH1_HEADS:
+            raise ValueError(f"unknown head {head!r}; expected one of {', '.join(MH1_HEADS)}")
+        from mace.calculators import mace_mp
+
+        return mace_mp(model=arg[3:], device=device, default_dtype="float64", head=head)
+    if head is not None:
+        raise ValueError(f"'head' selects a head of a multi-head model; {checkpoint} has one head")
     if arg.startswith("off:"):
         from mace.calculators import mace_off
 
@@ -67,16 +94,14 @@ def setup(checkpoint: str, device: str = "cuda"):
         return mace_omol(model=arg[5:], device=device, default_dtype="float64")
     from mace.calculators import mace_mp
 
-    if "@" in arg:
-        model, head = arg.split("@", 1)
-        return mace_mp(model=model, device=device, default_dtype="float64", head=head)
     return mace_mp(model=arg, device=device, default_dtype="float32")
 
 
-def setup_from_path(path: str, device: str = "cuda"):
+def setup_from_path(path: str, device: str = "cuda", head: str | None = None):
     # Custom checkpoints (`:custom` ids with user weights): fine-tunes load through
     # MACECalculator directly — the mp/off dispatch in setup() only exists
-    # to pick which pretrained file to download.
+    # to pick which pretrained file to download. `head` is for fine-tunes that
+    # keep multiple heads; single-head weights load without it.
     from mace.calculators import MACECalculator
 
-    return MACECalculator(model_paths=path, device=device, default_dtype="float32")
+    return MACECalculator(model_paths=path, device=device, default_dtype="float32", head=head)

--- a/sample_model_configurations/nvidia_configs/mace.py
+++ b/sample_model_configurations/nvidia_configs/mace.py
@@ -13,9 +13,12 @@
 
 All ship in the same `mace-torch` package, so they share an environment.
 Upstream-string routing in CHECKPOINTS: an `off:` prefix routes to mace_off()
-and an `omol:` prefix to mace_omol() (float64, molecules only); a `@head`
-suffix selects a head of a multi-head model (loaded in float64, per the
-MACE-MH-1 model card).
+and an `omol:` prefix to mace_omol() (float64, molecules only); an `mh:`
+prefix marks a multi-head model (float64, per the MACE-MH-1 model card).
+
+Multi-head checkpoints select a head via the `head` kwarg on setup()
+(setup_kwargs={"head": ...} / --kwarg head=...), named by upstream's training
+corpus — see MH1_HEADS; omat_pbe is the default.
 
 The OMOL checkpoint expects `charge` and `spin` in `atoms.info`.
 """
@@ -31,16 +34,40 @@ CHECKPOINTS = {
     # file mace-mpa-0-medium.model — keep the size explicit like mace-mp-0.
     "mace-mpa-0-medium": "medium-mpa-0",
     "mace-matpes-r2scan-0": "mace-matpes-r2scan-0",
-    "mace-mh-1-matpes-r2scan": "mh-1@matpes_r2scan",
+    # One entry per weights file: MH-1's heads are selected by setup(head=...).
+    "mace-mh-1": "mh:mh-1",
     # Only the extra-large OMOL model has been released.
     "mace-omol-0-extra-large": "omol:extra_large",
     # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
     "mace:custom": None,
 }
 
+# MH-1's heads, named by training corpus. The released weights file is the
+# authority (mace_select_head --list_heads; the model card also lists a
+# rgd1_b3lyp head, but that shipped only in mh-0 — ACEsuit/mace#1462).
+# Validated here because upstream only warns on an unknown head and silently
+# falls back to the last one.
+MH1_HEADS = (
+    "omat_pbe",
+    "omol",
+    "spice_wB97M",
+    "oc20_usemppbe",
+    "mp_pbe_refit_add",
+    "matpes_r2scan",
+)
 
-def setup(checkpoint: str, device: str = "cuda"):
+
+def setup(checkpoint: str, device: str = "cuda", head: str | None = None):
     arg = CHECKPOINTS[checkpoint]
+    if arg.startswith("mh:"):
+        head = head or "omat_pbe"
+        if head not in MH1_HEADS:
+            raise ValueError(f"unknown head {head!r}; expected one of {', '.join(MH1_HEADS)}")
+        from mace.calculators import mace_mp
+
+        return mace_mp(model=arg[3:], device=device, default_dtype="float64", head=head)
+    if head is not None:
+        raise ValueError(f"'head' selects a head of a multi-head model; {checkpoint} has one head")
     if arg.startswith("off:"):
         from mace.calculators import mace_off
 
@@ -51,16 +78,14 @@ def setup(checkpoint: str, device: str = "cuda"):
         return mace_omol(model=arg[5:], device=device, default_dtype="float64")
     from mace.calculators import mace_mp
 
-    if "@" in arg:
-        model, head = arg.split("@", 1)
-        return mace_mp(model=model, device=device, default_dtype="float64", head=head)
     return mace_mp(model=arg, device=device, default_dtype="float32")
 
 
-def setup_from_path(path: str, device: str = "cuda"):
+def setup_from_path(path: str, device: str = "cuda", head: str | None = None):
     # Custom checkpoints (`:custom` ids with user weights): fine-tunes load through
     # MACECalculator directly — the mp/off dispatch in setup() only exists
-    # to pick which pretrained file to download.
+    # to pick which pretrained file to download. `head` is for fine-tunes that
+    # keep multiple heads; single-head weights load without it.
     from mace.calculators import MACECalculator
 
-    return MACECalculator(model_paths=path, device=device, default_dtype="float32")
+    return MACECalculator(model_paths=path, device=device, default_dtype="float32", head=head)


### PR DESCRIPTION
My first pass at MACE mh1 broke convention by treating a task head as a separate checkpoint. But really, a checkpoint has_many task heads.