### PR TITLE
Fix tensornet and pet env recipes (CUDA verify failures)

### DIFF
--- a/sample_model_configurations/nvidia_configs/pet.py
+++ b/sample_model_configurations/nvidia_configs/pet.py
@@ -5,7 +5,7 @@
 #     "ase>=3.22",
 #     # upet pulls nvalchemi-toolkit-ops unpinned; 0.4+ needs torch>=2.8 at
 #     # runtime but only declares the constraint on its extras, so the
-#     # resolver won't catch it (same trap as the tensornet env).
+#     # resolver won't catch it (the same trap that bit the tensornet env).
 #     "torch>=2.8,<2.14",
 # ]
 # ///
@@ -26,6 +26,17 @@ CHECKPOINTS = {
 def setup(checkpoint: str, device: str = "cuda"):
     from huggingface_hub import hf_hub_download
     from upet.calculator import UPETCalculator
+
+    # Force metatomic's vesin neighbor-list fallback. metatomic-ase 0.1.2's
+    # nvalchemi fast path passes max_neighbors = len(system) * max(128,
+    # cutoff**3) — a float whenever the cutoff exceeds 128**(1/3) ≈ 5.04 Å —
+    # into nvalchemiops' torch.full size tuple, which raises TypeError. The
+    # path auto-activates on CUDA because upet hard-depends on
+    # nvalchemi-toolkit-ops, so the import always succeeds. The flag is read
+    # at call time, so patching after import works.
+    import metatomic_ase._neighbors as _neighbors
+
+    _neighbors.HAS_NVALCHEMIOPS = False
 
     # Passing model=/version= makes UPETCalculator resolve the name by listing
     # the hub repo — an uncached API call that fails on workers, which run

--- a/sample_model_configurations/nvidia_configs/tensornet.py
+++ b/sample_model_configurations/nvidia_configs/tensornet.py
@@ -5,10 +5,14 @@
 #     "ase>=3.22",
 #     "huggingface_hub",
 #     "matgl",
-#     # 0.4+ needs torch>=2.8 at runtime (custom-op registration uses string
-#     # annotations infer_schema can't parse on older torch) but only declares
-#     # the constraint on its extras, so the resolver won't catch it.
-#     "nvalchemi-toolkit-ops<0.4",
+#     # nvalchemi-toolkit-ops is deliberately absent. It's only an optional
+#     # matgl extra (accelerated neighbor lists), and no version can work on
+#     # this env's torch pin: 0.3.x registers torch custom ops in modules that
+#     # use `from __future__ import annotations`, which torch 2.4's
+#     # infer_schema can't parse — ValueError at import, and matgl's optional-
+#     # import guard in matgl/ext/ase.py only catches ImportError, so merely
+#     # importing PESCalculator crashes — while 0.4+ requires torch>=2.8.
+#     # Without it, matgl falls back to its own neighbor list.
 #     "pymatgen",
 #     "monty",
 #     "ruamel.yaml",
@@ -24,7 +28,10 @@
 # find-links = ["https://data.pyg.org/whl/torch-2.4.0+cu121.html"]
 #
 # [tool.uv.sources]
-# matgl = { git = "https://github.com/materialsvirtuallab/matgl.git" }
+# # Pinned: this recipe was originally written against matgl 1.0.0, and the
+# # unpinned git HEAD silently started building 4.x. setup() below is written
+# # for 4.0.3 — bump the tag deliberately, not by rebuild accident.
+# matgl = { git = "https://github.com/materialsvirtuallab/matgl.git", tag = "v4.0.3" }
 # ///
 """TensorNet env — hosts MatPES TensorNet checkpoints via MatGL."""
 
@@ -34,42 +41,23 @@ CHECKPOINTS = {
 
 
 def setup(checkpoint: str, device: str = "cuda"):
-    import torch
-
-    torch.set_default_device(device)
-
-    # matgl 1.0.0 imports ExpCellFilter from ase.constraints, but it moved to
-    # ase.filters in ASE 3.23. Patch it in before matgl imports.
-    import ase.constraints
-
-    if not hasattr(ase.constraints, "ExpCellFilter"):
-        from ase.filters import ExpCellFilter
-
-        ase.constraints.ExpCellFilter = ExpCellFilter
-
-    # DGL 2.x graphbolt imports torchdata submodules removed in torchdata>=0.7.
-    # Stub the entire graphbolt subpackage before `import dgl` runs; DGL's
-    # __init__ will use our empty stub and skip the real graphbolt initialisation.
-    # matgl only uses DGL for graph construction — graphbolt is never called.
-    import sys, types
-
-    for _name in [
-        "dgl.graphbolt",
-        "dgl.graphbolt.base",
-        "dgl.graphbolt.dataloader",
-        "dgl.graphbolt.feature_fetcher",
-        "dgl.graphbolt.minibatch_transformer",
-    ]:
-        if _name not in sys.modules:
-            sys.modules[_name] = types.ModuleType(_name)
-
     from huggingface_hub import snapshot_download
 
     import matgl
     from matgl.ext.ase import PESCalculator
 
-    # matgl 1.0.0 load_model only checks the GitHub manifest; HF models must
-    # be downloaded explicitly and passed as a local path.
+    # load_model only resolves names against matgl's own manifest; HF models
+    # must be downloaded explicitly and passed as a local path.
     local_path = snapshot_download(repo_id=CHECKPOINTS[checkpoint])
-    pot = matgl.load_model(local_path)
+
+    # Move with .to(device), never torch.set_default_device: under matgl 4.x
+    # the default-device hack splits the model across devices at load —
+    # Potential.__init__ registers data_mean from a constructor-kwarg tensor
+    # torch.load restored to cpu, while _eye3 (a persistent=False buffer, not
+    # in the state dict) is created fresh on the default device — and
+    # forward() then crashes with a cuda/cpu mismatch at
+    # `lat @ (self._eye3 + st)` in matgl/apps/pes.py. Module.to() moves
+    # params and all buffers coherently, and forward() migrates inputs to the
+    # model's device itself.
+    pot = matgl.load_model(local_path).to(device)
     return PESCalculator(potential=pot)

--- a/tests/sample_configs/test_pet_offline_load.py
+++ b/tests/sample_configs/test_pet_offline_load.py
@@ -51,9 +51,19 @@ def stubbed_libs(monkeypatch):
     upet_calculator.UPETCalculator = UPETCalculator
     upet.calculator = upet_calculator
 
+    # metatomic_ase comes with upet in the real env; setup() patches its
+    # HAS_NVALCHEMIOPS flag to force the vesin neighbor-list fallback.
+    metatomic_ase = types.ModuleType("metatomic_ase")
+    metatomic_neighbors = types.ModuleType("metatomic_ase._neighbors")
+    metatomic_neighbors.HAS_NVALCHEMIOPS = True
+    metatomic_ase._neighbors = metatomic_neighbors
+
     monkeypatch.setitem(sys.modules, "huggingface_hub", hf)
     monkeypatch.setitem(sys.modules, "upet", upet)
     monkeypatch.setitem(sys.modules, "upet.calculator", upet_calculator)
+    monkeypatch.setitem(sys.modules, "metatomic_ase", metatomic_ase)
+    monkeypatch.setitem(sys.modules, "metatomic_ase._neighbors", metatomic_neighbors)
+    captured["neighbors"] = metatomic_neighbors
     return captured
 
 
@@ -76,6 +86,16 @@ def test_setup_passes_checkpoint_path_not_model_name(stubbed_libs):
         "checkpoint_path": "/shared/cache/models/stub.ckpt",
         "device": "cpu",
     }
+
+
+def test_setup_forces_vesin_neighbor_fallback(stubbed_libs):
+    """metatomic-ase 0.1.2's nvalchemi fast path passes a float max_neighbors
+    into torch.full whenever the model cutoff exceeds ~5.04 Å, and it
+    auto-activates on CUDA — setup() must disable it before constructing the
+    calculator."""
+    env = _load_env_module()
+    env.setup("pet-oam-xl", device="cuda")
+    assert stubbed_libs["neighbors"].HAS_NVALCHEMIOPS is False
 
 
 def test_every_checkpoint_maps_to_parseable_filename():


### PR DESCRIPTION
Fixes two env recipes in `sample_model_configurations/nvidia_configs/` that fail checkpoint verification on CUDA. Both failures were confirmed on the Sophia fresh sync (2026-08-03); the tensornet failure reproduced identically on the Delta sync (2026-07-31) — `tensornet-matpes-pbe-2025-2` has never downloaded/verified anywhere.

## tensornet.py

The recipe was written against matgl 1.0.0 but installs matgl from **unpinned git HEAD**, so rebuilds silently started building matgl 4.0.3. Three changes:

1. **Drop `nvalchemi-toolkit-ops<0.4` from the deps.** 0.3.x registers torch custom ops in modules that use `from __future__ import annotations`; torch 2.4's `infer_schema` can't parse the resulting string annotations and raises `ValueError` at import (op: `nvalchemiops::batch_build_cell_list`). matgl's optional-import guard in `matgl/ext/ase.py` only catches `ImportError`, so `from matgl.ext.ase import PESCalculator` crashes outright. On this env's `torch<2.5` pin (held there by the PyG `+pt24cu121` find-links ABI) no version can work — 0.4+ requires torch>=2.8 — and the package is only an optional matgl extra, so removing it just restores matgl's own neighbor-list fallback.

2. **Replace the `torch.set_default_device(device)` hack with `matgl.load_model(local_path).to(device)`.** Under matgl 4.0.3 the default-device hack splits the model across devices at load: `Potential.__init__` registers `data_mean` from a constructor-kwarg tensor that `torch.load` restored to cpu, while `_eye3` (a `persistent=False` buffer, absent from the state dict) is created fresh on the default device (cuda). `forward()` then moves inputs to `self.data_mean.device` and crashes with a cuda/cpu mismatch at `lat @ (self._eye3 + st)` in `matgl/apps/pes.py`. `Module.to(device)` moves params and all buffers coherently.

3. **Remove the dead matgl-1.0.0-era workarounds** (the `ase.constraints.ExpCellFilter` backport and the `dgl.graphbolt` sys.modules stubs — matgl 4.x is PyG-based and has no DGL dependency) and **pin the matgl git source to `v4.0.3`**, so future major-version bumps are deliberate rather than a rebuild side effect.

## pet.py

**Force metatomic's vesin neighbor-list fallback in `setup()`** before constructing `UPETCalculator`. metatomic-ase 0.1.2's nvalchemi fast path computes `max_neighbors = len(system) * max(128, cutoff**3)` — a float whenever the model cutoff exceeds 128^(1/3) ≈ 5.04 Å — and passes it into nvalchemiops' `torch.full` size tuple, which raises `TypeError`. The path auto-activates on CUDA with no opt-out knob (upet hard-depends on nvalchemi-toolkit-ops, so the import always succeeds), which is why CPU verification passed. `HAS_NVALCHEMIOPS` is read at call time, so patching it after import works; the only cost is the CUDA-accelerated neighbor list.

Both root causes are upstream bugs (metatomic-ase's float `max_neighbors`; matgl's too-narrow `except ImportError` guard) — reports to follow separately.

## Deployment

Deployed clusters pick this up by refreshing their staged env sources and re-running `rootstock sync` — only the changed envs (`tensornet`, `pet`) are rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)