### PR TITLE
smoke-test: exercise the custom-weights path and report :custom verification in the manifest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,9 @@ rootstock install <env_source.py> [--root <path>] [--force] [--upgrade]
 # Download + verify a checkpoint by canonical id (idempotent). Use --no-verify on login nodes.
 rootstock add <checkpoint-id> [--kwarg key=val ...] [--device cuda] [--no-verify]
 
-# Re-verify all fetched checkpoints (suitable for nightly cron)
+# Re-verify all fetched checkpoints, plus each '<family>:custom' weights= path
+# (re-loads a same-family checkpoint's cached weights and compares results).
+# Suitable for nightly cron.
 rootstock smoke-test [--env ENV] [--checkpoint CKPT] [--device cuda] [--json]
 
 # Show status (per-checkpoint verified/stale grid; --json for machine-readable)

--- a/rootstock/cli.py
+++ b/rootstock/cli.py
@@ -375,11 +375,20 @@ def main():
         description=(
             "Re-verify checkpoints by running a forward pass on each. Never downloads. "
             "Canonical checkpoints always use setup_kwargs={} — checkpoints requiring "
-            "non-default kwargs may show as failing here even if they work in practice."
+            "non-default kwargs may show as failing here even if they work in practice. "
+            "Each run also exercises every '<family>:custom' entry by re-loading a "
+            "same-family checkpoint's cached weights via the weights= path and "
+            "requiring identical results."
         ),
     )
     smoke_parser.add_argument("--env", help="Filter to a single environment")
