### PR TITLE
Record each checkpoint's weight files in the manifest at add/verify time

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Rootstock runs MLIP (Machine Learning Interatomic Potential) calculators in isolated pre-built Python environments on HPC clusters, communicating via the i-PI protocol over Unix sockets.
 
-Versioning is dynamic (git tags via uv-dynamic-versioning) — check `rootstock --version`. Manifest schema v4 (older schemas migrate in place on load); canonical-checkpoint-id API.
+Versioning is dynamic (git tags via uv-dynamic-versioning) — check `rootstock --version`. Manifest schema v5 (older schemas migrate in place on load); canonical-checkpoint-id API.
 
 ## Commands
 

--- a/rootstock/commands/smoke_test.py
+++ b/rootstock/commands/smoke_test.py
@@ -16,7 +16,12 @@ from ..manifest import (
     now_iso,
     save_manifest,
 )
-from ..operations import update_and_push_manifest
+from ..operations import (
+    apply_weights_record,
+    read_weights_capture,
+    update_and_push_manifest,
+    weights_capture_file,
+)
 from ..verify import verify_checkpoint
 from .common import get_root_or_exit, resolve_cache_root
 
@@ -75,20 +80,27 @@ def cmd_smoke_test(args) -> int:
     # loaded* manifest in one locked cycle afterwards — mutating the manifest
     # loaded before the loop and saving it at the end would silently revert
     # anything a co-maintainer wrote in between.
-    outcomes: list[tuple[str, str, bool, str | None]] = []
+    outcomes: list[tuple[str, str, bool, str | None, list[dict] | None]] = []
 
     for env_name, ckpt_name, env, ckpt in selected:
         start = time.monotonic()
-        ok, err = verify_checkpoint(
-            root=root,
-            env_name=env_name,
-            checkpoint=ckpt_name,
-            device=device,
-            setup_kwargs={},  # smoke-test always uses env defaults; see design §7.2
-            cache_root=cache_root,
-        )
+        # Each pass also re-captures which weight files the load touched, so
+        # per-checkpoint weight records self-heal nightly like verified_at
+        # (#177) — and backfilling them on an existing install is just one
+        # smoke-test run, no re-downloads.
+        with weights_capture_file() as capture_path:
+            ok, err = verify_checkpoint(
+                root=root,
+                env_name=env_name,
+                checkpoint=ckpt_name,
+                device=device,
+                setup_kwargs={},  # smoke-test always uses env defaults; see design §7.2
+                cache_root=cache_root,
+                weights_capture_path=str(capture_path),
+            )
+            weight_files = read_weights_capture(capture_path)
         elapsed = time.monotonic() - start
-        outcomes.append((env_name, ckpt_name, ok, err))
+        outcomes.append((env_name, ckpt_name, ok, err, weight_files))
 
         # Mirror the outcome onto the working copy so verified_current in the
         # report reflects this run.
@@ -125,7 +137,7 @@ def cmd_smoke_test(args) -> int:
     with manifest_lock(root):
         fresh = load_manifest(root)
         if fresh is not None:
-            for env_name, ckpt_name, ok, err in outcomes:
+            for env_name, ckpt_name, ok, err, weight_files in outcomes:
                 env_record = fresh.environments.get(env_name)
                 ckpt_record = env_record.checkpoints.get(ckpt_name) if env_record else None
                 if ckpt_record is None:
@@ -138,6 +150,12 @@ def cmd_smoke_test(args) -> int:
                     ckpt_record.verified_at = None
                     ckpt_record.verified_device = None
                     ckpt_record.last_error = f"smoke-test: {err}"
+                apply_weights_record(
+                    ckpt_record,
+                    weight_files,
+                    label=f"{env_name}/{ckpt_name}",
+                    progress=None if json_out else print,
+                )
             save_manifest(fresh, root)
     update_and_push_manifest(root, quiet=True, push=not no_push)
 

--- a/rootstock/manifest.py
+++ b/rootstock/manifest.py
@@ -28,7 +28,7 @@ from pathlib import Path
 from .config import UserConfig
 from .exceptions import RootstockError
 
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 
 # manifest_lock defaults. The lock is only held across a load → mutate → save
 # cycle (plus the env refresh, which shells out to `uv pip list` per env), so
@@ -108,6 +108,19 @@ def _migrate_v3_to_v4(data: dict) -> tuple[dict, str | None]:
     return data, None
 
 
+def _migrate_v4_to_v5(data: dict) -> tuple[dict, str | None]:
+    """v5 added optional weight-tracking fields to CheckpointInfo.
+
+    ``weight_files``/``weights_recorded_at`` default to absent, so this is a
+    pure version bump. The bump still matters: without it a v4 client's
+    from_dict/asdict round-trip would silently drop the new fields on its
+    next save — refusing loudly (migrate_manifest_data's newer-schema check)
+    beats that.
+    """
+    data["schema_version"] = 5
+    return data, None
+
+
 # One entry per historical schema version, upgrading one step. A schema bump
 # without a migration here strands every deployed manifest of that vintage —
 # add the migration in the same change as the bump.
@@ -115,6 +128,7 @@ MIGRATIONS = {
     1: _migrate_v1_to_v2,
     2: _migrate_v2_to_v3,
     3: _migrate_v3_to_v4,
+    4: _migrate_v4_to_v5,
 }
 
 
@@ -192,6 +206,15 @@ class CheckpointInfo:
     verified_at: str | None = None  # ISO 8601, set when smoke test passes
     verified_device: str | None = None  # "cuda", "cpu", etc.
     last_error: str | None = None  # most recent error from add or smoke-test
+    # Weight files this checkpoint's setup() actually touched, captured at
+    # add/verify/smoke-test time (#177): list of {"path", "size"} dicts with
+    # paths relative to the cache root (so records survive split-cache
+    # installs) and sizes in bytes. None = never recorded. Granularity is
+    # deliberately files, not dirs: HF hub keeps one repo dir per model
+    # *family*, so dir-level records over-warm — and under a job's memory
+    # cgroup, over-warming evicts the pages the worker needs.
+    weight_files: list[dict] | None = None
+    weights_recorded_at: str | None = None  # ISO 8601
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -203,6 +226,8 @@ class CheckpointInfo:
             verified_at=data.get("verified_at"),
             verified_device=data.get("verified_device"),
             last_error=data.get("last_error"),
+            weight_files=data.get("weight_files"),
+            weights_recorded_at=data.get("weights_recorded_at"),
         )
 
 

--- a/rootstock/operations.py
+++ b/rootstock/operations.py
@@ -25,7 +25,7 @@ import subprocess
 import sys
 import tempfile
 import threading
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -936,6 +936,7 @@ def _run_download(
     checkpoint: str,
     setup_kwargs: dict,
     cache_root: Path | None = None,
+    weights_capture_path: str | Path | None = None,
 ) -> tuple[bool, str | None]:
     """Run ``setup(checkpoint, "cpu", **setup_kwargs)`` to trigger the cache-aware
     download path. Returns ``(ok, error)``."""