-    smoke_parser.add_argument("--checkpoint", help="Filter to a single checkpoint (requires --env)")
+    smoke_parser.add_argument(
+        "--checkpoint",
+        help=(
+            "Filter to a single checkpoint (requires --env); a '<family>:custom' id "
+            "runs just that custom-weights leg and its baseline"
+        ),
+    )
     smoke_parser.add_argument("--device", default="cuda", help="Device (default: cuda)")
     smoke_parser.add_argument("--json", action="store_true", help="Emit a JSON summary")
     smoke_parser.add_argument(

--- a/rootstock/commands/smoke_test.py
+++ b/rootstock/commands/smoke_test.py
@@ -1,15 +1,32 @@
-"""``rootstock smoke-test`` — re-verify checkpoints already in the manifest."""
+"""``rootstock smoke-test`` — re-verify checkpoints already in the manifest.
+
+Besides re-verifying every fetched canonical checkpoint, each run exercises
+the custom-weights path (#200): for every ``<family>:custom`` entry an env
+declares, the weights file a same-family canonical checkpoint already has on
+disk is loaded again via ``weights=`` (``setup_from_path``), and the two
+calculators must agree on the smoke-test structure. The outcome is recorded
+on the ``<family>:custom`` manifest entry so per-cluster support for
+user-supplied weights is visible downstream (e.g. on the almanac).
+"""
 
 from __future__ import annotations
 
 import json
 import sys
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
+from ..environment import (
+    CUSTOM_CHECKPOINT_SUFFIX,
+    is_custom_checkpoint,
+    parse_checkpoints_dict,
+    parse_custom_checkpoint_ids,
+)
 from ..manifest import (
     CheckpointInfo,
     EnvironmentInfo,
+    Manifest,
     is_verified,
     load_manifest,
     manifest_lock,
@@ -17,12 +34,13 @@ from ..manifest import (
     save_manifest,
 )
 from ..operations import (
+    _WEIGHTS_BYTE_FLOOR,
     apply_weights_record,
     read_weights_capture,
     update_and_push_manifest,
     weights_capture_file,
 )
-from ..verify import verify_checkpoint
+from ..verify import results_mismatch, verify_checkpoint
 from .common import get_root_or_exit, resolve_cache_root
 
 
@@ -37,11 +55,107 @@ def _select(
         for ckpt_name, ckpt in env.checkpoints.items():
             if checkpoint_filter is not None and ckpt_name != checkpoint_filter:
                 continue
+            if is_custom_checkpoint(ckpt_name):
+                # ':custom' records track the weights= leg below; they carry
+                # no shipped weights for the canonical loop to verify.
+                continue
             if ckpt.fetched_at is None:
                 # Smoke-test never downloads. Skip checkpoints that have never been fetched.
                 continue
             selected.append((env_name, ckpt_name, env, ckpt))
     return selected
+
+
+@dataclass(frozen=True)
+class CustomLeg:
+    """One planned run of the weights= path: re-load ``base``'s cached
+    weights file under the ``custom_id`` entry and compare results."""
+
+    env_name: str
+    custom_id: str
+    base: str  # same-family canonical checkpoint whose weights drive the leg
+
+
+def _family_of(ckpt_id: str, families: list[str]) -> str | None:
+    """The family a canonical id belongs to: the longest declared family that
+    equals it or prefixes it up to a ``-`` or a version digit — so
+    'mace-off23-small' belongs to 'mace-off' (not 'mace'), 'orb-v2' to
+    'orb-v2', while 'macex-1' belongs to no family named 'mace'."""
+    best = None
+    for family in families:
+        matches = ckpt_id == family or (
+            ckpt_id.startswith(family) and ckpt_id[len(family)] in "-0123456789"
+        )
+        if matches and (best is None or len(family) > len(best)):
+            best = family
+    return best
+
+
+def _plan_custom_legs(
+    root: Path,
+    manifest: Manifest,
+    env_filter: str | None,
+    ckpt_filter: str | None,
+) -> tuple[list[CustomLeg], list[tuple[str, str, str]]]:
+    """Plan one weights= leg per ``<family>:custom`` entry declared by a
+    manifest env's built source (#200).
+
+    The base is the first canonical id (in CHECKPOINTS declaration order —
+    env authors lead with the family's plainest-loading checkpoint) of the
+    same family that the manifest records as fetched. Returns the legs plus
+    ``(env, custom_id, reason)`` for entries that can't run this time.
+    """
+    legs: list[CustomLeg] = []
+    skipped: list[tuple[str, str, str]] = []
+    for env_name, env in manifest.environments.items():
+        if env_filter is not None and env_name != env_filter:
+            continue
+        source = Path(root) / "envs" / env_name / "env_source.py"
+        if not source.exists():
+            continue
+        try:
+            declared = parse_checkpoints_dict(source)
+            custom_ids = parse_custom_checkpoint_ids(source)
+        except ValueError:
+            continue
+        families = [c.removesuffix(CUSTOM_CHECKPOINT_SUFFIX) for c in custom_ids]
+        fetched = [
+            ckpt_id
+            for ckpt_id in declared
+            if (record := env.checkpoints.get(ckpt_id)) and record.fetched_at
+        ]
+        for custom_id, family in zip(custom_ids, families):
+            if ckpt_filter is not None and ckpt_filter != custom_id:
+                continue
+            base = next((c for c in fetched if _family_of(c, families) == family), None)
+            if base is None:
+                skipped.append(
+                    (
+                        env_name,
+                        custom_id,
+                        f"no fetched '{family}' checkpoint to borrow weights from",
+                    )
+                )
+                continue
+            legs.append(CustomLeg(env_name, custom_id, base))
+    return legs, skipped
+
+
+def _dominant_weights_file(files: list[dict] | None) -> str | None:
+    """The single weights file to hand to ``weights=``, from a load capture
+    (#177): the largest recorded file, required to be at least weights-sized
+    and at least twice everything else combined — sidecars (configs,
+    tokenizers) are small, while a second *shard* is comparable to the first.
+    Multi-shard checkpoints have no such file (setup_from_path takes one
+    path), so those can't run this leg. Returns the cache-root-relative
+    path, or None."""
+    if not files:
+        return None
+    largest = max(files, key=lambda f: f["size"])
+    rest = sum(f["size"] for f in files) - largest["size"]
+    if largest["size"] < _WEIGHTS_BYTE_FLOOR or largest["size"] < 2 * rest:
+        return None
+    return largest["path"]
 
 
 def cmd_smoke_test(args) -> int:
@@ -62,11 +176,33 @@ def cmd_smoke_test(args) -> int:
         print(f"Error: no manifest at {root}/manifest.json", file=sys.stderr)
         return 1
 
+    custom_legs, custom_skips = _plan_custom_legs(root, manifest, env_filter, ckpt_filter)
+
     selected = _select(manifest, env_filter, ckpt_filter)
-    if not selected:
+    if ckpt_filter is not None and is_custom_checkpoint(ckpt_filter):
+        # A ':custom' filter matches no canonical row; run just the base
+        # checkpoint(s) the leg needs for its comparison.
+        needed = {(leg.env_name, leg.base) for leg in custom_legs}
+        selected = [t for t in _select(manifest, env_filter, None) if (t[0], t[1]) in needed]
+
+    if not selected and not custom_legs:
         if json_out:
-            print(json.dumps({"results": [], "passed": 0, "failed": 0}, indent=2))
+            print(
+                json.dumps(
+                    {
+                        "results": [],
+                        "passed": 0,
+                        "failed": 0,
+                        "skipped": [
+                            {"env": e, "checkpoint": c, "reason": r} for e, c, r in custom_skips
+                        ],
+                    },
+                    indent=2,
+                )
+            )
         else:
+            for env_name, custom_id, reason in custom_skips:
+                print(f"{env_name}/{custom_id:<24} [SKIP]  {reason}")
             print("No fetched checkpoints to test.")
         return 0
 
@@ -82,12 +218,21 @@ def cmd_smoke_test(args) -> int:
     # anything a co-maintainer wrote in between.
     outcomes: list[tuple[str, str, bool, str | None, list[dict] | None]] = []
 
+    # The custom legs reuse the canonical loop's work: its results are the
+    # comparison baseline, and its fresh weight capture names the file on
+    # disk that weights= re-loads.
+    base_keys = {(leg.env_name, leg.base) for leg in custom_legs}
+    baselines: dict[tuple[str, str], dict] = {}
+    base_captures: dict[tuple[str, str], list[dict] | None] = {}
+    passed_keys: set[tuple[str, str]] = set()
+
     for env_name, ckpt_name, env, ckpt in selected:
         start = time.monotonic()
         # Each pass also re-captures which weight files the load touched, so
         # per-checkpoint weight records self-heal nightly like verified_at
         # (#177) — and backfilling them on an existing install is just one
         # smoke-test run, no re-downloads.
+        run_results: dict = {}
         with weights_capture_file() as capture_path:
             ok, err = verify_checkpoint(
                 root=root,
@@ -97,14 +242,20 @@ def cmd_smoke_test(args) -> int:
                 setup_kwargs={},  # smoke-test always uses env defaults; see design §7.2
                 cache_root=cache_root,
                 weights_capture_path=str(capture_path),
+                results=run_results,
             )
             weight_files = read_weights_capture(capture_path)
         elapsed = time.monotonic() - start
         outcomes.append((env_name, ckpt_name, ok, err, weight_files))
 
+        if (env_name, ckpt_name) in base_keys:
+            baselines[(env_name, ckpt_name)] = run_results
+            base_captures[(env_name, ckpt_name)] = weight_files
+
         # Mirror the outcome onto the working copy so verified_current in the
         # report reflects this run.
         if ok:
+            passed_keys.add((env_name, ckpt_name))
             ckpt.verified_at = now_iso()
             ckpt.verified_device = device
             ckpt.last_error = None
@@ -134,6 +285,92 @@ def cmd_smoke_test(args) -> int:
                 line += f"  {err}"
             print(line)
 
+    # Custom-weights legs (#200): re-load each base's cached weights file via
+    # the weights= path and require agreement with the canonical run.
+    custom_outcomes: list[tuple[str, str, bool, str | None]] = []
+    for leg in custom_legs:
+        key = (leg.env_name, leg.base)
+        if key not in passed_keys:
+            custom_skips.append(
+                (leg.env_name, leg.custom_id, f"baseline {leg.base} failed its own smoke-test")
+            )
+            continue
+        weights_rel = _dominant_weights_file(base_captures.get(key))
+        if weights_rel is None:
+            custom_skips.append(
+                (
+                    leg.env_name,
+                    leg.custom_id,
+                    f"no single dominant weights file in {leg.base}'s capture",
+                )
+            )
+            continue
+        weights_path = Path(cache_root) / weights_rel
+        if not weights_path.is_file():
+            custom_skips.append(
+                (leg.env_name, leg.custom_id, f"recorded weights file missing: {weights_path}")
+            )
+            continue
+
+        start = time.monotonic()
+        run_results = {}
+        ok, err = verify_checkpoint(
+            root=root,
+            env_name=leg.env_name,
+            checkpoint=leg.custom_id,
+            device=device,
+            setup_kwargs={},
+            cache_root=cache_root,
+            checkpoint_path=str(weights_path),
+            results=run_results,
+        )
+        if ok:
+            mismatch = results_mismatch(baselines[key], run_results)
+            if mismatch is not None:
+                ok, err = False, f"weights= run diverges from {leg.base}: {mismatch}"
+        elapsed = time.monotonic() - start
+        custom_outcomes.append((leg.env_name, leg.custom_id, ok, err))
+
+        env = manifest.environments[leg.env_name]
+        ckpt = env.checkpoints.setdefault(leg.custom_id, CheckpointInfo())
+        if ok:
+            ckpt.verified_at = now_iso()
+            ckpt.verified_device = device
+            ckpt.last_error = None
+            n_passed += 1
+        else:
+            ckpt.verified_at = None
+            ckpt.verified_device = None
+            ckpt.last_error = f"smoke-test: {err}"
+            n_failed += 1
+
+        results.append(
+            {
+                "env": leg.env_name,
+                "checkpoint": leg.custom_id,
+                "base_checkpoint": leg.base,
+                "device": device,
+                "passed": ok,
+                "elapsed_s": round(elapsed, 2),
+                "error": err,
+                "verified_current": is_verified(env, ckpt),
+            }
+        )
+
+        if not json_out:
+            verdict = "PASS" if ok else "FAIL"
+            line = (
+                f"{leg.env_name}/{leg.custom_id:<24} [{verdict}]  {device}  {elapsed:5.1f}s"
+                f"  (weights from {leg.base})"
+            )
+            if not ok:
+                line += f"  {err}"
+            print(line)
+
+    if not json_out:
+        for env_name, custom_id, reason in custom_skips:
+            print(f"{env_name}/{custom_id:<24} [SKIP]  {reason}")
+
     with manifest_lock(root):
         fresh = load_manifest(root)
         if fresh is not None:
@@ -156,6 +393,21 @@ def cmd_smoke_test(args) -> int:
                     label=f"{env_name}/{ckpt_name}",
                     progress=None if json_out else print,
                 )
+            for env_name, custom_id, ok, err in custom_outcomes:
+                env_record = fresh.environments.get(env_name)
+                if env_record is None:
+                    continue  # env removed while we were testing
+                # Created on first pass — ':custom' entries are never fetched,
+                # so nothing else ever writes them into the manifest.
+                ckpt_record = env_record.checkpoints.setdefault(custom_id, CheckpointInfo())
+                if ok:
+                    ckpt_record.verified_at = now_iso()
+                    ckpt_record.verified_device = device
+                    ckpt_record.last_error = None
+                else:
+                    ckpt_record.verified_at = None
+                    ckpt_record.verified_device = None
+                    ckpt_record.last_error = f"smoke-test: {err}"
             save_manifest(fresh, root)
     update_and_push_manifest(root, quiet=True, push=not no_push)
 
@@ -168,12 +420,18 @@ def cmd_smoke_test(args) -> int:
                     "results": results,
                     "passed": n_passed,
                     "failed": n_failed,
+                    "skipped": [
+                        {"env": e, "checkpoint": c, "reason": r} for e, c, r in custom_skips
+                    ],
                     "elapsed_s": round(total_elapsed, 2),
                 },
                 indent=2,
             )
         )
     else:
-        print(f"\n{n_passed} passed, {n_failed} failed in {total_elapsed:.1f}s")
+        summary = f"\n{n_passed} passed, {n_failed} failed"
+        if custom_skips:
+            summary += f", {len(custom_skips)} skipped"
+        print(f"{summary} in {total_elapsed:.1f}s")
 
     return 0 if n_failed == 0 else 1

--- a/rootstock/commands/status.py
+++ b/rootstock/commands/status.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 
 from ..config import DEFAULT_CONFIG_FILE
+from ..environment import is_custom_checkpoint
 from ..install_state import InstallState, read_install_state
 from ..manifest import is_verified
 from .common import get_root_or_exit, resolve_cache_root
@@ -17,10 +18,15 @@ def _short_date(iso: str | None) -> str:
 
 
 def _checkpoint_line(env, ckpt_name: str, ckpt) -> str:
-    fetched = f"fetched {_short_date(ckpt.fetched_at)}"
-    if ckpt.last_error and ckpt.fetched_at is None:
-        # Never successfully fetched.
-        return f"    {ckpt_name:<24}  not fetched   ⚠  {ckpt.last_error}"
+    if is_custom_checkpoint(ckpt_name):
+        # ':custom' rows record smoke-test's weights= leg (#200) — there is
+        # nothing to fetch, the user supplies the weights file.
+        fetched = "user weights"
+    else:
+        fetched = f"fetched {_short_date(ckpt.fetched_at)}"
+        if ckpt.last_error and ckpt.fetched_at is None:
+            # Never successfully fetched.
+            return f"    {ckpt_name:<24}  not fetched   ⚠  {ckpt.last_error}"
 
     if ckpt.verified_at is None:
         verified = "not verified"