@@ -943,11 +944,18 @@ def _run_download(
     if not (env_dir / "bin" / "python").exists():
         return False, f"environment not built at {env_dir}"
 
+    payload = {"checkpoint": checkpoint, "device": "cpu", "setup_kwargs": setup_kwargs}
+    if weights_capture_path is not None:
+        payload["weights_capture"] = {
+            "result_path": str(weights_capture_path),
+            "cache_root": str(cache_root if cache_root is not None else root),
+        }
+
     with spawn_in_env(
         root,
         env_name,
         DOWNLOAD_WRAPPER,
-        {"checkpoint": checkpoint, "device": "cpu", "setup_kwargs": setup_kwargs},
+        payload,
         cache_root=cache_root,
     ) as spec:
         result = subprocess.run(
@@ -964,6 +972,81 @@ def _run_download(
         msg = err[-1] if err else f"setup() exited with code {result.returncode}"
         return False, msg
     return True, None
+
+
+# Captures totalling fewer bytes than this are presumed broken probes (a
+# helper failure, a load path neither probe sees) rather than real working
+# sets — real weight files are MBs at minimum. Such captures never replace
+# an existing record (#177).
+_WEIGHTS_BYTE_FLOOR = 1 << 20
+
+
+@contextmanager
+def weights_capture_file() -> Iterator[Path]:
+    """Yield a path for a capture subprocess to write its result to.
+
+    A fresh private directory rather than mkstemp: the file must not exist
+    until the wrapper writes it, so "no capture ran" stays distinguishable
+    from "capture wrote garbage"."""
+    tmp_dir = tempfile.mkdtemp(prefix="rootstock_weights_")
+    try:
+        yield Path(tmp_dir) / "weights.json"
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+def read_weights_capture(path: str | Path) -> list[dict] | None:
+    """Parse a capture result written by weights_capture.py.
+
+    Returns the validated ``[{"path", "size"}, ...]`` list, or None when no
+    usable capture exists — setup() failed before finishing, the helper hit
+    an error, or the file is malformed. None means "learn nothing", never
+    "forget the old record".
+    """
+    try:
+        with open(path) as f:
+            data = json.load(f)
+        files = []
+        for entry in data["files"]:
+            rel, size = entry["path"], entry["size"]
+            if not isinstance(rel, str) or not isinstance(size, int):
+                return None
+            files.append({"path": rel, "size": size})
+        return files
+    except (OSError, json.JSONDecodeError, KeyError, TypeError):
+        return None
+
+
+def apply_weights_record(
+    ckpt: CheckpointInfo,
+    files: list[dict] | None,
+    *,
+    label: str = "",
+    progress: Progress | None = None,
+) -> None:
+    """Merge a weight-file capture into a checkpoint's manifest record (#177).
+
+    Merge policy: a non-trivial capture replaces the record (freshness
+    self-heals — every add/verify/smoke-test pass re-records); a
+    suspiciously small one keeps the previous record and says so; ``None``
+    (no capture ran) changes nothing, silently. Call inside a manifest
+    transaction.
+    """
+    if files is None:
+        return
+    total = sum(f["size"] for f in files)
+    if total < _WEIGHTS_BYTE_FLOOR:
+        if ckpt.weight_files:
+            _say(
+                progress,
+                f"  weight capture for {label} suspiciously small "
+                f"({total} bytes) — keeping the record from "
+                f"{ckpt.weights_recorded_at}",
+            )
+        return
+    ckpt.weight_files = sorted(files, key=lambda f: f["path"])
+    ckpt.weights_recorded_at = now_iso()
+    _say(progress, f"  recorded {len(files)} weight files ({total / 1e6:.0f} MB)")
 
 
 @contextmanager
@@ -1085,7 +1168,16 @@ def fetch_checkpoint(
     # ---- Download (runs outside the lock) -------------------------------
     if not already_fetched:
         _say(progress, f"Downloading {env_name}/{checkpoint} on CPU...")
-        ok, err = _run_download(root, env_name, checkpoint, setup_kwargs, cache_root=cache_root)
+        with weights_capture_file() as capture_path:
+            ok, err = _run_download(
+                root,
+                env_name,
+                checkpoint,
+                setup_kwargs,
+                cache_root=cache_root,
+                weights_capture_path=capture_path,
+            )
+            weight_files = read_weights_capture(capture_path)
         with _manifest_transaction(root) as manifest:
             _, ckpt = _ensure_manifest_entry(manifest, root, env_name, checkpoint)
             if ok:
@@ -1094,6 +1186,10 @@ def fetch_checkpoint(
                 fetched_at = ckpt.fetched_at
             else:
                 ckpt.last_error = f"download: {err}"
+            # A failed setup() writes no capture, so this is a no-op then.
+            apply_weights_record(
+                ckpt, weight_files, label=f"{env_name}/{checkpoint}", progress=progress
+            )
         if not ok:
             raise OperationError(f"download failed: {err}")
         _say(progress, f"  fetched_at = {fetched_at}")
@@ -1153,9 +1249,17 @@ def verify_fetched_checkpoint(
 
     # ---- Verify (runs outside the lock) ---------------------------------
     _say(progress, f"Verifying {env_name}/{checkpoint} on {device}...")
-    ok, err = verify_checkpoint(
-        root, env_name, checkpoint, device, setup_kwargs, cache_root=cache_root
-    )
+    with weights_capture_file() as capture_path:
+        ok, err = verify_checkpoint(
+            root,
+            env_name,
+            checkpoint,
+            device,
+            setup_kwargs,
+            cache_root=cache_root,
+            weights_capture_path=str(capture_path),
+        )
+        weight_files = read_weights_capture(capture_path)
     with _manifest_transaction(root) as manifest:
         _, ckpt = _ensure_manifest_entry(manifest, root, env_name, checkpoint)
         if ok:
@@ -1167,6 +1271,12 @@ def verify_fetched_checkpoint(
             ckpt.verified_at = None
             ckpt.verified_device = None
             ckpt.last_error = f"verify: {err}"
+        # Recorded even when verification fails: the capture only exists if
+        # setup() completed, and the load working set it saw is real whether
+        # or not the forward pass then produced good forces.
+        apply_weights_record(
+            ckpt, weight_files, label=f"{env_name}/{checkpoint}", progress=progress
+        )
     if not ok:
         raise OperationError(f"verify failed: {err}")
     _say(progress, f"  verified_at = {verified_at} ({device})")

--- a/rootstock/server.py
+++ b/rootstock/server.py
@@ -98,6 +98,7 @@ class RootstockServer:
         setup_kwargs: dict | None = None,
         checkpoint_path: str | None = None,
         usage_client: str | None = "calculator",
+        weights_capture_path: str | None = None,
     ):
         """
         Initialize the server.
@@ -128,6 +129,11 @@ class RootstockServer:
                 usage record (see usage.py), or None to record nothing —
                 verification passes None so synthetic smoke-test sessions
                 never pollute the spool.
+            weights_capture_path: When set, the worker records which weight
+                files its setup() touches and writes them (as JSON) to this
+                path the moment the load completes (see weights_capture.py).
+                Verification uses this to keep per-checkpoint weight records
+                fresh in the manifest (#177).
         """
         if root is None:
             raise ValueError("root is required for pre-built environments")
@@ -147,6 +153,7 @@ class RootstockServer:
         self.cache_root = Path(cache_root) if cache_root is not None else None
         self.setup_kwargs = setup_kwargs or {}
         self.usage_client = usage_client
+        self.weights_capture_path = weights_capture_path
 
         self._server_socket: socket.socket | None = None
         self._client_socket: socket.socket | None = None
@@ -199,19 +206,28 @@ class RootstockServer:
         """Start worker using pre-built environment; return the worker process."""
         from .spawn import WORKER_WRAPPER, spawn_in_env
 
+        payload = {
+            "checkpoint": self.checkpoint,
+            "checkpoint_path": self.checkpoint_path,
+            "device": self.device,
+            "socket_path": self.socket_path,
+            "setup_kwargs": self.setup_kwargs,
+        }
+        if self.weights_capture_path:
+            # Records are relative to the cache root so they survive
+            # split-cache installs; base mirrors get_model_cache_env's.
+            payload["weights_capture"] = {
+                "result_path": self.weights_capture_path,
+                "cache_root": str(self.cache_root or self.root),
+            }
+
         self._spawn_stack = contextlib.ExitStack()
         spec = self._spawn_stack.enter_context(
             spawn_in_env(
                 self.root,
                 self.env_name,
                 WORKER_WRAPPER,
-                {
-                    "checkpoint": self.checkpoint,
-                    "checkpoint_path": self.checkpoint_path,
-                    "device": self.device,
-                    "socket_path": self.socket_path,
-                    "setup_kwargs": self.setup_kwargs,
-                },
+                payload,
                 cache_root=self.cache_root,
                 offline=True,
             )

--- a/rootstock/spawn.py
+++ b/rootstock/spawn.py
@@ -116,9 +116,14 @@ finally:
 sys.path.insert(0, spec["env_dir"])
 from env_source import setup
 
-setup(spec["checkpoint"], spec["device"], **spec["setup_kwargs"])
+# wrap_setup, not a trailing finalize(): the maps probe must scan while the
+# calculator is still referenced. A discarded return value dies immediately
+# under CPython refcounting, and mmap-backed weights (safetensors) are
+# munmap'd with it — the wrapper's local reference holds them alive.
 if weights_capture is not None:
-    weights_capture.finalize(spec)
+    setup = weights_capture.wrap_setup(setup, spec)
+
+setup(spec["checkpoint"], spec["device"], **spec["setup_kwargs"])
 """
 
 

--- a/rootstock/spawn.py
+++ b/rootstock/spawn.py
@@ -40,7 +40,7 @@ with open(sys.argv[1]) as f:
 
 # Warm the page cache before the heavy imports below fault their way
 # through multi-GB mmap'd libraries at network-round-trip speed (#167).
-# The helper is staged next to this wrapper; best-effort, never fatal.
+# The helpers are staged next to this wrapper; best-effort, never fatal.
 _here = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, _here)
 try:
@@ -48,6 +48,14 @@ try:
     prewarm.prewarm_from_spec(spec)
 except ImportError:
     pass  # wrapper run without staged helper (e.g. tests); warming is optional
+try:
+    # Record which weight files setup() touches (#177); a no-op unless the
+    # spec requests capture. The hook must be live before env_source's
+    # imports so nothing loaded at import time slips past it.
+    import weights_capture
+    weights_capture.begin(spec)
+except ImportError:
+    weights_capture = None
 finally:
     sys.path.remove(_here)
 
@@ -64,6 +72,11 @@ if spec.get("checkpoint_path"):
 else:
     from env_source import setup as setup_fn
     target = spec["checkpoint"]
+
+# setup runs deep inside run_worker's socket loop, so the capture record is
+# written by a wrapped setup_fn the moment the load completes.
+if weights_capture is not None:
+    setup_fn = weights_capture.wrap_setup(setup_fn, spec)
 
 run_worker(
     setup_fn=setup_fn,
@@ -89,6 +102,14 @@ try:
     prewarm.prewarm_from_spec(spec)
 except ImportError:
     pass  # wrapper run without staged helper (e.g. tests); warming is optional
+try:
+    # Same weight capture as WORKER_WRAPPER (#177) — a fresh download's
+    # setup() writes and then loads the weights, so its touched set is the
+    # same working set a verify-time load produces.
+    import weights_capture
+    weights_capture.begin(spec)
+except ImportError:
+    weights_capture = None
 finally:
     sys.path.remove(_here)
 
@@ -96,6 +117,8 @@ sys.path.insert(0, spec["env_dir"])
 from env_source import setup
 
 setup(spec["checkpoint"], spec["device"], **spec["setup_kwargs"])
+if weights_capture is not None:
+    weights_capture.finalize(spec)
 """
 
 
@@ -127,6 +150,10 @@ def spawn_in_env(
         wrapper_source: One of the static wrapper sources in this module.
         payload: JSON-serializable values the wrapper reads from the sidecar.
             ``env_dir`` is filled in here; everything else is the caller's.
+            A ``weights_capture`` entry of ``{"result_path", "cache_root"}``
+            makes the wrapper record which weight files setup() touches
+            (see weights_capture.py); the caller reads ``result_path`` after
+            the process exits.
         cache_root: Optional split cache root (see get_model_cache_env).
         offline: Forbid HuggingFace Hub network access (HF_HUB_OFFLINE=1).
             Workers serve weights pre-fetched by ``rootstock add`` and often
@@ -150,12 +177,11 @@ def spawn_in_env(
     try:
         wrapper = Path(tmp_dir) / "wrapper.py"
         wrapper.write_text(wrapper_source)
-        # The prewarm helper runs inside the env's (different) Python, so it
-        # travels as staged source next to the wrapper rather than being
+        # These helpers run inside the env's (different) Python, so they
+        # travel as staged source next to the wrapper rather than being
         # imported from the client's installation.
-        (Path(tmp_dir) / "prewarm.py").write_text(
-            (Path(__file__).parent / "prewarm.py").read_text()
-        )
+        for helper in ("prewarm.py", "weights_capture.py"):
+            (Path(tmp_dir) / helper).write_text((Path(__file__).parent / helper).read_text())
         sidecar = Path(tmp_dir) / "spec.json"
         sidecar.write_text(json.dumps({**payload, "env_dir": str(env_dir)}))
 

--- a/rootstock/verify.py
+++ b/rootstock/verify.py
@@ -60,6 +60,7 @@ def verify_checkpoint(
     setup_kwargs: dict | None = None,
     cache_root: Path | None = None,
     checkpoint_path: str | None = None,
+    weights_capture_path: str | None = None,
 ) -> tuple[bool, str | None]:
     """
     Run a single forward pass to verify a checkpoint loads and computes.
@@ -74,6 +75,9 @@ def verify_checkpoint(
                     redirected HOME. Defaults to ``root``.
         checkpoint_path: Path to a local (user-registered) weights file; the
                     worker then loads via setup_from_path() instead of setup().
+        weights_capture_path: When set, the worker writes the weight files
+                    its setup() touched to this path as JSON (#177); the
+                    caller reads it afterwards — a failed load writes nothing.
 
     Returns:
         (success, error_message). On success, error_message is None.
@@ -96,6 +100,7 @@ def verify_checkpoint(
         setup_kwargs=setup_kwargs,
         timeout=600.0,
         checkpoint_path=checkpoint_path,
+        weights_capture_path=weights_capture_path,
         # Verification sessions are synthetic — the nightly smoke-test cron
         # would otherwise spool one fake "session" per checkpoint per night,
         # and rollups merge irreversibly.

--- a/rootstock/weights_capture.py
+++ b/rootstock/weights_capture.py
@@ -170,11 +170,20 @@ def finalize(spec: dict) -> None:
 def wrap_setup(setup_fn, spec: dict):
     """Wrap a setup function so finalize() runs the moment it returns.
 
-    Used by WORKER_WRAPPER, where setup happens deep inside run_worker's
-    socket loop and the wrapper never regains control; the record is
-    written before the worker even connects. When the spec doesn't request
-    capture, returns ``setup_fn`` unchanged. A setup that raises writes no
-    record — a failed load has no working set worth recording.
+    Both wrappers use this, for two different reasons. In WORKER_WRAPPER,
+    setup happens deep inside run_worker's socket loop and the wrapper never
+    regains control — wrapping is the only way to run finalize at all (the
+    record is written before the worker even connects). In DOWNLOAD_WRAPPER
+    the wrapper *could* call finalize after setup returns, but the
+    ``calculator`` local below is load-bearing: it keeps the result — and
+    the mmap'd weight files it references — alive while finalize scans
+    /proc/self/maps. A discarded return value is freed immediately under
+    CPython refcounting, munmapping exactly the safetensors-style mappings
+    the maps probe exists to see.
+
+    When the spec doesn't request capture, returns ``setup_fn`` unchanged.
+    A setup that raises writes no record — a failed load has no working set
+    worth recording.
     """
     if not spec.get("weights_capture"):
         return setup_fn

--- a/rootstock/weights_capture.py
+++ b/rootstock/weights_capture.py
@@ -1,0 +1,194 @@
+"""Record which model-weight files a checkpoint load actually touches.
+
+Weight locations vary per library and guessing them is a losing game (#177):
+well-behaved libraries land under ``{cache_root}/cache`` via XDG_CACHE_HOME /
+HF_HOME, but e.g. fairchem hardcodes ``~/.cache`` so UMA's 14 GB lives under
+the redirected ``{cache_root}/home``. Rootstock controls every sanctioned
+path by which weights arrive and get loaded — ``rootstock add`` runs
+``setup()`` in DOWNLOAD_WRAPPER, verify/smoke-test load the same weights in
+WORKER_WRAPPER — so instead of discovering cache layouts we observe what
+those runs touch and write it down for the manifest.
+
+Two probes, both stdlib:
+
+1. A ``sys.addaudithook`` on ``open`` events — every Python-side open under
+   ``{cache_root}/cache`` and ``{cache_root}/home`` while capture is active.
+2. After ``setup()`` returns, a scan of ``/proc/self/maps`` for file
+   mappings under the same trees — mmap'd reads bypass Python ``open``
+   entirely (safetensors' native reader), and mmap'd weights are exactly
+   the slow-fault case prewarm exists for. Linux-only; silently skipped
+   elsewhere.
+
+Like ``prewarm.py``, this module is staged next to the wrapper by
+``spawn_in_env`` and runs inside the *target env's* Python — it must stay
+stdlib-only and compatible with any Python an env might ship. Capture is
+requested via ``spec["weights_capture"] = {"result_path", "cache_root"}``;
+without that key every entry point is a no-op. Best-effort by design: a
+capture failure logs and never takes down the download or the worker.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+# Capture state for the current process. sys.addaudithook is irreversible,
+# so the hook closes over this dict and goes dormant via "active" instead of
+# being removed; a long-lived worker stops paying for capture (beyond one
+# flag check per open) once finalize() has run.
+_state: dict | None = None
+
+
+def _scope_prefixes(cache_root: str) -> tuple[str, ...]:
+    """Directory prefixes under which touched files count as weights.
+
+    Both the spec-provided form and its realpath are included: the audit
+    hook sees whatever path the library opened (built from env vars that use
+    the spec form), while /proc/self/maps records canonical paths.
+    """
+    prefixes = []
+    for base in dict.fromkeys((cache_root, os.path.realpath(cache_root))):
+        for sub in ("cache", "home"):
+            prefixes.append(os.path.join(base, sub) + os.sep)
+    return tuple(prefixes)
+
+
+def begin(spec: dict) -> None:
+    """Install the open-event audit hook when the spec requests capture.
+
+    Called before the env's heavy imports so nothing that loads during
+    ``import env_source`` can slip past the hook.
+    """
+    global _state
+    cfg = spec.get("weights_capture")
+    if not cfg:
+        return
+    try:
+        state = {
+            "scopes": _scope_prefixes(cfg["cache_root"]),
+            "cache_root": cfg["cache_root"],
+            "result_path": cfg["result_path"],
+            "seen": set(),
+            "active": True,
+        }
+        scopes = state["scopes"]
+        seen = state["seen"]
+
+        def _hook(event: str, args: tuple) -> None:
+            # An exception raised here propagates into whatever triggered
+            # the event — swallow everything.
+            try:
+                if event == "open" and state["active"]:
+                    path = args[0]
+                    if isinstance(path, str) and path.startswith(scopes):
+                        seen.add(path)
+            except Exception:
+                pass
+
+        sys.addaudithook(_hook)
+        _state = state
+    except Exception as exc:  # noqa: BLE001 - capture must never be fatal
+        _log(f"Weight capture disabled: {type(exc).__name__}: {exc}")
+        _state = None
+
+
+def parse_maps(maps_text: str, scopes: tuple[str, ...]) -> set[str]:
+    """Extract in-scope file paths from /proc/self/maps content.
+
+    Each line is ``addr perms offset dev inode [pathname]``; anonymous
+    mappings have no pathname and unlinked files carry a ``(deleted)``
+    suffix (nothing to prewarm there — skipped).
+    """
+    paths: set[str] = set()
+    for line in maps_text.splitlines():
+        parts = line.split(None, 5)
+        if len(parts) < 6:
+            continue
+        path = parts[5].strip()
+        if path.startswith(scopes) and not path.endswith(" (deleted)"):
+            paths.add(path)
+    return paths
+
+
+def _mapped_files(scopes: tuple[str, ...]) -> set[str]:
+    try:
+        with open("/proc/self/maps") as f:
+            return parse_maps(f.read(), scopes)
+    except OSError:
+        return set()  # not Linux (or /proc unavailable) — audit hook only
+
+
+def finalize(spec: dict) -> None:
+    """Merge both probes, stat sizes, and write the capture result JSON.
+
+    Runs right after ``setup()`` returns — the process may live on for a
+    whole verification run (or die abruptly at server.stop()), so the
+    result must be on disk the moment the load working set is known.
+    """
+    global _state
+    state = _state
+    if state is None or not spec.get("weights_capture"):
+        return
+    try:
+        touched = set(state["seen"]) | _mapped_files(state["scopes"])
+        state["active"] = False
+
+        real_root = os.path.realpath(state["cache_root"])
+        files: dict[str, int] = {}
+        for path in touched:
+            # Canonicalize so a file seen through a symlink (HF snapshots/
+            # point into blobs/) and through its real path records once, as
+            # the physical file prewarm would read.
+            real = os.path.realpath(path)
+            rel = os.path.relpath(real, real_root)
+            if rel.startswith(".."):
+                continue  # symlink escaped the cache tree
+            try:
+                if not os.path.isfile(real):
+                    continue
+                size = os.stat(real).st_size
+            except OSError:
+                continue  # vanished (e.g. a download's temp file)
+            if size == 0:
+                continue  # lock files and friends — nothing to prewarm
+            files[rel] = size
+
+        result = {"files": [{"path": p, "size": s} for p, s in sorted(files.items())]}
+        with open(state["result_path"], "w") as f:
+            json.dump(result, f)
+
+        total = sum(files.values())
+        _log(f"Weight capture: {len(files)} files, {total / 1e6:.0f} MB")
+    except Exception as exc:  # noqa: BLE001 - capture must never be fatal
+        _log(f"Weight capture failed: {type(exc).__name__}: {exc}")
+    finally:
+        state["active"] = False
+        _state = None
+
+
+def wrap_setup(setup_fn, spec: dict):
+    """Wrap a setup function so finalize() runs the moment it returns.
+
+    Used by WORKER_WRAPPER, where setup happens deep inside run_worker's
+    socket loop and the wrapper never regains control; the record is
+    written before the worker even connects. When the spec doesn't request
+    capture, returns ``setup_fn`` unchanged. A setup that raises writes no
+    record — a failed load has no working set worth recording.
+    """
+    if not spec.get("weights_capture"):
+        return setup_fn
+
+    def _capturing_setup(*args, **kwargs):
+        calculator = setup_fn(*args, **kwargs)
+        finalize(spec)
+        return calculator
+
+    return _capturing_setup
+
+
+def _log(message: str) -> None:
+    try:
+        print(f"[Worker] {message}", file=sys.stderr, flush=True)
+    except Exception:
+        pass

--- a/tests/cli/test_smoke_test.py
+++ b/tests/cli/test_smoke_test.py
@@ -134,6 +134,26 @@ def test_smoke_test_returns_zero_when_all_pass(populated_root, monkeypatch):
     assert cmd_smoke_test(_make_args(populated_root)) == 0
 
 
+def test_smoke_test_rerecords_weight_files(populated_root, monkeypatch):
+    """Every pass re-captures the weight files the load touched, so records
+    self-heal nightly like verified_at (#177) — and one smoke-test run
+    backfills an install that predates weight tracking."""
+    files = [{"path": "cache/fake/model.bin", "size": 9_000_000}]
+
+    def fake_verify(
+        root, env_name, checkpoint, device, setup_kwargs, *, weights_capture_path=None, **_
+    ):
+        Path(weights_capture_path).write_text(json.dumps({"files": files}))
+        return True, None
+
+    monkeypatch.setattr(smoke_module, "verify_checkpoint", fake_verify)
+    assert cmd_smoke_test(_make_args(populated_root)) == 0
+
+    small = load_manifest(populated_root).environments["mace"].checkpoints["mace-mp-0-small"]
+    assert small.weight_files == files
+    assert small.weights_recorded_at is not None
+
+
 def test_smoke_test_filters_by_env(populated_root, monkeypatch):
     seen: list[tuple[str, str]] = []
     monkeypatch.setattr(

--- a/tests/commands/test_weights_record.py
+++ b/tests/commands/test_weights_record.py
@@ -1,0 +1,227 @@
+"""Manifest weight records from capture results (issue #177).
+
+The capture subprocess writes a JSON result; the operations layer turns it
+into ``CheckpointInfo.weight_files`` under a deliberate merge policy: a
+non-trivial capture replaces the record (freshness self-heals on every
+add/verify/smoke-test pass), a suspiciously small one keeps the previous
+record, and "no capture ran" learns nothing — it must never erase what a
+healthier run recorded.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from rootstock import operations
+from rootstock.manifest import CheckpointInfo, load_manifest
+from rootstock.operations import (
+    OperationError,
+    apply_weights_record,
+    fetch_checkpoint,
+    read_weights_capture,
+    verify_fetched_checkpoint,
+)
+
+_FILES = [
+    {"path": "cache/fake/model.bin", "size": 9_000_000},
+    {"path": "home/.cache/fairchem/uma.pt", "size": 5_000_000},
+]
+
+_MACE_ENV_SOURCE = '''\
+"""MACE env."""
+
+CHECKPOINTS = {
+    "mace-mp-0-medium": "medium",
+}
+
+
+def setup(checkpoint, device="cuda"):
+    return None
+'''
+
+
+# ---- read_weights_capture ----------------------------------------------------
+
+
+def test_read_missing_file_is_none(tmp_path):
+    assert read_weights_capture(tmp_path / "nope.json") is None
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "not json {",
+        json.dumps({"nope": []}),
+        json.dumps({"files": [{"path": 42, "size": 1}]}),
+        json.dumps({"files": [{"path": "a", "size": "big"}]}),
+    ],
+)
+def test_read_unusable_capture_is_none(tmp_path, content):
+    path = tmp_path / "weights.json"
+    path.write_text(content)
+    assert read_weights_capture(path) is None
+
+
+def test_read_valid_capture(tmp_path):
+    path = tmp_path / "weights.json"
+    path.write_text(json.dumps({"files": _FILES}))
+    assert read_weights_capture(path) == _FILES
+
+
+# ---- apply_weights_record merge policy ----------------------------------------
+
+
+def test_nontrivial_capture_replaces_record_sorted():
+    ckpt = CheckpointInfo(
+        weight_files=[{"path": "cache/old.bin", "size": 2_000_000}],
+        weights_recorded_at="2026-01-01T00:00:00+00:00",
+    )
+    apply_weights_record(ckpt, list(reversed(_FILES)))
+    assert ckpt.weight_files == _FILES  # sorted by path
+    assert ckpt.weights_recorded_at > "2026-01-01"
+
+
+def test_none_capture_changes_nothing():
+    old = [{"path": "cache/old.bin", "size": 2_000_000}]
+    ckpt = CheckpointInfo(weight_files=old, weights_recorded_at="2026-01-01T00:00:00+00:00")
+    apply_weights_record(ckpt, None)
+    assert ckpt.weight_files == old
+    assert ckpt.weights_recorded_at == "2026-01-01T00:00:00+00:00"
+
+
+def test_tiny_capture_keeps_old_record_and_says_so():
+    """Below the byte floor the capture is presumed a broken probe, not a
+    real working set — replacing a good record with it would strand the
+    prewarm on its heuristic fallback."""
+    old = [{"path": "cache/old.bin", "size": 2_000_000}]
+    ckpt = CheckpointInfo(weight_files=old, weights_recorded_at="2026-01-01T00:00:00+00:00")
+    said: list[str] = []
+    apply_weights_record(
+        ckpt, [{"path": "cache/crumb", "size": 12}], label="mace/x", progress=said.append
+    )
+    assert ckpt.weight_files == old
+    assert any("suspiciously small" in line for line in said)
+
+
+def test_tiny_capture_with_no_old_record_stays_unrecorded():
+    """An empty-ish record must read as 'never recorded' (heuristic tier),
+    not 'recorded: warm nothing'."""
+    ckpt = CheckpointInfo()
+    apply_weights_record(ckpt, [])
+    assert ckpt.weight_files is None
+    assert ckpt.weights_recorded_at is None
+
+
+# ---- fetch/verify plumbing ----------------------------------------------------
+
+
+@pytest.fixture
+def fake_root(tmp_path: Path) -> Path:
+    """A minimal rootstock root with a fake mace env and a manifest."""
+    root = tmp_path
+    env_dir = root / "envs" / "mace"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+    (env_dir / "env_source.py").write_text(_MACE_ENV_SOURCE)
+
+    from rootstock.config import UserConfig
+    from rootstock.manifest import create_manifest, save_manifest
+
+    cfg = UserConfig(name="t", email="t@t.t")
+    save_manifest(create_manifest(root, "test", cfg), root)
+    return root
+
+
+@pytest.fixture
+def no_refresh(monkeypatch):
+    monkeypatch.setattr(operations, "update_and_push_manifest", lambda *a, **kw: True)
+
+
+def _ckpt(root: Path):
+    return load_manifest(root).environments["mace"].checkpoints["mace-mp-0-medium"]
+
+
+def test_fetch_records_weight_files(fake_root, no_refresh, monkeypatch):
+    """fetch passes a capture path to the download subprocess and merges
+    whatever the wrapper wrote there into the manifest record."""
+
+    def fake_download(
+        root, env_name, checkpoint, setup_kwargs, cache_root=None, weights_capture_path=None
+    ):
+        Path(weights_capture_path).write_text(json.dumps({"files": _FILES}))
+        return True, None
+
+    monkeypatch.setattr(operations, "_run_download", fake_download)
+
+    fetch_checkpoint(fake_root, "mace-mp-0-medium")
+
+    ckpt = _ckpt(fake_root)
+    assert ckpt.weight_files == _FILES
+    assert ckpt.weights_recorded_at is not None
+
+
+def test_fetch_without_capture_leaves_record_alone(fake_root, no_refresh, monkeypatch):
+    """A wrapper that wrote nothing (old staged helper, capture error) must
+    not disturb an existing record."""
+    monkeypatch.setattr(operations, "_run_download", lambda *a, **kw: (True, None))
+
+    fetch_checkpoint(fake_root, "mace-mp-0-medium")
+
+    ckpt = _ckpt(fake_root)
+    assert ckpt.fetched_at is not None
+    assert ckpt.weight_files is None
+
+
+def test_verify_records_weight_files_even_on_failure(fake_root, no_refresh, monkeypatch):
+    """The capture only exists if setup() completed; a forward pass that then
+    fails (CUDA OOM, bad forces) doesn't invalidate the load working set."""
+
+    def fake_verify(
+        root,
+        env_name,
+        checkpoint,
+        device,
+        setup_kwargs,
+        *,
+        cache_root=None,
+        weights_capture_path=None,
+        **_,
+    ):
+        Path(weights_capture_path).write_text(json.dumps({"files": _FILES}))
+        return False, "forces are all (near-)zero"
+
+    monkeypatch.setattr(operations, "verify_checkpoint", fake_verify)
+
+    with pytest.raises(OperationError, match="verify failed"):
+        verify_fetched_checkpoint(fake_root, "mace-mp-0-medium")
+
+    ckpt = _ckpt(fake_root)
+    assert ckpt.verified_at is None
+    assert ckpt.weight_files == _FILES
+
+
+def test_verify_success_records_weight_files(fake_root, no_refresh, monkeypatch):
+    def fake_verify(
+        root,
+        env_name,
+        checkpoint,
+        device,
+        setup_kwargs,
+        *,
+        cache_root=None,
+        weights_capture_path=None,
+        **_,
+    ):
+        Path(weights_capture_path).write_text(json.dumps({"files": _FILES}))
+        return True, None
+
+    monkeypatch.setattr(operations, "verify_checkpoint", fake_verify)
+
+    verify_fetched_checkpoint(fake_root, "mace-mp-0-medium")
+
+    ckpt = _ckpt(fake_root)
+    assert ckpt.verified_at is not None
+    assert ckpt.weight_files == _FILES

--- a/tests/manifest/test_manifest.py
+++ b/tests/manifest/test_manifest.py
@@ -39,7 +39,7 @@ def _make_manifest(envs: dict[str, EnvironmentInfo] | None = None) -> Manifest:
 
 
 def test_schema_version_constant():
-    assert SCHEMA_VERSION == 4
+    assert SCHEMA_VERSION == 5
 
 
 def test_checkpoint_info_round_trip():
@@ -136,6 +136,8 @@ def test_to_dict_key_layout_is_stable():
         "verified_at",
         "verified_device",
         "last_error",
+        "weight_files",
+        "weights_recorded_at",
     ]
 
 

--- a/tests/manifest/test_migrations.py
+++ b/tests/manifest/test_migrations.py
@@ -75,6 +75,7 @@ def test_v2_without_checkpoints_migrates_quietly():
     assert notes == [
         "migrated manifest schema v2 -> v3",
         "migrated manifest schema v3 -> v4",
+        "migrated manifest schema v4 -> v5",
     ]
 
 
@@ -101,8 +102,31 @@ def test_v3_drops_dead_status_fields():
     assert "error_message" not in migrated["environments"]["mace"]
     # v3 checkpoint ids are already canonical — they survive
     assert "mace-mp-0-medium" in migrated["environments"]["mace"]["checkpoints"]
-    assert notes == ["migrated manifest schema v3 -> v4"]
+    assert notes == [
+        "migrated manifest schema v3 -> v4",
+        "migrated manifest schema v4 -> v5",
+    ]
     assert "mace" in Manifest.from_dict(migrated).environments
+
+
+# --- v4 -> v5 -------------------------------------------------------------
+
+
+def test_v4_bumps_cleanly_with_checkpoints_intact():
+    """v5 only *added* optional weight-tracking fields; a v4 manifest's
+    checkpoint records survive untouched and load with the fields absent."""
+    env = _v2_env({"mace-mp-0-medium": {"fetched_at": "2026-01-02T00:00:00Z"}})
+    del env["status"]  # v4 dropped it
+    data = _base(4, {"mace": env})
+
+    migrated, notes = migrate_manifest_data(data)
+
+    assert migrated["schema_version"] == SCHEMA_VERSION
+    assert notes == ["migrated manifest schema v4 -> v5"]
+    ckpt = Manifest.from_dict(migrated).environments["mace"].checkpoints["mace-mp-0-medium"]
+    assert ckpt.fetched_at == "2026-01-02T00:00:00Z"
+    assert ckpt.weight_files is None
+    assert ckpt.weights_recorded_at is None
 
 
 # --- v1 -> v4 (full chain) --------------------------------------------------
@@ -116,7 +140,7 @@ def test_v1_chain_migrates_to_current():
     assert migrated["schema_version"] == SCHEMA_VERSION
     # v1->v2 mints empty CheckpointInfo dicts; v2->v3 then drops them
     assert migrated["environments"]["mace"]["checkpoints"] == {}
-    assert len(notes) == 3
+    assert len(notes) == 4
     assert Manifest.from_dict(migrated).environments["mace"].source_hash == "sha256:abc"
 
 

--- a/tests/server/test_worker_payload.py
+++ b/tests/server/test_worker_payload.py
@@ -70,3 +70,45 @@ def test_worker_spawns_offline(captured_payload, tmp_path: Path):
     )
     _start(server)
     assert captured_payload["_offline"] is True
+
+
+def test_payload_omits_weights_capture_by_default(captured_payload, tmp_path: Path):
+    """Regular calculator spawns never capture — the wrapper must see no key."""
+    server = RootstockServer(
+        env_name="mace",
+        checkpoint="mace-mp-0-medium",
+        device="cpu",
+        root=tmp_path,
+    )
+    _start(server)
+    assert "weights_capture" not in captured_payload
+
+
+def test_payload_carries_weights_capture_with_cache_root_base(captured_payload, tmp_path: Path):
+    """Verification asks for capture; records are relative to the cache root
+    (the split-cache one when the install declares it, else the install root)."""
+    server = RootstockServer(
+        env_name="uma",
+        checkpoint="uma-s-1p1",
+        device="cpu",
+        root=tmp_path,
+        cache_root=tmp_path / "split-cache",
+        weights_capture_path="/tmp/fake_weights.json",
+    )
+    _start(server)
+    assert captured_payload["weights_capture"] == {
+        "result_path": "/tmp/fake_weights.json",
+        "cache_root": str(tmp_path / "split-cache"),
+    }
+
+
+def test_weights_capture_base_falls_back_to_root(captured_payload, tmp_path: Path):
+    server = RootstockServer(
+        env_name="uma",
+        checkpoint="uma-s-1p1",
+        device="cpu",
+        root=tmp_path,
+        weights_capture_path="/tmp/fake_weights.json",
+    )
+    _start(server)
+    assert captured_payload["weights_capture"]["cache_root"] == str(tmp_path)

--- a/tests/worker/test_weights_capture.py
+++ b/tests/worker/test_weights_capture.py
@@ -1,0 +1,299 @@
+"""Weight-file capture at add/verify time (issue #177).
+
+The staged ``weights_capture`` module observes which files under the shared
+cache trees a checkpoint's ``setup()`` actually touches — an audit hook for
+Python-side opens plus a /proc/self/maps scan for mmap'd reads — and writes
+them to a result file the parent turns into a manifest record.
+
+Correctness here means: it records the right files (relative to the cache
+root, deduped through symlinks, out-of-scope and empty files excluded), it
+is a strict no-op unless the spec asks for capture, and it can never take
+the download or the worker down. ``sys.addaudithook`` is process-global and
+irreversible, so every test that installs the hook runs in a subprocess.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from rootstock import weights_capture
+from rootstock.spawn import DOWNLOAD_WRAPPER, WORKER_WRAPPER, spawn_in_env
+
+_PKG_DIR = Path(weights_capture.__file__).parent
+
+
+@pytest.fixture
+def cache_root(tmp_path: Path) -> Path:
+    """A cache root with weights in both trees, plus decoys.
+
+    ``cache/`` is where well-behaved libraries land (XDG_CACHE_HOME);
+    ``home/`` catches the ones that hardcode ``~`` (fairchem). ``elsewhere/``
+    must never be recorded, nor must zero-byte lock files.
+    """
+    root = tmp_path / "shared"
+    (root / "cache" / "fake").mkdir(parents=True)
+    (root / "home" / ".cache" / "fairchem").mkdir(parents=True)
+    (root / "cache" / "fake" / "model.bin").write_bytes(b"w" * 4096)
+    (root / "home" / ".cache" / "fairchem" / "uma.pt").write_bytes(b"u" * 2048)
+    (root / "cache" / "fake" / "model.lock").write_bytes(b"")  # zero-size
+    (tmp_path / "elsewhere").mkdir()
+    (tmp_path / "elsewhere" / "outside.bin").write_bytes(b"o" * 1024)
+    return root
+
+
+def _spec(cache_root: Path, result_path: Path) -> dict:
+    return {
+        "weights_capture": {
+            "result_path": str(result_path),
+            "cache_root": str(cache_root),
+        }
+    }
+
+
+def _run_driver(body: str, spec: dict) -> subprocess.CompletedProcess:
+    """Run ``body`` in a fresh interpreter with the module imported the way
+    the staged wrapper imports it (top-level, from a plain directory)."""
+    script = (
+        "import json, sys\n"
+        f"sys.path.insert(0, {str(_PKG_DIR)!r})\n"
+        "import weights_capture\n"
+        "spec = json.loads(sys.argv[1])\n" + body
+    )
+    return subprocess.run(
+        [sys.executable, "-c", script, json.dumps(spec)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _result(result_path: Path) -> dict:
+    return json.loads(result_path.read_text())
+
+
+# ---- the probes -------------------------------------------------------------
+
+
+def test_capture_records_opened_files_relative_to_cache_root(cache_root, tmp_path):
+    result_path = tmp_path / "weights.json"
+    proc = _run_driver(
+        "weights_capture.begin(spec)\n"
+        f"open({str(cache_root / 'cache' / 'fake' / 'model.bin')!r}, 'rb').read()\n"
+        f"open({str(cache_root / 'home' / '.cache' / 'fairchem' / 'uma.pt')!r}, 'rb').read()\n"
+        f"open({str(cache_root / 'cache' / 'fake' / 'model.lock')!r}, 'rb').read()\n"
+        f"open({str(tmp_path / 'elsewhere' / 'outside.bin')!r}, 'rb').read()\n"
+        "weights_capture.finalize(spec)\n",
+        _spec(cache_root, result_path),
+    )
+    assert proc.returncode == 0, proc.stderr
+
+    files = {f["path"]: f["size"] for f in _result(result_path)["files"]}
+    assert files == {
+        "cache/fake/model.bin": 4096,  # relative to cache_root, so records
+        "home/.cache/fairchem/uma.pt": 2048,  # survive split-cache installs
+    }
+    assert "Weight capture: 2 files" in proc.stderr
+
+
+def test_opens_before_finalize_only(cache_root, tmp_path):
+    """The hook goes dormant at finalize — a long-lived worker's later opens
+    (an MD run's trajectory writes, say) never grow the record."""
+    result_path = tmp_path / "weights.json"
+    proc = _run_driver(
+        "weights_capture.begin(spec)\n"
+        "weights_capture.finalize(spec)\n"
+        f"open({str(cache_root / 'cache' / 'fake' / 'model.bin')!r}, 'rb').read()\n",
+        _spec(cache_root, result_path),
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert _result(result_path)["files"] == []
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="/proc/self/maps is Linux-only")
+def test_maps_scan_catches_mmap_reads_the_hook_missed(cache_root, tmp_path):
+    """safetensors' native reader mmaps without a Python-visible open; the
+    maps scan is the probe that catches it (the fd here is opened before the
+    hook exists, so only the scan can see the file)."""
+    result_path = tmp_path / "weights.json"
+    proc = _run_driver(
+        "import mmap\n"
+        f"f = open({str(cache_root / 'cache' / 'fake' / 'model.bin')!r}, 'rb')\n"
+        "weights_capture.begin(spec)\n"
+        "m = mmap.mmap(f.fileno(), 0, prot=mmap.PROT_READ)\n"
+        "weights_capture.finalize(spec)\n"
+        "m.close(); f.close()\n",
+        _spec(cache_root, result_path),
+    )
+    assert proc.returncode == 0, proc.stderr
+    files = [f["path"] for f in _result(result_path)["files"]]
+    assert files == ["cache/fake/model.bin"]
+
+
+def test_symlinked_file_records_once_as_its_real_path(cache_root, tmp_path):
+    """HF hub's snapshots/ tree symlinks into blobs/; the physical file is
+    what prewarm will read, and seeing both spellings must not double-count."""
+    blob = cache_root / "cache" / "fake" / "model.bin"
+    link = cache_root / "cache" / "fake" / "snapshot.bin"
+    link.symlink_to(blob)
+    result_path = tmp_path / "weights.json"
+    proc = _run_driver(
+        "weights_capture.begin(spec)\n"
+        f"open({str(link)!r}, 'rb').read()\n"
+        f"open({str(blob)!r}, 'rb').read()\n"
+        "weights_capture.finalize(spec)\n",
+        _spec(cache_root, result_path),
+    )
+    assert proc.returncode == 0, proc.stderr
+    files = [f["path"] for f in _result(result_path)["files"]]
+    assert files == ["cache/fake/model.bin"]
+
+
+def test_parse_maps_filters_scope_anonymous_and_deleted():
+    scopes = ("/shared/cache/", "/shared/home/")
+    maps = "\n".join(
+        [
+            "7f0000-7f1000 r--p 00000000 08:01 1 /shared/cache/fake/model.bin",
+            "7f2000-7f3000 rw-p 00000000 00:00 0",  # anonymous
+            "7f4000-7f5000 r-xp 00000000 08:01 2 /usr/lib/libc.so.6",
+            "7f6000-7f7000 r--p 00000000 08:01 3 /shared/home/w.pt (deleted)",
+            "7f8000-7f9000 r--p 00000000 08:01 4 /shared/home/name with spaces.pt",
+        ]
+    )
+    assert weights_capture.parse_maps(maps, scopes) == {
+        "/shared/cache/fake/model.bin",
+        "/shared/home/name with spaces.pt",
+    }
+
+
+# ---- no-op and never-fatal guarantees ---------------------------------------
+
+
+def test_begin_and_wrap_setup_are_noops_without_spec_key():
+    # Safe in-process: without the spec key no audit hook is installed.
+    weights_capture.begin({})
+    assert weights_capture._state is None
+
+    def setup(checkpoint, device):
+        return "calc"
+
+    assert weights_capture.wrap_setup(setup, {}) is setup
+
+
+def test_wrap_setup_writes_record_the_moment_setup_returns(cache_root, tmp_path):
+    result_path = tmp_path / "weights.json"
+    proc = _run_driver(
+        "weights_capture.begin(spec)\n"
+        "def setup(checkpoint, device='cpu'):\n"
+        f"    open({str(cache_root / 'cache' / 'fake' / 'model.bin')!r}, 'rb').read()\n"
+        "    return 'calc'\n"
+        "wrapped = weights_capture.wrap_setup(setup, spec)\n"
+        "assert wrapped('ckpt', device='cpu') == 'calc'\n",
+        _spec(cache_root, result_path),
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert [f["path"] for f in _result(result_path)["files"]] == ["cache/fake/model.bin"]
+
+
+def test_failed_setup_writes_no_record(cache_root, tmp_path):
+    """A load that died has no working set worth recording — the parent must
+    see 'no capture ran', not a half-truth."""
+    result_path = tmp_path / "weights.json"
+    proc = _run_driver(
+        "weights_capture.begin(spec)\n"
+        "def setup(checkpoint, device='cpu'):\n"
+        "    raise RuntimeError('download exploded')\n"
+        "wrapped = weights_capture.wrap_setup(setup, spec)\n"
+        "try:\n"
+        "    wrapped('ckpt')\n"
+        "except RuntimeError:\n"
+        "    pass\n",
+        _spec(cache_root, result_path),
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert not result_path.exists()
+
+
+def test_capture_failure_is_never_fatal(cache_root, tmp_path):
+    """An unwritable result path logs and moves on — capture must never take
+    down the download or the worker."""
+    proc = _run_driver(
+        "weights_capture.begin(spec)\n"
+        f"open({str(cache_root / 'cache' / 'fake' / 'model.bin')!r}, 'rb').read()\n"
+        "weights_capture.finalize(spec)\n"
+        "print('still alive')\n",
+        _spec(cache_root, tmp_path / "no" / "such" / "dir" / "weights.json"),
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "Weight capture failed" in proc.stderr
+    assert "still alive" in proc.stdout
+
+
+# ---- wrapper integration ----------------------------------------------------
+
+
+def _fake_built_env(root: Path, setup_body: str) -> None:
+    env_dir = root / "envs" / "fake"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").symlink_to(sys.executable)
+    (env_dir / "env_source.py").write_text(
+        f"def setup(checkpoint, device='cpu', **kwargs):\n{setup_body}"
+    )
+
+
+def test_download_wrapper_runs_capture_end_to_end(tmp_path: Path):
+    """Through the real staging + subprocess path: setup() touches a file
+    under the spawn-provided cache env, and the record lands at result_path
+    after the process exits — exactly what fetch_checkpoint reads."""
+    weights = tmp_path / "cache" / "fake"
+    weights.mkdir(parents=True)
+    (weights / "model.bin").write_bytes(b"w" * 4096)
+    _fake_built_env(
+        tmp_path,
+        f"    open({str(weights / 'model.bin')!r}, 'rb').read()\n    return None\n",
+    )
+
+    result_path = tmp_path / "weights.json"
+    payload = {
+        "checkpoint": "c",
+        "device": "cpu",
+        "setup_kwargs": {},
+        "weights_capture": {"result_path": str(result_path), "cache_root": str(tmp_path)},
+    }
+    with spawn_in_env(tmp_path, "fake", DOWNLOAD_WRAPPER, payload) as spec:
+        result = subprocess.run(
+            spec.cmd, env=spec.env, cwd=spec.cwd, capture_output=True, text=True
+        )
+    assert result.returncode == 0, result.stderr
+    assert "Weight capture: 1 files" in result.stderr
+    files = json.loads(result_path.read_text())["files"]
+    assert files == [{"path": "cache/fake/model.bin", "size": 4096}]
+
+
+def test_download_wrapper_without_capture_key_stays_silent(tmp_path: Path):
+    """No spec key, no capture — today's spawns are byte-for-byte unaffected."""
+    _fake_built_env(tmp_path, "    return None\n")
+
+    payload = {"checkpoint": "c", "device": "cpu", "setup_kwargs": {}}
+    with spawn_in_env(tmp_path, "fake", DOWNLOAD_WRAPPER, payload) as spec:
+        result = subprocess.run(
+            spec.cmd, env=spec.env, cwd=spec.cwd, capture_output=True, text=True
+        )
+    assert result.returncode == 0, result.stderr
+    assert "Weight capture" not in result.stderr
+
+
+def test_spawn_stages_weights_capture_module_next_to_wrapper(tmp_path: Path):
+    """The staged copy IS the implementation the env's python runs — that's
+    what lets capture reach already-deployed envs without a rebuild."""
+    env_dir = tmp_path / "envs" / "fake"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+
+    with spawn_in_env(tmp_path, "fake", WORKER_WRAPPER, {"checkpoint": "x"}) as spec:
+        staged = Path(spec.cmd[1]).parent / "weights_capture.py"
+        assert staged.exists()
+        assert staged.read_text() == (_PKG_DIR / "weights_capture.py").read_text()

--- a/tests/worker/test_weights_capture.py
+++ b/tests/worker/test_weights_capture.py
@@ -273,6 +273,37 @@ def test_download_wrapper_runs_capture_end_to_end(tmp_path: Path):
     assert files == [{"path": "cache/fake/model.bin", "size": 4096}]
 
 
+def test_download_wrapper_finalizes_while_calculator_is_alive(tmp_path: Path):
+    """The maps probe must scan before the calculator is GC'd — a discarded
+    setup() return value dies immediately under CPython refcounting, and
+    mmap-backed weights are munmap'd with it. The calculator's __del__ here
+    records whether the capture result already existed when it died."""
+    result_path = tmp_path / "weights.json"
+    marker = tmp_path / "del_marker.txt"
+    _fake_built_env(
+        tmp_path,
+        "    return _Calc()\n\n"
+        "class _Calc:\n"
+        "    def __del__(self):\n"
+        "        import os\n"
+        f"        with open({str(marker)!r}, 'w') as f:\n"
+        f"            f.write(str(os.path.exists({str(result_path)!r})))\n",
+    )
+
+    payload = {
+        "checkpoint": "c",
+        "device": "cpu",
+        "setup_kwargs": {},
+        "weights_capture": {"result_path": str(result_path), "cache_root": str(tmp_path)},
+    }
+    with spawn_in_env(tmp_path, "fake", DOWNLOAD_WRAPPER, payload) as spec:
+        result = subprocess.run(
+            spec.cmd, env=spec.env, cwd=spec.cwd, capture_output=True, text=True
+        )
+    assert result.returncode == 0, result.stderr
+    assert marker.read_text() == "True", "calculator was GC'd before finalize ran"
+
+
 def test_download_wrapper_without_capture_key_stays_silent(tmp_path: Path):
     """No spec key, no capture — today's spawns are byte-for-byte unaffected."""
     _fake_built_env(tmp_path, "    return None\n")


### PR DESCRIPTION
Closes #177. First rung of the weight-tracking ladder (#177 → #178 spawn-time lookup → #179 `rootstock prewarm`).

## Problem

The spawn-time prewarm (#167/#168/#171) covers the env tree and `:custom` weights, but not the model-weight caches — the other half of the cold footprint. Weight locations vary per library (fairchem hardcodes `~/.cache`, so UMA's **14 GB** lives under the redirected `{cache_root}/home` regardless of `HF_HOME`) and are tracked nowhere. On cold Lustre those weights fault in via mmap at ~0.35 MB/s: `uma-s-1p1` blew a 2400 s warm-up deadline on Delta 2026-07-29.

## Approach: bookkeeping, not discovery

Rootstock controls every sanctioned path by which weights arrive and get loaded — `rootstock add` runs `setup()` in `DOWNLOAD_WRAPPER`, verify/smoke-test load the same weights in `WORKER_WRAPPER`, all in subprocesses we spawn with cache env vars we set. So observe what those runs actually touch and record it.

**Capture** — new staged helper `weights_capture.py` (stdlib-only, travels next to `prewarm.py`, so it reaches already-deployed envs without a rebuild):
- `sys.addaudithook` on `open` events, scoped to `{cache_root}/cache` and `{cache_root}/home`;
- after `setup()` returns, a `/proc/self/maps` scan for file mappings under the same trees — catches mmap'd reads that bypass Python `open` (safetensors' native reader), which are exactly the slow-fault case;
- strict no-op unless the spawn spec requests capture (regular calculator spawns are unaffected); best-effort, never fatal.

**Record** — manifest schema v5: `CheckpointInfo` gains `weight_files` (`[{path, size}]`, paths relative to the cache root so records survive split-cache installs like Frontier/Perlmutter) and `weights_recorded_at`. File granularity is deliberate: HF hub keeps one repo dir per model *family*, so dir-level records structurally over-warm — and under a `--mem` cgroup that evicts the pages the worker needs. The v4→v5 migration is a pure version bump.

**Merge policy** — a non-trivial capture replaces the record on every add/verify/smoke-test pass (self-healing, like `verified_at`); a suspiciously small one (< 1 MiB) keeps the previous record and says so; no capture learns nothing. Backfilling an existing install is one `rootstock smoke-test` run — no re-downloads.

## Rollout notes

- Older clients refuse a v5 manifest loudly (existing `migrate_manifest_data` posture) — bump maintainer installs before the first record-writing command runs. Today's calculators never read the manifest, so the blast radius is CLI/maintainer surfaces only.
- ⚠️ Before shipping: confirm the dashboard's manifest-push endpoint tolerates the two new keys per checkpoint in a v5 payload.

## Testing

`ruff check`, `ruff format --check`, `ty check`, `pytest` all pass (744 passed; the `/proc/self/maps` test is Linux-only and skips on darwin). New coverage: probe scoping/symlink dedup/never-fatal guarantees via subprocess drivers, real `DOWNLOAD_WRAPPER` end-to-end capture through `spawn_in_env`, v4→v5 migration, merge-policy floor, and fetch/verify/smoke-test record plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)