--- a/rootstock/verify.py
+++ b/rootstock/verify.py
@@ -28,6 +28,13 @@ if TYPE_CHECKING:
 # silent failure where a model returns zeros for everything.
 _FORCE_ZERO_THRESHOLD = 1e-8
 
+# Tolerances for results_mismatch: loose enough for GPU nondeterminism and
+# minor loader differences between setup() and setup_from_path() (e.g. dtype
+# defaults), tight enough that a different model cannot pass — wrong weights
+# move energies by orders of magnitude more than either.
+_ENERGY_ATOL = 1e-4  # eV
+_FORCES_ATOL = 1e-3  # eV/Å
+
 
 def _smoke_test_atoms() -> "Atoms":  # noqa: UP037 — Atoms is TYPE_CHECKING-only
     """Hardcoded H2O-in-a-box used as input for every smoke test."""
@@ -61,6 +68,7 @@ def verify_checkpoint(
     cache_root: Path | None = None,
     checkpoint_path: str | None = None,
     weights_capture_path: str | None = None,
+    results: dict | None = None,
 ) -> tuple[bool, str | None]:
     """
     Run a single forward pass to verify a checkpoint loads and computes.
@@ -78,6 +86,9 @@ def verify_checkpoint(
         weights_capture_path: When set, the worker writes the weight files
                     its setup() touched to this path as JSON (#177); the
                     caller reads it afterwards — a failed load writes nothing.
+        results: When a dict is passed and verification succeeds, it receives
+                    the computed ``energy``/``forces``/``virial`` so the
+                    caller can compare runs (see ``results_mismatch``).
 
     Returns:
         (success, error_message). On success, error_message is None.
@@ -136,4 +147,29 @@ def verify_checkpoint(
     if not np.all(np.isfinite(virial)):
         return False, "non-finite values in virial"
 
+    if results is not None:
+        results["energy"] = float(energy)
+        results["forces"] = np.asarray(forces, dtype=float)
+        results["virial"] = np.asarray(virial, dtype=float)
     return True, None
+
+
+def results_mismatch(baseline: dict, candidate: dict) -> str | None:
+    """
+    Compare two successful ``verify_checkpoint`` results (``results`` dicts)
+    from the same structure on the same device.
+
+    Used by smoke-test's custom-weights leg (#200): the same checkpoint loaded
+    via setup() and via setup_from_path(weights file) must agree — anything
+    beyond tolerance means the weights= path loaded something else.
+
+    Returns a short description of the first difference, or None when they
+    agree within tolerance.
+    """
+    d_energy = abs(candidate["energy"] - baseline["energy"])
+    if d_energy > _ENERGY_ATOL:
+        return f"energy differs by {d_energy:.3e} eV (tolerance {_ENERGY_ATOL:.0e})"
+    d_forces = float(np.max(np.abs(candidate["forces"] - baseline["forces"])))
+    if d_forces > _FORCES_ATOL:
+        return f"max force component differs by {d_forces:.3e} eV/Å (tolerance {_FORCES_ATOL:.0e})"
+    return None

--- a/tests/cli/test_smoke_test.py
+++ b/tests/cli/test_smoke_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 from rootstock.commands import smoke_test as smoke_module
@@ -215,3 +216,288 @@ def test_smoke_test_empty_selection_returns_0(tmp_path, monkeypatch):
     )
     rc = cmd_smoke_test(_make_args(tmp_path))
     assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Custom-weights legs (#200): each '<family>:custom' entry re-loads a
+# same-family checkpoint's cached weights via weights= and must agree.
+# ---------------------------------------------------------------------------
+
+UMA_SOURCE = """\
+CHECKPOINTS = {
+    "uma-s-1p1": "uma-s-1p1",
+    "uma:custom": None,
+}
+
+
+def setup(checkpoint: str, device: str = "cuda"):
+    raise NotImplementedError
+
+
+def setup_from_path(path: str, device: str = "cuda"):
+    raise NotImplementedError
+"""
+
+MACE_SOURCE = """\
+CHECKPOINTS = {
+    "mace-mp-0-small": "small",
+    "mace-off23-small": "off:small",
+    "mace:custom": None,
+    "mace-off:custom": None,
+}
+
+
+def setup(checkpoint: str, device: str = "cuda"):
+    raise NotImplementedError
+
+
+def setup_from_path(path: str, device: str = "cuda"):
+    raise NotImplementedError
+"""
+
+# Weights file each canonical checkpoint's load "touches" (cache-root-relative).
+CAPTURES = {
+    "uma-s-1p1": "cache/uma/uma-s-1p1.pt",
+    "mace-mp-0-small": "cache/mace/mp-small.model",
+    "mace-off23-small": "cache/mace/off-small.model",
+}
+
+
+@pytest.fixture
+def custom_root(tmp_path: Path, monkeypatch) -> Path:
+    """A root whose built env sources declare ':custom' entries: uma (one
+    family) and mace (two families), every canonical checkpoint fetched and
+    its weights file present on disk."""
+    root = tmp_path
+    for env, source in (("uma", UMA_SOURCE), ("mace", MACE_SOURCE)):
+        (root / "envs" / env / "bin").mkdir(parents=True)
+        (root / "envs" / env / "bin" / "python").touch()
+        (root / "envs" / env / "env_source.py").write_text(source)
+    for rel in CAPTURES.values():
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"weights")
+
+    cfg = UserConfig(name="t", email="t@t.t")
+    manifest = create_manifest(root, "test", cfg)
+    manifest.environments["uma"] = EnvironmentInfo(
+        built_at="2026-01-01T00:00:00Z",
+        source_hash="sha256:abc",
+        source="",
+        python_requires=">=3.10",
+        dependencies={},
+        checkpoints={"uma-s-1p1": CheckpointInfo(fetched_at="2026-01-02T00:00:00Z")},
+    )
+    manifest.environments["mace"] = EnvironmentInfo(
+        built_at="2026-01-01T00:00:00Z",
+        source_hash="sha256:def",
+        source="",
+        python_requires=">=3.10",
+        dependencies={},
+        checkpoints={
+            "mace-mp-0-small": CheckpointInfo(fetched_at="2026-01-02T00:00:00Z"),
+            "mace-off23-small": CheckpointInfo(fetched_at="2026-01-02T00:00:00Z"),
+        },
+    )
+    save_manifest(manifest, root)
+
+    monkeypatch.setattr(
+        "rootstock.commands.smoke_test.update_and_push_manifest",
+        lambda *a, **kw: True,
+    )
+    return root
+
+
+def _fake_verify_factory(calls: list[dict], custom_energy_offset: float = 0.0, fail=()):
+    """A verify_checkpoint stand-in: canonical calls write a one-file weight
+    capture (per CAPTURES); every successful call fills identical results,
+    except custom legs get ``custom_energy_offset`` added."""
+
+    def fake_verify(
+        root,
+        env_name,
+        checkpoint,
+        device,
+        setup_kwargs,
+        cache_root=None,
+        checkpoint_path=None,
+        weights_capture_path=None,
+        results=None,
+    ):
+        calls.append(
+            {"env": env_name, "checkpoint": checkpoint, "checkpoint_path": checkpoint_path}
+        )
+        if checkpoint in fail:
+            return False, "RuntimeError: boom"
+        if weights_capture_path is not None and checkpoint in CAPTURES:
+            Path(weights_capture_path).write_text(
+                json.dumps({"files": [{"path": CAPTURES[checkpoint], "size": 9_000_000}]})
+            )
+        if results is not None:
+            results["energy"] = -10.0 + (custom_energy_offset if checkpoint_path else 0.0)
+            results["forces"] = np.full((3, 3), 0.1)
+        return True, None
+
+    return fake_verify
+
+
+def test_custom_leg_verifies_and_records(custom_root, monkeypatch):
+    calls: list[dict] = []
+    monkeypatch.setattr(smoke_module, "verify_checkpoint", _fake_verify_factory(calls))
+
+    assert cmd_smoke_test(_make_args(custom_root)) == 0
+
+    m = load_manifest(custom_root)
+    custom = m.environments["uma"].checkpoints["uma:custom"]
+    assert custom.verified_at is not None
+    assert custom.verified_device == "cuda"
+    assert custom.last_error is None
+    assert custom.fetched_at is None  # never fetched — the user supplies weights
+
+    (leg,) = [c for c in calls if c["checkpoint"] == "uma:custom"]
+    assert leg["checkpoint_path"] == str(custom_root / "cache/uma/uma-s-1p1.pt")
+
+
+def test_custom_leg_pairs_each_family_with_its_base(custom_root, monkeypatch):
+    calls: list[dict] = []
+    monkeypatch.setattr(smoke_module, "verify_checkpoint", _fake_verify_factory(calls))
+
+    assert cmd_smoke_test(_make_args(custom_root, env="mace")) == 0
+
+    by_ckpt = {c["checkpoint"]: c for c in calls if c["checkpoint_path"]}
+    assert by_ckpt["mace:custom"]["checkpoint_path"] == str(
+        custom_root / "cache/mace/mp-small.model"
+    )
+    assert by_ckpt["mace-off:custom"]["checkpoint_path"] == str(
+        custom_root / "cache/mace/off-small.model"
+    )
+
+    m = load_manifest(custom_root)
+    assert m.environments["mace"].checkpoints["mace:custom"].verified_at is not None
+    assert m.environments["mace"].checkpoints["mace-off:custom"].verified_at is not None
+
+
+def test_custom_leg_divergence_fails_and_records_error(custom_root, monkeypatch):
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        smoke_module,
+        "verify_checkpoint",
+        _fake_verify_factory(calls, custom_energy_offset=1.0),
+    )
+
+    assert cmd_smoke_test(_make_args(custom_root, env="uma")) == 1
+
+    custom = load_manifest(custom_root).environments["uma"].checkpoints["uma:custom"]
+    assert custom.verified_at is None
+    assert "diverges" in custom.last_error
+    # The canonical baseline itself passed.
+    base = load_manifest(custom_root).environments["uma"].checkpoints["uma-s-1p1"]
+    assert base.verified_at is not None
+
+
+def test_custom_leg_skipped_when_baseline_fails(custom_root, monkeypatch, capsys):
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        smoke_module,
+        "verify_checkpoint",
+        _fake_verify_factory(calls, fail={"uma-s-1p1"}),
+    )
+
+    rc = cmd_smoke_test(_make_args(custom_root, env="uma", json=True))
+    assert rc == 1  # the canonical failure
+
+    parsed = json.loads(capsys.readouterr().out.strip())
+    (skip,) = parsed["skipped"]
+    assert skip["checkpoint"] == "uma:custom"
+    assert "baseline" in skip["reason"]
+    # No weights= call was attempted, and no manifest entry was written.
+    assert all(c["checkpoint_path"] is None for c in calls)
+    assert "uma:custom" not in load_manifest(custom_root).environments["uma"].checkpoints
+
+
+def test_custom_leg_skipped_without_fetched_family_base(custom_root, monkeypatch, capsys):
+    m = load_manifest(custom_root)
+    m.environments["uma"].checkpoints["uma-s-1p1"].fetched_at = None
+    save_manifest(m, custom_root)
+
+    monkeypatch.setattr(smoke_module, "verify_checkpoint", _fake_verify_factory([]))
+    rc = cmd_smoke_test(_make_args(custom_root, env="uma", json=True))
+    assert rc == 0
+
+    parsed = json.loads(capsys.readouterr().out.strip())
+    assert parsed["results"] == []
+    (skip,) = parsed["skipped"]
+    assert skip["checkpoint"] == "uma:custom"
+    assert "no fetched" in skip["reason"]
+
+
+def test_custom_leg_skipped_without_dominant_weights_file(custom_root, monkeypatch, capsys):
+    def fake_verify(root, env_name, checkpoint, device, setup_kwargs, **kw):
+        if kw.get("weights_capture_path"):
+            # Two comparable shards — no single file to hand to weights=.
+            Path(kw["weights_capture_path"]).write_text(
+                json.dumps(
+                    {
+                        "files": [
+                            {"path": "cache/uma/shard1.pt", "size": 9_000_000},
+                            {"path": "cache/uma/shard2.pt", "size": 8_000_000},
+                        ]
+                    }
+                )
+            )
+        if kw.get("results") is not None:
+            kw["results"]["energy"] = -10.0
+            kw["results"]["forces"] = np.full((3, 3), 0.1)
+        return True, None
+
+    monkeypatch.setattr(smoke_module, "verify_checkpoint", fake_verify)
+    rc = cmd_smoke_test(_make_args(custom_root, env="uma", json=True))
+    assert rc == 0
+
+    parsed = json.loads(capsys.readouterr().out.strip())
+    (skip,) = parsed["skipped"]
+    assert "dominant" in skip["reason"]
+    assert "uma:custom" not in load_manifest(custom_root).environments["uma"].checkpoints
+
+
+def test_custom_checkpoint_filter_runs_only_leg_and_baseline(custom_root, monkeypatch):
+    calls: list[dict] = []
+    monkeypatch.setattr(smoke_module, "verify_checkpoint", _fake_verify_factory(calls))
+
+    rc = cmd_smoke_test(_make_args(custom_root, env="uma", checkpoint="uma:custom"))
+    assert rc == 0
+    assert [c["checkpoint"] for c in calls] == ["uma-s-1p1", "uma:custom"]
+
+
+def test_select_never_picks_custom_manifest_entries(custom_root):
+    """Even a hand-edited ':custom' record with fetched_at set must not enter
+    the canonical loop — there are no shipped weights for setup() to load."""
+    m = load_manifest(custom_root)
+    m.environments["uma"].checkpoints["uma:custom"] = CheckpointInfo(
+        fetched_at="2026-01-02T00:00:00Z"
+    )
+    selected = smoke_module._select(m, None, None)
+    assert all(name != "uma:custom" for _, name, _, _ in selected)
+
+
+def test_family_of_longest_match_wins():
+    families = ["mace", "mace-off"]
+    assert smoke_module._family_of("mace-off23-small", families) == "mace-off"
+    assert smoke_module._family_of("mace-mp-0-small", families) == "mace"
+    assert smoke_module._family_of("orb-v2", ["orb-v2"]) == "orb-v2"
+    assert smoke_module._family_of("esen-sm-direct-all-omol", ["uma"]) is None
+    # Prefixes only count on a '-' boundary.
+    assert smoke_module._family_of("macex-1", ["mace"]) is None
+
+
+def test_dominant_weights_file():
+    assert smoke_module._dominant_weights_file(None) is None
+    assert smoke_module._dominant_weights_file([]) is None
+    big = {"path": "cache/a/model.pt", "size": 9_000_000}
+    small = {"path": "cache/a/config.json", "size": 1_000}
+    assert smoke_module._dominant_weights_file([big, small]) == "cache/a/model.pt"
+    # Two comparable shards: ambiguous, setup_from_path takes one path.
+    shard = {"path": "cache/a/shard2.pt", "size": 8_000_000}
+    assert smoke_module._dominant_weights_file([big, shard]) is None
+    # A lone tiny file is a broken capture, not weights.
+    assert smoke_module._dominant_weights_file([small]) is None

--- a/tests/verify/test_verify_checkpoint.py
+++ b/tests/verify/test_verify_checkpoint.py
@@ -229,3 +229,50 @@ def test_verify_opts_out_of_usage_recording(monkeypatch):
     monkeypatch.setattr("rootstock.server.RootstockServer", factory)
     verify.verify_checkpoint(Path("/tmp"), "mace", "mace-mp-0-medium", "cuda")
     assert captured["usage_client"] is None
+
+
+def test_verify_fills_results_on_success(stub_server):
+    stub_server(energy=-10.5, forces=_ok_forces(), virial=_ok_virial())
+    results: dict = {}
+    ok, _ = verify.verify_checkpoint(
+        Path("/tmp"), "mace", "mace-mp-0-medium", "cuda", results=results
+    )
+    assert ok is True
+    assert results["energy"] == -10.5
+    np.testing.assert_allclose(results["forces"], _ok_forces())
+    np.testing.assert_allclose(results["virial"], _ok_virial())
+
+
+def test_verify_leaves_results_empty_on_failure(stub_server):
+    """A failed run must not hand the caller half-trustworthy numbers."""
+    stub_server(energy=float("nan"), forces=_ok_forces(), virial=_ok_virial())
+    results: dict = {}
+    ok, _ = verify.verify_checkpoint(
+        Path("/tmp"), "mace", "mace-mp-0-medium", "cuda", results=results
+    )
+    assert ok is False
+    assert results == {}
+
+
+def test_results_mismatch_agrees_within_tolerance():
+    a = {"energy": -10.5, "forces": _ok_forces()}
+    b = {"energy": -10.5 + 5e-5, "forces": _ok_forces() + 5e-4}
+    assert verify.results_mismatch(a, b) is None
+
+
+def test_results_mismatch_flags_energy_difference():
+    a = {"energy": -10.5, "forces": _ok_forces()}
+    b = {"energy": -10.4, "forces": _ok_forces()}
+    msg = verify.results_mismatch(a, b)
+    assert msg is not None
+    assert "energy" in msg
+
+
+def test_results_mismatch_flags_force_difference():
+    a = {"energy": -10.5, "forces": _ok_forces()}
+    delta = np.zeros((3, 3))
+    delta[0, 0] = 0.01
+    b = {"energy": -10.5, "forces": _ok_forces() + delta}
+    msg = verify.results_mismatch(a, b)
+    assert msg is not None
+    assert "force" in msg


### PR DESCRIPTION
Closes #200. **Stacked on #202** (weight-file records) — merge that first; this diff is just the top commit.

## What

Every `rootstock smoke-test` run now exercises the custom-checkpoint (`weights=`) machinery (#173–#175), and records the outcome on a `<family>:custom` entry in the manifest so per-cluster support for user-supplied weights is visible downstream (e.g. on the almanac, which reads the manifest dump).

For each `<family>:custom` entry a built env declares:

1. **Pick a baseline**: the first (in `CHECKPOINTS` declaration order) fetched canonical checkpoint of the same family — longest-prefix family match, allowing a version digit at the boundary so `mace-off` owns `mace-off23-small` while `mace` doesn't.
2. **Resolve its weights on disk**: the *dominant* file of the baseline's weight capture from this very run (#177 records) — largest recorded file, ≥1 MiB and ≥2× everything else combined, so multi-shard checkpoints are skipped rather than mis-loaded. No extra download: the capture is fresh and the file is already local.
3. **Re-load via `weights=`**: same env, `checkpoint=<family>:custom`, `checkpoint_path=` the resolved file → the worker's `setup_from_path` branch.
4. **Compare**: energy/forces must agree with the canonical run within 1e-4 eV / 1e-3 eV/Å (`verify.results_mismatch`) — loose enough for GPU nondeterminism and minor loader drift, orders of magnitude too tight for wrong weights to pass.

The outcome lands in the same locked manifest write as the canonical outcomes: `<family>:custom` gets `verified_at`/`verified_device`/`last_error` (never `fetched_at` — there's nothing to fetch; smoke-test is the only writer of these entries).

## Behavior notes

- Legs **skip non-fatally** (text `[SKIP]` lines + a `skipped` array in `--json`) when the baseline fails its own smoke-test, no family checkpoint is fetched, or the capture has no single dominant file. Skips leave the manifest entry untouched.
- `--env X --checkpoint <family>:custom` runs just that leg plus its baseline — handy for validating the custom path on a cluster without a full sweep.
- `_select` now explicitly refuses `:custom` ids for the canonical loop (belt-and-braces on top of `fetched_at is None`).
- `status` renders `:custom` rows as `user weights` instead of the misleading `not fetched`; `sync`'s planner already skips `:custom` ids, and the manifest refresh carries the entries through to the push unchanged.
- Nightly scripts need no change.

## Known limits (deliberate)

- A family whose only fetched checkpoint loads differently through the hook than through `setup()` (e.g. `mace-mh-1`: float64 + `head=` canonically, float32 + no head via `setup_from_path`) would fail the comparison. Declaration order protects against this as long as a plain-loading family member is fetched — env authors should keep one early in `CHECKPOINTS`.
- Testing one family's weights verifies the shared per-env hook; each family entry is still only marked verified when its own family's weights were actually exercised.

## Testing

- Unit tests for family matching, dominant-file selection, leg planning/skipping, divergence failure, manifest recording, and the `:custom` filter (12 new tests in `tests/cli/test_smoke_test.py`, 5 in `tests/verify/`).
- `ruff check`, `ruff format --check`, `ty check`, full `pytest` all green (759 passed).
- Not yet validated end-to-end on a real cluster; `rootstock smoke-test --env uma --checkpoint uma:custom` on Frontier/Delta is the intended first live run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)