### PR TITLE
Add 'rootstock prune': the subtractive half of sync

### DIFF
--- a/rootstock/batch.py
+++ b/rootstock/batch.py
@@ -763,6 +763,11 @@ def plan_prune(
     declared set (including unregistering source files). Category-B internal
     garbage is collected in both modes; ``gc_only`` limits the plan to it.
 
+    A declaring directory that exists but is *empty* affirmatively declares
+    zero environments (everything installed is undeclared); a registry dir
+    that doesn't exist declares nothing, and the plan degrades to the
+    internal-GC tier alone.
+
     ``min_age_hours`` guards every category-B item: pid-liveness is
     meaningless on a shared filesystem (the build owning ``.build/<env>.<pid>``
     may be on another node), so anything mtime-newer than the guard is left
@@ -794,13 +799,27 @@ def plan_prune(
     registered = dict(state.sources)
 
     # ---- desired sources ----------------------------------------------------
+    # Presence vs. absence of the declaring directory carries meaning. A
+    # directory that exists but declares nothing is an affirmative "zero
+    # environments" — the declarative retirement move ("delete the source,
+    # prune") taken to its limit. An *absent* registry is no declaration at
+    # all: there is nothing to converge to, so only the internal-GC tier
+    # (which needs no declared state) runs. A nonexistent SOURCE_DIR stays a
+    # usage error in the adapter — that's a typo, not a declaration.
+    declarative = not gc_only
     if source_dir is not None:
-        staged = sorted(source_dir.glob("*.py"))
-        if not staged:
-            raise ops.OperationError(f"No *.py environment files found in {source_dir}")
-        desired: dict[str, Path] = {path.stem: path for path in staged}
-    else:
+        desired: dict[str, Path] = {path.stem: path for path in sorted(source_dir.glob("*.py"))}
+    elif (root / "environments").is_dir():
         desired = registered
+    else:
+        desired = {}
+        if declarative and (state.envs or (manifest is not None and bool(manifest.environments))):
+            plan.notes.append(
+                f"{root / 'environments'} does not exist — no declared state to "
+                f"converge to; collecting internal garbage only (an empty "
+                f"environments/ dir, by contrast, declares zero environments)"
+            )
+        declarative = False
 
     # ---- scope validation (mirrors sync) -------------------------------------
     known_envs = set(state.envs) | set(registered) | set(desired)
@@ -831,14 +850,16 @@ def plan_prune(
     # passes --yes, so "prune this one checkpoint id" must not ride along
     # with env deletion nobody asked for. --env restores env pruning scoped
     # to the named envs.
-    env_tier = not gc_only and (bool(envs) or not checkpoints)
+    env_tier = declarative and (bool(envs) or not checkpoints)
     pruned_env_names: set[str] = set()
-    if env_tier and source_dir is None and not registered and state.envs:
-        # A lost/empty environments/ dir would read as "delete everything";
-        # the plan-confirm gate protects execution, but say it out loud.
+    if env_tier and not desired and (state.envs or registered):
+        # Reachable only when the declaring dir exists (an absent registry
+        # already degraded to gc-only above): a deliberate zero-environment
+        # declaration. The plan-confirm gate still stands, but say it plainly.
+        where = source_dir if source_dir is not None else root / "environments"
         plan.notes.append(
-            f"no env sources are registered under {root / 'environments'} — every "
-            f"built env counts as undeclared (use --gc-only if that's not intended)"
+            f"{where} declares no environments — reading it as a deliberate "
+            f"zero-environment state; everything installed will be removed"
         )
     if env_tier:
         for name in sorted(set(state.envs) | set(registered)):
@@ -867,7 +888,7 @@ def plan_prune(
     # parsed keeps everything: sync's planner skips *adding* work on a parse
     # error, so prune must skip *removing* — the conservative direction flips.
     declared_by_env: dict[str, set[str] | None] = {}
-    if not gc_only:
+    if declarative:
         for name in sorted(desired):
             try:
                 declared_by_env[name] = set(parse_checkpoints_dict(desired[name]))
@@ -879,7 +900,7 @@ def plan_prune(
                 )
 
     pruned: list[tuple[str, str, CheckpointInfo, str]] = []  # (env, ckpt, record, reason)
-    if not gc_only and manifest is not None:
+    if declarative and manifest is not None:
         for env_name in sorted(manifest.environments):
             if envs and env_name not in envs:
                 continue
@@ -1069,7 +1090,9 @@ def plan_prune(
     # The records capture the read working set, not the download set, so
     # "delete everything unrecorded" would over-delete. Report it instead;
     # --deep graduates it to deletion for maintainers who trust the records.
-    if not gc_only:
+    # Gated on `declarative`: with no registry dir at all, the root doesn't
+    # look like a healthy install, and --deep especially shouldn't act on it.
+    if declarative:
         attributed_files: set[str] = set()
         for record in manifest.environments.values() if manifest else []:
             for info in record.checkpoints.values():

--- a/rootstock/batch.py
+++ b/rootstock/batch.py
@@ -1,7 +1,8 @@
 """
-Batch convergence: the planner and executor behind ``rootstock sync``.
+Batch convergence: the planners and executors behind ``rootstock sync`` and
+``rootstock prune``.
 
-The planner diffs desired state — the env sources registered in
+The sync planner diffs desired state — the env sources registered in
 ``{root}/environments/``, optionally overlaid by a staging directory of
 new/patched sources, plus each source's CHECKPOINTS table — against actual
 state (the InstallState reader + manifest), and emits only the delta as work
@@ -11,11 +12,21 @@ plain threads suffice), with keep-going failure semantics: a failed item
 skips its dependents with the cause attached, and whatever didn't converge
 is picked up by simply re-running sync. The install root is the checkpoint;
 there is no other resume state.
+
+The prune planner takes the opposite half of the same diff — ``actual −
+desired`` — plus an internal-GC tier that needs no declared state at all
+(``.build`` leftovers, orphaned interpreters, stale lockfiles, ``.trash``,
+the uv cache). Same keep-going executor idiom, same single end-of-run
+manifest refresh + push. Deletion orders are chosen so a crash mid-run
+strands only *unreferenced* state that a later run collects.
 """
 
 from __future__ import annotations
 
+import os
 import queue
+import shutil
+import subprocess
 import threading
 import time
 from collections.abc import Callable, Sequence
@@ -27,7 +38,15 @@ from . import operations as ops
 from .environment import is_custom_checkpoint, parse_checkpoints_dict
 from .exceptions import RootstockError
 from .install_state import read_install_state
-from .manifest import compute_source_hash, is_verified
+from .layout import resolve_cache_root
+from .manifest import (
+    CheckpointInfo,
+    compute_source_hash,
+    is_verified,
+    load_manifest,
+    manifest_lock,
+    save_manifest,
+)
 from .verify import DEFAULT_VERIFY_TIMEOUT
 
 PHASES = ("build", "download", "verify")
@@ -531,3 +550,739 @@ def render_summary(report: SyncReport, say: Say = print) -> None:
         say(f"  skipped {result.phase}: {result.label} — {result.reason}")
     if report.failed:
         say("Re-run the same sync after fixing; completed work is skipped automatically.")
+
+
+# -----------------------------------------------------------------------------
+# Prune plan
+# -----------------------------------------------------------------------------
+
+DEFAULT_MIN_AGE_HOURS = 24.0
+
+
+@dataclass
+class PruneCheckpointItem:
+    """Drop one checkpoint's manifest record, then its unshared weight files.
+
+    ``files`` are cache-root-relative paths from the record's ``weight_files``
+    minus anything a surviving checkpoint also recorded (HF blobs are shared
+    within a repo dir) and minus files covered by a whole-repo-dir item.
+    ``recorded=False`` means the checkpoint predates weight tracking: only the
+    record is dropped, and its weights surface as unattributed cache instead.
+    """
+
+    env_name: str
+    checkpoint: str
+    reason: str
+    recorded: bool = True
+    files: list[str] = field(default_factory=list)
+    reclaim_bytes: int = 0
+
+
+@dataclass
+class PruneWeightDirItem:
+    """Remove a whole HF repo dir: every checkpoint attributed to it is
+    being pruned, so unrecorded residue (unread snapshot files, refs, locks)
+    goes with it."""
+
+    path: str  # cache-root-relative, e.g. cache/huggingface/hub/models--x--y
+    reason: str
+    checkpoints: list[str] = field(default_factory=list)
+    reclaim_bytes: int = 0
+
+    @property
+    def env_name(self) -> str:  # display label for ItemResult
+        return Path(self.path).name
+
+
+@dataclass
+class PruneEnvItem:
+    """Remove a built env (trash-rename, then rmtree) and, in SOURCE_DIR
+    mode, unregister its source file + lockfile."""
+
+    env_name: str
+    reason: str
+    reclaim_bytes: int = 0
+    env_dir: bool = True  # False: registered source with no built env
+    source_file: str | None = None  # environments/<name>.py to unregister
+
+
+@dataclass
+class GCItem:
+    """One piece of internal garbage; ``path`` is absolute."""
+
+    kind: str  # "build" | "trash" | "interpreter" | "lockfile" | "uv-cache" | "unattributed"
+    path: str
+    reason: str
+    reclaim_bytes: int | None = None  # None: unknown until executed (uv-cache)
+
+    @property
+    def env_name(self) -> str:  # display label for ItemResult
+        return f"{self.kind}:{Path(self.path).name}"
+
+
+@dataclass
+class PrunePlan:
+    """``actual − desired``, as ordered delete items, plus internal GC."""
+
+    checkpoints: list[PruneCheckpointItem] = field(default_factory=list)
+    weight_dirs: list[PruneWeightDirItem] = field(default_factory=list)
+    envs: list[PruneEnvItem] = field(default_factory=list)
+    gc: list[GCItem] = field(default_factory=list)
+    # Tier 2: cache/home contents no weight record attributes. Report-only
+    # unless --deep graduated them into gc items.
+    unattributed: list[dict] = field(default_factory=list)  # {"path", "bytes"}
+    notes: list[str] = field(default_factory=list)
+
+    @property
+    def is_empty(self) -> bool:
+        return not (self.checkpoints or self.weight_dirs or self.envs or self.gc)
+
+    @property
+    def reclaim_bytes(self) -> int:
+        return (
+            sum(i.reclaim_bytes for i in self.checkpoints)
+            + sum(i.reclaim_bytes for i in self.weight_dirs)
+            + sum(i.reclaim_bytes for i in self.envs)
+            + sum(i.reclaim_bytes or 0 for i in self.gc)
+        )
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def _tree_bytes(path: Path) -> int:
+    """Recursive apparent size; symlinks counted, never followed."""
+    try:
+        if not path.is_dir() or path.is_symlink():
+            return path.lstat().st_size
+    except OSError:
+        return 0
+    total = 0
+    for dirpath, _dirnames, filenames in os.walk(path):
+        for name in filenames:
+            try:
+                total += (Path(dirpath) / name).lstat().st_size
+            except OSError:
+                pass
+    return total
+
+
+def format_bytes(n: int) -> str:
+    value = float(n)
+    for unit in ("B", "KB", "MB", "GB"):
+        if abs(value) < 1024:
+            return f"{value:.0f} {unit}" if unit == "B" else f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{value:.1f} TB"
+
+
+def _safe_weight_path(cache_base: Path, relpath: str) -> Path | None:
+    """Resolve a recorded cache-relative path, refusing anything that could
+    escape the cache root — a corrupted record must not become an rm outside
+    the install."""
+    rel = Path(relpath)
+    if rel.is_absolute() or ".." in rel.parts or not rel.parts:
+        return None
+    return cache_base / rel
+
+
+def _hf_repo_dir(relpath: str) -> str | None:
+    """The cache-relative HF repo dir containing ``relpath``, if any.
+
+    HF hub keeps one ``models--org--name`` dir per repo, with blobs shared by
+    every revision — the unit at which whole-dir removal is safe.
+    """
+    parts = Path(relpath).parts
+    for i, part in enumerate(parts):
+        if part.startswith(("models--", "datasets--")):
+            return str(Path(*parts[: i + 1]))
+    return None
+
+
+def plan_prune(
+    root: Path,
+    *,
+    source_dir: Path | None = None,
+    envs: list[str] | None = None,
+    checkpoints: list[str] | None = None,
+    gc_only: bool = False,
+    deep: bool = False,
+    min_age_hours: float = DEFAULT_MIN_AGE_HOURS,
+    cache_root: Path | None = None,
+) -> PrunePlan:
+    """Compute what pruning would remove from ``root``.
+
+    Desired state mirrors sync's inputs: the sources registered in
+    ``{root}/environments/`` — or, with ``source_dir``, exactly that
+    directory, so ``sync dir/ && prune dir/`` converges a cluster to a
+    declared set (including unregistering source files). Category-B internal
+    garbage is collected in both modes; ``gc_only`` limits the plan to it.
+
+    ``min_age_hours`` guards every category-B item: pid-liveness is
+    meaningless on a shared filesystem (the build owning ``.build/<env>.<pid>``
+    may be on another node), so anything mtime-newer than the guard is left
+    alone and noted.
+    """
+    root = Path(root)
+    cache_base = Path(cache_root) if cache_root is not None else resolve_cache_root(root)
+    state = read_install_state(root)
+    manifest = state.manifest
+    plan = PrunePlan()
+    cutoff = time.time() - min_age_hours * 3600.0
+
+    def young(path: Path) -> bool:
+        try:
+            return path.lstat().st_mtime > cutoff
+        except OSError:
+            return True  # can't stat it -> don't touch it
+
+    registered = dict(state.sources)
+
+    # ---- desired sources ----------------------------------------------------
+    if source_dir is not None:
+        staged = sorted(source_dir.glob("*.py"))
+        if not staged:
+            raise ops.OperationError(f"No *.py environment files found in {source_dir}")
+        desired: dict[str, Path] = {path.stem: path for path in staged}
+    else:
+        desired = registered
+
+    # ---- scope validation (mirrors sync) -------------------------------------
+    known_envs = set(state.envs) | set(registered) | set(desired)
+    if manifest is not None:
+        known_envs |= set(manifest.environments)
+    if envs:
+        unknown = sorted(set(envs) - known_envs)
+        if unknown:
+            raise ops.OperationError(
+                f"Unknown environment(s): {', '.join(unknown)}. "
+                f"Known: {', '.join(sorted(known_envs)) or '(none)'}"
+            )
+    recorded_ids = {
+        ckpt_id
+        for record in (manifest.environments.values() if manifest else [])
+        for ckpt_id in record.checkpoints
+    }
+    if checkpoints:
+        unknown = sorted(set(checkpoints) - recorded_ids)
+        if unknown:
+            raise ops.OperationError(
+                f"Unknown checkpoint id(s): {', '.join(unknown)}. "
+                f"Recorded in the manifest: {', '.join(sorted(recorded_ids)) or '(none)'}"
+            )
+
+    # ---- env items ------------------------------------------------------------
+    pruned_env_names: set[str] = set()
+    if not gc_only and source_dir is None and not registered and state.envs:
+        # A lost/empty environments/ dir would read as "delete everything";
+        # the plan-confirm gate protects execution, but say it out loud.
+        plan.notes.append(
+            f"no env sources are registered under {root / 'environments'} — every "
+            f"built env counts as undeclared (use --gc-only if that's not intended)"
+        )
+    if not gc_only:
+        for name in sorted(set(state.envs) | set(registered)):
+            if name in desired or (envs and name not in envs):
+                continue
+            built = state.envs.get(name)
+            reason = f"not in {source_dir}" if source_dir is not None else "no registered source"
+            # In default mode a cruft env by definition has no registered
+            # source; only SOURCE_DIR mode unregisters source files.
+            unregister = source_dir is not None and name in registered
+            plan.envs.append(
+                PruneEnvItem(
+                    env_name=name,
+                    reason=reason,
+                    reclaim_bytes=_tree_bytes(built.path) if built else 0,
+                    env_dir=built is not None,
+                    source_file=str(registered[name]) if unregister else None,
+                )
+            )
+            pruned_env_names.add(name)
+
+    # ---- checkpoint items -----------------------------------------------------
+    # Declared ids per desired env. A desired env whose CHECKPOINTS can't be
+    # parsed keeps everything: sync's planner skips *adding* work on a parse
+    # error, so prune must skip *removing* — the conservative direction flips.
+    declared_by_env: dict[str, set[str] | None] = {}
+    if not gc_only:
+        for name in sorted(desired):
+            try:
+                declared_by_env[name] = set(parse_checkpoints_dict(desired[name]))
+            except ValueError as exc:
+                declared_by_env[name] = None
+                plan.notes.append(
+                    f"{name}: cannot parse CHECKPOINTS ({exc}); keeping all of its "
+                    f"checkpoint records"
+                )
+
+    pruned: list[tuple[str, str, CheckpointInfo, str]] = []  # (env, ckpt, record, reason)
+    if not gc_only and manifest is not None:
+        for env_name in sorted(manifest.environments):
+            if envs and env_name not in envs:
+                continue
+            record = manifest.environments[env_name]
+            declared = declared_by_env.get(env_name)
+            for ckpt_id in sorted(record.checkpoints):
+                if checkpoints and ckpt_id not in checkpoints:
+                    continue
+                if is_custom_checkpoint(ckpt_id):
+                    continue  # never fetched, no weights of ours to release
+                info = record.checkpoints[ckpt_id]
+                if env_name in pruned_env_names:
+                    reason = "env pruned"
+                elif env_name not in desired:
+                    # Manifest-only record (env gone from disk, not registered):
+                    # the refresh drops the env record; release the weights first.
+                    reason = "env not installed"
+                elif declared is None:
+                    continue
+                elif ckpt_id not in declared:
+                    reason = "not declared"
+                elif info.fetched_at is not None and _weights_all_missing(info, cache_base):
+                    reason = "weights missing on disk"
+                else:
+                    continue
+                pruned.append((env_name, ckpt_id, info, reason))
+
+    if pruned:
+        assert manifest is not None  # pruned items only come from manifest records
+        pruned_keys = {(env, ckpt) for env, ckpt, _, _ in pruned}
+        # Refcount every recorded file across the whole manifest: a file is
+        # deletable only when no *surviving* checkpoint also recorded it.
+        surviving_files: set[str] = set()
+        repo_attribution: dict[str, set[tuple[str, str]]] = {}
+        for env_name, record in manifest.environments.items():
+            for ckpt_id, info in record.checkpoints.items():
+                for entry in info.weight_files or []:
+                    relpath = entry.get("path")
+                    if not relpath:
+                        continue
+                    if (env_name, ckpt_id) not in pruned_keys:
+                        surviving_files.add(relpath)
+                    repo = _hf_repo_dir(relpath)
+                    if repo is not None:
+                        repo_attribution.setdefault(repo, set()).add((env_name, ckpt_id))
+
+        released_repos = {repo for repo, keys in repo_attribution.items() if keys <= pruned_keys}
+
+        for env_name, ckpt_id, info, reason in pruned:
+            weight_files = info.weight_files or []
+            files: list[str] = []
+            reclaim = 0
+            for entry in weight_files:
+                relpath = entry.get("path")
+                if not relpath or relpath in surviving_files:
+                    continue
+                if _hf_repo_dir(relpath) in released_repos:
+                    continue  # the whole-repo-dir item covers it
+                target = _safe_weight_path(cache_base, relpath)
+                if target is None:
+                    plan.notes.append(f"{ckpt_id}: refusing suspicious recorded path {relpath!r}")
+                    continue
+                try:
+                    reclaim += target.lstat().st_size
+                except OSError:
+                    continue  # already gone; nothing to delete or count
+                files.append(relpath)
+            plan.checkpoints.append(
+                PruneCheckpointItem(
+                    env_name=env_name,
+                    checkpoint=ckpt_id,
+                    reason=reason,
+                    recorded=bool(weight_files),
+                    files=files,
+                    reclaim_bytes=reclaim,
+                )
+            )
+
+        for repo in sorted(released_repos):
+            repo_path = _safe_weight_path(cache_base, repo)
+            if repo_path is None or not repo_path.exists():
+                continue
+            plan.weight_dirs.append(
+                PruneWeightDirItem(
+                    path=repo,
+                    reason="every checkpoint attributed to it is pruned",
+                    checkpoints=sorted({ckpt for _, ckpt in repo_attribution[repo]}),
+                    reclaim_bytes=_tree_bytes(repo_path),
+                )
+            )
+
+    # ---- category B: internal GC (both modes, age-guarded) ---------------------
+    age_skipped: dict[str, int] = {}
+
+    def collect(kind: str, entries: list[Path], reason_for: Callable[[Path], str]) -> None:
+        for entry in entries:
+            if young(entry):
+                age_skipped[kind] = age_skipped.get(kind, 0) + 1
+                continue
+            plan.gc.append(GCItem(kind, str(entry), reason_for(entry), _tree_bytes(entry)))
+
+    build_root = root / ".build"
+    if build_root.is_dir():
+        collect("build", sorted(build_root.iterdir()), lambda _: "leftover from a crashed build")
+
+    trash_root = root / ".trash"
+    if trash_root.is_dir():
+        collect("trash", sorted(trash_root.iterdir()), lambda _: "leftover from a crashed prune")
+
+    python_root = root / ".python"
+    if python_root.is_dir():
+        # An interpreter is live iff some built env's bin/python resolves into
+        # it — including envs being pruned this run, so a failed env deletion
+        # never leaves a broken venv; a newly orphaned interpreter is simply
+        # collected by the next run.
+        live: set[str] = set()
+        for env_state in state.envs.values():
+            try:
+                real = (env_state.path / "bin" / "python").resolve()
+                rel = real.relative_to(python_root.resolve())
+            except (OSError, ValueError):
+                continue
+            if rel.parts:
+                live.add(rel.parts[0])
+        orphans = [entry for entry in sorted(python_root.iterdir()) if entry.name not in live]
+        collect(
+            "interpreter",
+            orphans,
+            lambda entry: (
+                "stranded staging copy"
+                if ".installing." in entry.name
+                else "no built env resolves into it"
+            ),
+        )
+
+    env_src_dir = root / "environments"
+    if env_src_dir.is_dir():
+        orphan_locks = [
+            lock
+            for lock in sorted(env_src_dir.glob("*.py.lock"))
+            if not lock.with_suffix("").exists()
+        ]
+        collect("lockfile", orphan_locks, lambda _: "no matching environment source")
+
+    for kind, count in sorted(age_skipped.items()):
+        plan.notes.append(
+            f"{kind}: left {count} entr{'y' if count == 1 else 'ies'} younger than "
+            f"--min-age ({min_age_hours:g}h) alone"
+        )
+
+    uv_cache = root / ".uv-cache"
+    if uv_cache.is_dir():
+        plan.gc.append(GCItem("uv-cache", str(uv_cache), "delegate to `uv cache prune`", None))
+
+    # ---- tier 2: unattributed cache/home contents ------------------------------
+    # The records capture the read working set, not the download set, so
+    # "delete everything unrecorded" would over-delete. Report it instead;
+    # --deep graduates it to deletion for maintainers who trust the records.
+    if not gc_only:
+        attributed_files: set[str] = set()
+        for record in manifest.environments.values() if manifest else []:
+            for info in record.checkpoints.values():
+                for entry in info.weight_files or []:
+                    if entry.get("path"):
+                        attributed_files.add(entry["path"])
+
+        def is_attributed(rel: str) -> bool:
+            prefix = rel + "/"
+            return any(f == rel or f.startswith(prefix) for f in attributed_files)
+
+        candidates: list[Path] = []
+        cache_dir = cache_base / "cache"
+        if cache_dir.is_dir():
+            for child in sorted(cache_dir.iterdir()):
+                if child.name == "huggingface":
+                    hub = child / "hub"
+                    if hub.is_dir():
+                        candidates.extend(sorted(p for p in hub.iterdir() if p.is_dir()))
+                else:
+                    candidates.append(child)
+        home_dir = cache_base / "home"
+        if home_dir.is_dir():
+            for child in sorted(home_dir.iterdir()):
+                if child.name == ".cache" and child.is_dir():
+                    candidates.extend(sorted(child.iterdir()))
+                else:
+                    candidates.append(child)
+
+        released = {repo for repo in (i.path for i in plan.weight_dirs)}
+        for candidate in candidates:
+            rel = str(candidate.relative_to(cache_base))
+            if rel in released or is_attributed(rel):
+                continue
+            size = _tree_bytes(candidate)
+            if deep:
+                plan.gc.append(
+                    GCItem("unattributed", str(candidate), "no weight record claims it", size)
+                )
+            else:
+                plan.unattributed.append({"path": str(candidate), "bytes": size})
+
+    return plan
+
+
+def _weights_all_missing(info, cache_base: Path) -> bool:
+    """A record whose weights were hand-deleted: files recorded, none exist."""
+    paths = [
+        _safe_weight_path(cache_base, entry["path"])
+        for entry in info.weight_files or []
+        if entry.get("path")
+    ]
+    paths = [p for p in paths if p is not None]
+    return bool(paths) and not any(p.exists() for p in paths)
+
+
+# -----------------------------------------------------------------------------
+# Prune execution
+# -----------------------------------------------------------------------------
+
+
+def _prune_empty_parents(start: Path, cache_base: Path) -> None:
+    """rmdir upward from ``start`` until a non-empty dir or a cache top."""
+    stops = {cache_base, cache_base / "cache", cache_base / "home"}
+    current = start
+    while current not in stops and cache_base in current.parents:
+        try:
+            current.rmdir()
+        except OSError:
+            return
+        current = current.parent
+
+
+def execute_prune(
+    root: Path,
+    plan: PrunePlan,
+    *,
+    fail_fast: bool = False,
+    push: bool = True,
+    cache_root: Path | None = None,
+    say: Say = print,
+) -> SyncReport:
+    """Execute a prune plan: checkpoints → weight dirs → envs → gc, then one
+    manifest refresh + push.
+
+    Deletion orders are crash-safe by construction:
+
+    - Checkpoint records are dropped (one manifest transaction) *before* any
+      weight file: a crash strands unreferenced files, which surface as
+      unattributed cache — files-first would strand a ``fetched_at`` record
+      pointing at nothing and make verify fail confusingly.
+    - Envs go disk-first via trash-rename (``envs/<name>`` →
+      ``.trash/<name>.<ts>``, then rmtree): readers see atomic disappearance,
+      the manifest refresh already drops records for missing envs, and a
+      crashed prune leaves ``.trash`` for the next run's GC.
+
+    Serial by design (v1): nothing here is a six-hour job, and delete storms
+    on a shared filesystem don't get faster with threads.
+    """
+    root = Path(root)
+    cache_base = Path(cache_root) if cache_root is not None else resolve_cache_root(root)
+    report = SyncReport()
+
+    # ---- records first: one manifest transaction for every pruned checkpoint --
+    record_error: str | None = None
+    if plan.checkpoints:
+        try:
+            with manifest_lock(root):
+                manifest = load_manifest(root)
+                if manifest is not None:
+                    for item in plan.checkpoints:
+                        record = manifest.environments.get(item.env_name)
+                        if record is not None:
+                            record.checkpoints.pop(item.checkpoint, None)
+                    save_manifest(manifest, root)
+        except Exception as exc:
+            record_error = f"could not drop checkpoint records: {exc}"
+
+    if record_error is not None:
+        # Files must not outlive their records' removal, so the whole weight
+        # tier is off; envs and gc are disk-first and safe to continue.
+        for item in plan.checkpoints:
+            report.results.append(
+                ItemResult("checkpoint", item.env_name, item.checkpoint, "failed", record_error)
+            )
+        for dir_item in plan.weight_dirs:
+            report.results.append(
+                ItemResult(
+                    "weights", dir_item.env_name, None, "skipped", "checkpoint records not dropped"
+                )
+            )
+
+    aborted = fail_fast and record_error is not None
+
+    # ---- phase: per-checkpoint weight files ------------------------------------
+    def checkpoint_work(item: PruneCheckpointItem):
+        def work(buffered: list[str]) -> None:
+            for relpath in item.files:
+                target = _safe_weight_path(cache_base, relpath)
+                if target is None:
+                    continue
+                try:
+                    target.unlink()
+                except FileNotFoundError:
+                    pass
+                _prune_empty_parents(target.parent, cache_base)
+
+        return work
+
+    if record_error is None and not aborted:
+        results = _run_phase("checkpoint", plan.checkpoints, checkpoint_work, 1, fail_fast, say)
+        report.results.extend(results)
+        aborted = fail_fast and any(r.status == "failed" for r in results)
+
+        def dir_work(item: PruneWeightDirItem):
+            def work(buffered: list[str]) -> None:
+                target = _safe_weight_path(cache_base, item.path)
+                if target is not None and target.exists():
+                    shutil.rmtree(target)
+                    _prune_empty_parents(target.parent, cache_base)
+
+            return work
+
+        if aborted:
+            for dir_item in plan.weight_dirs:
+                report.results.append(
+                    ItemResult("weights", dir_item.env_name, None, "skipped", "--fail-fast")
+                )
+        else:
+            results = _run_phase("weights", plan.weight_dirs, dir_work, 1, fail_fast, say)
+            report.results.extend(results)
+            aborted = fail_fast and any(r.status == "failed" for r in results)
+
+    # ---- phase: envs -------------------------------------------------------------
+    def env_work(item: PruneEnvItem):
+        def work(buffered: list[str]) -> None:
+            if item.env_dir:
+                env_path = root / "envs" / item.env_name
+                if env_path.exists():
+                    trash = root / ".trash"
+                    trash.mkdir(exist_ok=True)
+                    doomed = trash / f"{item.env_name}.{int(time.time())}"
+                    env_path.rename(doomed)
+                    shutil.rmtree(doomed)
+            if item.source_file:
+                source = Path(item.source_file)
+                source.unlink(missing_ok=True)
+                Path(f"{source}.lock").unlink(missing_ok=True)
+
+        return work
+
+    if aborted:
+        for item in plan.envs:
+            report.results.append(ItemResult("env", item.env_name, None, "skipped", "--fail-fast"))
+    else:
+        results = _run_phase("env", plan.envs, env_work, 1, fail_fast, say)
+        report.results.extend(results)
+        aborted = fail_fast and any(r.status == "failed" for r in results)
+
+    # ---- phase: internal gc --------------------------------------------------------
+    def gc_work(item: GCItem):
+        def work(buffered: list[str]) -> None:
+            path = Path(item.path)
+            if item.kind == "uv-cache":
+                if shutil.which("uv") is None:
+                    raise ops.OperationError("uv not found in PATH")
+                proc = subprocess.run(
+                    ["uv", "cache", "prune"],
+                    env={**os.environ, "UV_CACHE_DIR": str(path)},
+                    capture_output=True,
+                    text=True,
+                    timeout=600,
+                )
+                if proc.returncode != 0:
+                    raise ops.OperationError(
+                        f"uv cache prune failed: {proc.stderr.strip() or proc.stdout.strip()}"
+                    )
+                return
+            if path.is_dir() and not path.is_symlink():
+                shutil.rmtree(path)
+            else:
+                path.unlink(missing_ok=True)
+
+        return work
+
+    if aborted:
+        for item in plan.gc:
+            report.results.append(ItemResult("gc", item.env_name, None, "skipped", "--fail-fast"))
+    else:
+        report.results.extend(_run_phase("gc", plan.gc, gc_work, 1, fail_fast, say))
+
+    # ---- final: one refresh + push -------------------------------------------------
+    if any(r.status == "ok" for r in report.results):
+        ops.update_and_push_manifest(root, quiet=True, push=push)
+
+    return report
+
+
+def render_prune_plan(
+    plan: PrunePlan,
+    say: Say = print,
+    root: Path | None = None,
+    cache_root: Path | None = None,
+) -> None:
+    """Human-readable plan with per-item reclaimed bytes, terraform-style.
+
+    ``root``/``cache_root`` only shorten display paths; the plan's own paths
+    stay absolute (gc) or cache-relative (weights) for the executor.
+    """
+
+    def display(path: str) -> str:
+        for base in (root, cache_root):
+            if base is not None:
+                try:
+                    return str(Path(path).relative_to(base))
+                except ValueError:
+                    continue
+        return path
+
+    if plan.is_empty:
+        say("Nothing to prune — install matches its declared state.")
+
+    if plan.checkpoints:
+        say(f"checkpoint records ({len(plan.checkpoints)}):")
+        for item in plan.checkpoints:
+            label = f"{item.env_name}/{item.checkpoint}"
+            if not item.recorded:
+                detail = "no weight record — weights become unattributed"
+            elif item.files:
+                detail = f"{len(item.files)} file(s), {format_bytes(item.reclaim_bytes)}"
+            else:
+                detail = "no unshared weight files"
+            say(f"  {label:<44} {item.reason:<28} {detail}")
+
+    if plan.weight_dirs:
+        say(f"weight dirs ({len(plan.weight_dirs)}):")
+        for item in plan.weight_dirs:
+            say(f"  {item.path:<60} {format_bytes(item.reclaim_bytes)}")
+
+    if plan.envs:
+        say(f"envs ({len(plan.envs)}):")
+        for item in plan.envs:
+            what = "" if item.env_dir else " (source file only)"
+            say(
+                f"  {item.env_name:<44} {item.reason + what:<40} {format_bytes(item.reclaim_bytes)}"
+            )
+
+    if plan.gc:
+        say(f"gc ({len(plan.gc)}):")
+        for item in plan.gc:
+            size = format_bytes(item.reclaim_bytes) if item.reclaim_bytes is not None else ""
+            say(f"  {display(item.path):<60} {item.reason:<36} {size}")
+
+    if plan.unattributed:
+        total = sum(entry["bytes"] for entry in plan.unattributed)
+        say(
+            f"unattributed cache ({format_bytes(total)}) — no weight record claims "
+            f"these; review manually (--deep deletes them):"
+        )
+        for entry in plan.unattributed:
+            say(f"  {display(entry['path']):<60} {format_bytes(entry['bytes'])}")
+
+    if not plan.is_empty:
+        say(f"reclaims {format_bytes(plan.reclaim_bytes)}")
+
+    if plan.notes:
+        say("notes:")
+        for note in plan.notes:
+            say(f"  - {note}")

--- a/rootstock/batch.py
+++ b/rootstock/batch.py
@@ -675,21 +675,40 @@ class PrunePlan:
         return asdict(self)
 
 
-def _tree_bytes(path: Path) -> int:
-    """Recursive apparent size; symlinks counted, never followed."""
+def _tree_stats(path: Path) -> tuple[int, float]:
+    """(recursive apparent size, newest mtime in the tree); symlinks counted,
+    never followed.
+
+    The mtime is the newest of *any* entry, not the top dir's: a download
+    writing deep inside an HF repo dir (``blobs/…``) never bumps the
+    top-level mtime, and the age guard must still see it as active.
+    """
     try:
-        if not path.is_dir() or path.is_symlink():
-            return path.lstat().st_size
+        top = path.lstat()
     except OSError:
-        return 0
-    total = 0
-    for dirpath, _dirnames, filenames in os.walk(path):
+        return 0, 0.0
+    if not path.is_dir() or path.is_symlink():
+        return top.st_size, top.st_mtime
+    total, newest = 0, top.st_mtime
+    for dirpath, dirnames, filenames in os.walk(path):
         for name in filenames:
             try:
-                total += (Path(dirpath) / name).lstat().st_size
+                st = (Path(dirpath) / name).lstat()
+            except OSError:
+                continue
+            total += st.st_size
+            newest = max(newest, st.st_mtime)
+        for name in dirnames:
+            try:
+                newest = max(newest, (Path(dirpath) / name).lstat().st_mtime)
             except OSError:
                 pass
-    return total
+    return total, newest
+
+
+def _tree_bytes(path: Path) -> int:
+    """Recursive apparent size; symlinks counted, never followed."""
+    return _tree_stats(path)[0]
 
 
 def format_bytes(n: int) -> str:
@@ -808,15 +827,20 @@ def plan_prune(
             )
 
     # ---- env items ------------------------------------------------------------
+    # --checkpoint alone narrows the run to checkpoint pruning: batch usage
+    # passes --yes, so "prune this one checkpoint id" must not ride along
+    # with env deletion nobody asked for. --env restores env pruning scoped
+    # to the named envs.
+    env_tier = not gc_only and (bool(envs) or not checkpoints)
     pruned_env_names: set[str] = set()
-    if not gc_only and source_dir is None and not registered and state.envs:
+    if env_tier and source_dir is None and not registered and state.envs:
         # A lost/empty environments/ dir would read as "delete everything";
         # the plan-confirm gate protects execution, but say it out loud.
         plan.notes.append(
             f"no env sources are registered under {root / 'environments'} — every "
             f"built env counts as undeclared (use --gc-only if that's not intended)"
         )
-    if not gc_only:
+    if env_tier:
         for name in sorted(set(state.envs) | set(registered)):
             if name in desired or (envs and name not in envs):
                 continue
@@ -902,7 +926,36 @@ def plan_prune(
                     if repo is not None:
                         repo_attribution.setdefault(repo, set()).add((env_name, ckpt_id))
 
-        released_repos = {repo for repo, keys in repo_attribution.items() if keys <= pruned_keys}
+        # Whole-dir release trusts the attribution map to be complete — but a
+        # *fetched* surviving checkpoint with no weight record (pre-tracking
+        # install, capture never ran) could be using any repo dir without
+        # appearing in it. One such survivor anywhere disables dir-level
+        # release; per-file refcounted deletion still runs, and one
+        # smoke-test run backfills the records. Custom checkpoints never
+        # have records or shipped weights, and unfetched ones have no bytes
+        # on disk — neither blinds the map.
+        unrecorded_survivors = sorted(
+            ckpt_id
+            for env_name, record in manifest.environments.items()
+            for ckpt_id, info in record.checkpoints.items()
+            if (env_name, ckpt_id) not in pruned_keys
+            and not is_custom_checkpoint(ckpt_id)
+            and info.fetched_at is not None
+            and not info.weight_files
+        )
+        if unrecorded_survivors:
+            released_repos: set[str] = set()
+            if repo_attribution:
+                plan.notes.append(
+                    "keeping HF repo dirs whole (per-file deletion only): surviving "
+                    "checkpoint(s) have no weight records and could share them: "
+                    f"{', '.join(unrecorded_survivors)}. One smoke-test run backfills "
+                    "the records."
+                )
+        else:
+            released_repos = {
+                repo for repo, keys in repo_attribution.items() if keys <= pruned_keys
+            }
 
         for env_name, ckpt_id, info, reason in pruned:
             weight_files = info.weight_files or []
@@ -1049,18 +1102,33 @@ def plan_prune(
         if candidates:
             emit("scanning cache/home for unattributed contents")
         released = {repo for repo in (i.path for i in plan.weight_dirs)}
+        deep_young = 0
         for candidate in candidates:
             rel = str(candidate.relative_to(cache_base))
             if rel in released or is_attributed(rel):
                 continue
             emit(f"sizing {rel}")
-            size = _tree_bytes(candidate)
-            if deep:
+            size, newest = _tree_stats(candidate)
+            # The age guard applies to --deep with extra force: a checkpoint
+            # another node is downloading *right now* is unattributed by
+            # definition (records are written only after setup succeeds).
+            # Judge by the newest mtime anywhere in the tree — the write
+            # lands deep inside the dir, not on the candidate itself.
+            if deep and newest <= cutoff:
                 plan.gc.append(
                     GCItem("unattributed", str(candidate), "no weight record claims it", size)
                 )
             else:
+                if deep:
+                    deep_young += 1
                 plan.unattributed.append({"path": str(candidate), "bytes": size})
+        if deep_young:
+            plan.notes.append(
+                f"--deep: left {deep_young} unattributed "
+                f"entr{'y' if deep_young == 1 else 'ies'} younger than --min-age "
+                f"({min_age_hours:g}h) alone — an in-flight download looks exactly "
+                f"like this; reported above instead"
+            )
 
     return plan
 
@@ -1130,12 +1198,16 @@ def execute_prune(
         try:
             with manifest_lock(root):
                 manifest = load_manifest(root)
-                if manifest is not None:
-                    for item in plan.checkpoints:
-                        record = manifest.environments.get(item.env_name)
-                        if record is not None:
-                            record.checkpoints.pop(item.checkpoint, None)
-                    save_manifest(manifest, root)
+                if manifest is None:
+                    # The plan's checkpoint items came from a manifest, so it
+                    # vanishing means the world changed under us; deleting the
+                    # files anyway would break records-drop-before-files.
+                    raise ops.OperationError("manifest disappeared between plan and execute")
+                for item in plan.checkpoints:
+                    record = manifest.environments.get(item.env_name)
+                    if record is not None:
+                        record.checkpoints.pop(item.checkpoint, None)
+                save_manifest(manifest, root)
         except Exception as exc:
             record_error = f"could not drop checkpoint records: {exc}"
 

--- a/rootstock/batch.py
+++ b/rootstock/batch.py
@@ -288,6 +288,23 @@ class SyncReport:
         }
 
 
+class _LiveList(list):
+    """A progress sink that records lines *and* surfaces them immediately.
+
+    Only safe when the phase runs serially — live output from parallel
+    workers would interleave unreadably, which is why the default path
+    buffers instead.
+    """
+
+    def __init__(self, say: Say):
+        super().__init__()
+        self._say = say
+
+    def append(self, line: str) -> None:
+        super().append(line)
+        self._say(f"    {line}")
+
+
 class _PhaseRunner:
     """Run one phase's items through a bounded thread pool.
 
@@ -295,12 +312,17 @@ class _PhaseRunner:
     progress would interleave unreadably), so each item's progress lines are
     buffered and only surfaced — through the shared, locked ``say`` — when
     the item fails; successes get a one-line completion mark.
+
+    ``live`` inverts that for serial phases (prune): every progress line
+    streams as it happens, so someone tailing a batch job's outfile sees the
+    slow deletes moving — and, on a hang, what they hung on.
     """
 
-    def __init__(self, phase: str, total: int, say: Say):
+    def __init__(self, phase: str, total: int, say: Say, live: bool = False):
         self.phase = phase
         self.total = total
         self.say = say
+        self.live = live
         self._lock = threading.Lock()
         self._done = 0
 
@@ -311,14 +333,16 @@ class _PhaseRunner:
             took = f", {result.seconds:.0f}s" if result.seconds is not None else ""
             self.say(f"[{self.phase} {self._done}/{self.total}] {result.label}: {mark}{took}")
             if result.status == "failed":
-                for line in buffered:
-                    self.say(f"    {line}")
+                if not self.live:  # live lines were already surfaced
+                    for line in buffered:
+                        self.say(f"    {line}")
                 self.say(f"    error: {result.reason}")
 
     def run_item(self, item, work: Callable[[list[str]], None]) -> ItemResult:
-        """Execute one item, buffering its progress; never raises."""
+        """Execute one item, buffering (or live-streaming) its progress;
+        never raises."""
         checkpoint = getattr(item, "checkpoint", None)
-        buffered: list[str] = []
+        buffered: list[str] = _LiveList(self.say) if self.live else []
         start = time.monotonic()
         try:
             work(buffered)
@@ -340,10 +364,11 @@ def _run_phase(
     max_workers: int,
     fail_fast: bool,
     say: Say,
+    live: bool = False,
 ) -> list[ItemResult]:
     if not items:
         return []
-    runner = _PhaseRunner(phase, len(items), say)
+    runner = _PhaseRunner(phase, len(items), say, live=live)
     results: list[ItemResult] = []
     with ThreadPoolExecutor(max_workers=max(1, min(max_workers, len(items)))) as pool:
         futures = {pool.submit(runner.run_item, item, make_work(item)): item for item in items}
@@ -709,6 +734,7 @@ def plan_prune(
     deep: bool = False,
     min_age_hours: float = DEFAULT_MIN_AGE_HOURS,
     cache_root: Path | None = None,
+    progress: Say | None = None,
 ) -> PrunePlan:
     """Compute what pruning would remove from ``root``.
 
@@ -722,9 +748,19 @@ def plan_prune(
     meaningless on a shared filesystem (the build owning ``.build/<env>.<pid>``
     may be on another node), so anything mtime-newer than the guard is left
     alone and noted.
+
+    ``progress`` receives a line before each potentially slow step — the
+    per-item byte counts come from full tree walks, which on a loaded
+    shared filesystem can each take minutes with nothing else to show.
     """
     root = Path(root)
     cache_base = Path(cache_root) if cache_root is not None else resolve_cache_root(root)
+
+    def emit(line: str) -> None:
+        if progress is not None:
+            progress(line)
+
+    emit(f"reading install state under {root}")
     state = read_install_state(root)
     manifest = state.manifest
     plan = PrunePlan()
@@ -786,6 +822,8 @@ def plan_prune(
                 continue
             built = state.envs.get(name)
             reason = f"not in {source_dir}" if source_dir is not None else "no registered source"
+            if built is not None:
+                emit(f"sizing envs/{name}")
             # In default mode a cruft env by definition has no registered
             # source; only SOURCE_DIR mode unregisters source files.
             unregister = source_dir is not None and name in registered
@@ -900,6 +938,7 @@ def plan_prune(
             repo_path = _safe_weight_path(cache_base, repo)
             if repo_path is None or not repo_path.exists():
                 continue
+            emit(f"sizing {repo}")
             plan.weight_dirs.append(
                 PruneWeightDirItem(
                     path=repo,
@@ -917,6 +956,7 @@ def plan_prune(
             if young(entry):
                 age_skipped[kind] = age_skipped.get(kind, 0) + 1
                 continue
+            emit(f"sizing {entry}")
             plan.gc.append(GCItem(kind, str(entry), reason_for(entry), _tree_bytes(entry)))
 
     build_root = root / ".build"
@@ -1006,11 +1046,14 @@ def plan_prune(
                 else:
                     candidates.append(child)
 
+        if candidates:
+            emit("scanning cache/home for unattributed contents")
         released = {repo for repo in (i.path for i in plan.weight_dirs)}
         for candidate in candidates:
             rel = str(candidate.relative_to(cache_base))
             if rel in released or is_attributed(rel):
                 continue
+            emit(f"sizing {rel}")
             size = _tree_bytes(candidate)
             if deep:
                 plan.gc.append(
@@ -1083,6 +1126,7 @@ def execute_prune(
     # ---- records first: one manifest transaction for every pruned checkpoint --
     record_error: str | None = None
     if plan.checkpoints:
+        say(f"dropping {len(plan.checkpoints)} checkpoint record(s) from the manifest")
         try:
             with manifest_lock(root):
                 manifest = load_manifest(root)
@@ -1112,12 +1156,23 @@ def execute_prune(
     aborted = fail_fast and record_error is not None
 
     # ---- phase: per-checkpoint weight files ------------------------------------
+    # Every action is logged *before* it runs: on a shared filesystem a
+    # single unlink or rmtree can stall for minutes, and someone tailing a
+    # batch job's outfile should see what it stalled on.
     def checkpoint_work(item: PruneCheckpointItem):
         def work(buffered: list[str]) -> None:
+            if not item.files:
+                buffered.append("record dropped; no weight files to delete")
+                return
             for relpath in item.files:
                 target = _safe_weight_path(cache_base, relpath)
                 if target is None:
                     continue
+                try:
+                    size = format_bytes(target.lstat().st_size)
+                except OSError:
+                    size = "already gone"
+                buffered.append(f"rm {relpath} ({size})")
                 try:
                     target.unlink()
                 except FileNotFoundError:
@@ -1127,7 +1182,9 @@ def execute_prune(
         return work
 
     if record_error is None and not aborted:
-        results = _run_phase("checkpoint", plan.checkpoints, checkpoint_work, 1, fail_fast, say)
+        results = _run_phase(
+            "checkpoint", plan.checkpoints, checkpoint_work, 1, fail_fast, say, live=True
+        )
         report.results.extend(results)
         aborted = fail_fast and any(r.status == "failed" for r in results)
 
@@ -1135,8 +1192,11 @@ def execute_prune(
             def work(buffered: list[str]) -> None:
                 target = _safe_weight_path(cache_base, item.path)
                 if target is not None and target.exists():
+                    buffered.append(f"rm -r {item.path} ({format_bytes(item.reclaim_bytes)})")
                     shutil.rmtree(target)
                     _prune_empty_parents(target.parent, cache_base)
+                else:
+                    buffered.append(f"{item.path} already gone")
 
             return work
 
@@ -1146,7 +1206,9 @@ def execute_prune(
                     ItemResult("weights", dir_item.env_name, None, "skipped", "--fail-fast")
                 )
         else:
-            results = _run_phase("weights", plan.weight_dirs, dir_work, 1, fail_fast, say)
+            results = _run_phase(
+                "weights", plan.weight_dirs, dir_work, 1, fail_fast, say, live=True
+            )
             report.results.extend(results)
             aborted = fail_fast and any(r.status == "failed" for r in results)
 
@@ -1159,10 +1221,15 @@ def execute_prune(
                     trash = root / ".trash"
                     trash.mkdir(exist_ok=True)
                     doomed = trash / f"{item.env_name}.{int(time.time())}"
+                    buffered.append(f"mv envs/{item.env_name} -> .trash/{doomed.name}")
                     env_path.rename(doomed)
+                    buffered.append(
+                        f"rm -r .trash/{doomed.name} ({format_bytes(item.reclaim_bytes)})"
+                    )
                     shutil.rmtree(doomed)
             if item.source_file:
                 source = Path(item.source_file)
+                buffered.append(f"unregistering {source.name} (+ lockfile)")
                 source.unlink(missing_ok=True)
                 Path(f"{source}.lock").unlink(missing_ok=True)
 
@@ -1172,7 +1239,7 @@ def execute_prune(
         for item in plan.envs:
             report.results.append(ItemResult("env", item.env_name, None, "skipped", "--fail-fast"))
     else:
-        results = _run_phase("env", plan.envs, env_work, 1, fail_fast, say)
+        results = _run_phase("env", plan.envs, env_work, 1, fail_fast, say, live=True)
         report.results.extend(results)
         aborted = fail_fast and any(r.status == "failed" for r in results)
 
@@ -1183,6 +1250,7 @@ def execute_prune(
             if item.kind == "uv-cache":
                 if shutil.which("uv") is None:
                     raise ops.OperationError("uv not found in PATH")
+                buffered.append("running `uv cache prune`")
                 proc = subprocess.run(
                     ["uv", "cache", "prune"],
                     env={**os.environ, "UV_CACHE_DIR": str(path)},
@@ -1194,7 +1262,16 @@ def execute_prune(
                     raise ops.OperationError(
                         f"uv cache prune failed: {proc.stderr.strip() or proc.stdout.strip()}"
                     )
+                for line in (proc.stderr + proc.stdout).splitlines():
+                    if line.strip():
+                        buffered.append(f"uv: {line.strip()}")
                 return
+            size = f" ({format_bytes(item.reclaim_bytes)})" if item.reclaim_bytes else ""
+            try:
+                shown = path.relative_to(root)
+            except ValueError:
+                shown = path
+            buffered.append(f"rm -r {shown}{size}")
             if path.is_dir() and not path.is_symlink():
                 shutil.rmtree(path)
             else:
@@ -1206,10 +1283,14 @@ def execute_prune(
         for item in plan.gc:
             report.results.append(ItemResult("gc", item.env_name, None, "skipped", "--fail-fast"))
     else:
-        report.results.extend(_run_phase("gc", plan.gc, gc_work, 1, fail_fast, say))
+        report.results.extend(_run_phase("gc", plan.gc, gc_work, 1, fail_fast, say, live=True))
 
     # ---- final: one refresh + push -------------------------------------------------
     if any(r.status == "ok" for r in report.results):
+        say(
+            "refreshing manifest (runs `uv pip list` per env)"
+            + ("; pushing to backend" if push else "; push disabled")
+        )
         ops.update_and_push_manifest(root, quiet=True, push=push)
 
     return report

--- a/rootstock/cli.py
+++ b/rootstock/cli.py
@@ -36,6 +36,16 @@ Commands:
             rootstock sync --rebuild                 # after a CLI version bump
             rootstock sync --phases build,download   # login node (no GPU)
 
+    rootstock prune [<source-dir>] [--root <path> | --cluster <name>] [--dry-run] [--yes]
+        The subtractive half of sync: remove built envs with no registered
+        source, checkpoint records (and their unshared weight files) no
+        source declares, and internal garbage (.build/.trash leftovers,
+        orphaned interpreters, stale lockfiles, the uv cache). Plan-confirm
+        by default; batch jobs pass --yes.
+            rootstock prune --cluster delta --dry-run
+            rootstock prune ./environments/ --yes    # retire everything not declared here
+            rootstock prune --gc-only --yes          # internal garbage only
+
     rootstock benchmark [--root <path>] [--checkpoints <id> ...] [--devices cuda cpu] [--list]
         Measure i-PI IPC overhead: RootstockCalculator vs. the same calculator
         called directly inside its pre-built env. `--list` shows installed ids.
@@ -79,6 +89,7 @@ from .commands import (
     cmd_manifest_push,
     cmd_manifest_show,
     cmd_new_env,
+    cmd_prune,
     cmd_resolve,
     cmd_serve,
     cmd_setup_perms,
@@ -389,6 +400,108 @@ def main():
         help="Skip the up-front shared-install permission check",
     )
     sync_parser.set_defaults(func=cmd_sync)
+
+    # prune command
+    prune_parser = subparsers.add_parser(
+        "prune",
+        help="Remove undeclared envs/checkpoints and internal garbage (sync's subtractive half)",
+        description=(
+            "Plan and execute the removal of actual state not covered by "
+            "declared state: built envs with no registered source, manifest "
+            "checkpoint records no source declares (plus their weight files, "
+            "refcounted against surviving checkpoints), and internal garbage "
+            "(.build/.trash leftovers, orphaned interpreters, stale "
+            "lockfiles, the uv cache). Prints the plan and asks for "
+            "confirmation before deleting anything; idempotent and safe to "
+            "re-run after a failure. Don't run while a sync is in flight."
+        ),
+    )
+    prune_parser.add_argument(
+        "source_dir",
+        nargs="?",
+        help=(
+            "Optional directory declaring the *complete* desired set of env "
+            "sources (*.py): anything registered, built, or fetched beyond it "
+            "is pruned — including registered source files. Defaults to the "
+            "root's registered environments."
+        ),
+    )
+    prune_parser.add_argument(
+        "--root",
+        default=os.environ.get(ROOTSTOCK_ROOT_ENV),
+        help=f"Root directory (default: ${ROOTSTOCK_ROOT_ENV})",
+    )
+    prune_parser.add_argument(
+        "--cluster",
+        help="Resolve the root from the cluster registry instead of --root",
+    )
+    prune_parser.add_argument(
+        "--env",
+        action="append",
+        metavar="NAME",
+        help="Limit to this environment (and its checkpoints); repeatable",
+    )
+    prune_parser.add_argument(
+        "--checkpoint",
+        action="append",
+        metavar="ID",
+        help="Limit checkpoint pruning to this id; repeatable",
+    )
+    prune_parser.add_argument(
+        "--gc-only",
+        action="store_true",
+        help="Collect internal garbage only; never touches envs or checkpoints",
+    )
+    prune_parser.add_argument(
+        "--deep",
+        action="store_true",
+        help=(
+            "Also delete unattributed cache/home contents (anything no "
+            "checkpoint's weight record claims). Only sensible once weight "
+            "records have been backfilled — run a smoke-test first"
+        ),
+    )
+    prune_parser.add_argument(
+        "--min-age",
+        type=float,
+        default=24.0,
+        metavar="HOURS",
+        help=(
+            "Leave .build/.trash/interpreter entries younger than this alone "
+            "— they may belong to a build running on another node (default: 24)"
+        ),
+    )
+    prune_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip the confirmation prompt (for batch jobs)",
+    )
+    prune_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the plan and exit without deleting anything",
+    )
+    prune_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the plan and results as JSON on stdout (progress goes to stderr)",
+    )
+    prune_parser.add_argument(
+        "--fail-fast",
+        action="store_true",
+        help="Stop scheduling new deletions after the first failure (default: keep going)",
+    )
+    prune_parser.add_argument(
+        "--no-push",
+        action="store_true",
+        help="Don't push manifest to backend",
+    )
+    prune_parser.add_argument(
+        "--no-perm-check",
+        action="store_true",
+        help="Skip the up-front shared-install permission check",
+    )
+    prune_parser.set_defaults(func=cmd_prune)
 
     # smoke-test command
     smoke_parser = subparsers.add_parser(

--- a/rootstock/cli.py
+++ b/rootstock/cli.py
@@ -78,6 +78,7 @@ import os
 import sys
 
 from . import __version__
+from .batch import DEFAULT_MIN_AGE_HOURS
 from .commands import (
     cmd_add,
     cmd_benchmark,
@@ -445,7 +446,10 @@ def main():
         "--checkpoint",
         action="append",
         metavar="ID",
-        help="Limit checkpoint pruning to this id; repeatable",
+        help=(
+            "Limit pruning to this checkpoint id (env pruning is skipped "
+            "unless --env is also given); repeatable"
+        ),
     )
     prune_parser.add_argument(
         "--gc-only",
@@ -464,11 +468,12 @@ def main():
     prune_parser.add_argument(
         "--min-age",
         type=float,
-        default=24.0,
+        default=DEFAULT_MIN_AGE_HOURS,
         metavar="HOURS",
         help=(
-            "Leave .build/.trash/interpreter entries younger than this alone "
-            "— they may belong to a build running on another node (default: 24)"
+            "Leave .build/.trash/interpreter entries (and --deep candidates) "
+            "younger than this alone — they may belong to work running on "
+            f"another node (default: {DEFAULT_MIN_AGE_HOURS:g})"
         ),
     )
     prune_parser.add_argument(

--- a/rootstock/cli.py
+++ b/rootstock/cli.py
@@ -423,8 +423,10 @@ def main():
         help=(
             "Optional directory declaring the *complete* desired set of env "
             "sources (*.py): anything registered, built, or fetched beyond it "
-            "is pruned — including registered source files. Defaults to the "
-            "root's registered environments."
+            "is pruned — including registered source files. An empty directory "
+            "declares zero environments. Defaults to the root's registered "
+            "environments (if that dir doesn't exist, nothing is declared and "
+            "only internal garbage is collected)."
         ),
     )
     prune_parser.add_argument(

--- a/rootstock/commands/__init__.py
+++ b/rootstock/commands/__init__.py
@@ -7,6 +7,7 @@ from .create import cmd_new_env
 from .init import cmd_init
 from .install import cmd_install
 from .manifest import cmd_manifest_init, cmd_manifest_push, cmd_manifest_show
+from .prune import cmd_prune
 from .resolve import cmd_resolve
 from .serve import cmd_serve
 from .setup_perms import cmd_setup_perms
@@ -26,6 +27,7 @@ __all__ = [
     "cmd_manifest_push",
     "cmd_manifest_show",
     "cmd_new_env",
+    "cmd_prune",
     "cmd_resolve",
     "cmd_serve",
     "cmd_setup_perms",

--- a/rootstock/commands/common.py
+++ b/rootstock/commands/common.py
@@ -39,6 +39,16 @@ def warn_on_permissions(root: Path, cache_root: Path) -> None:
     )
 
 
+def resolve_root(args) -> Path:
+    """``--root`` (or env/config fallback), with ``--cluster`` as a registry
+    bootstrap for admins driving a known cluster by name."""
+    if getattr(args, "cluster", None) and not args.root:
+        from ..clusters import get_root_for_cluster
+
+        return get_root_for_cluster(args.cluster)
+    return get_root_or_exit(args)
+
+
 def get_root_or_exit(args) -> Path:
     """
     Get the root directory from args, environment variable, or config file.

--- a/rootstock/commands/prune.py
+++ b/rootstock/commands/prune.py
@@ -92,8 +92,18 @@ def cmd_prune(args) -> int:
     cache_root = resolve_cache_root(root)
 
     # With --json the machine-readable document owns stdout; everything
-    # human-oriented (plan, progress, summary) moves to stderr.
-    say = (lambda line: print(line, file=sys.stderr)) if args.json else print
+    # human-oriented (plan, progress, summary) moves to stderr. Every line is
+    # flushed: prune runs inside batch jobs whose stdout is a redirected file
+    # (block-buffered by default), and `tail -f` on the job's outfile must
+    # show slow deletes as they happen, not when the buffer fills.
+    if args.json:
+
+        def say(line: str) -> None:
+            print(line, file=sys.stderr, flush=True)
+    else:
+
+        def say(line: str) -> None:
+            print(line, flush=True)
 
     try:
         plan = plan_prune(
@@ -105,10 +115,12 @@ def cmd_prune(args) -> int:
             deep=args.deep,
             min_age_hours=args.min_age,
             cache_root=cache_root,
+            progress=say,
         )
     except (OperationError, ManifestError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
+    say("")
 
     render_prune_plan(plan, say=say, root=root, cache_root=cache_root)
 

--- a/rootstock/commands/prune.py
+++ b/rootstock/commands/prune.py
@@ -1,0 +1,154 @@
+"""``rootstock prune`` — the subtractive half of ``sync``.
+
+Thin argparse adapter over :mod:`rootstock.batch` (the prune planner and
+delete executor); process-wide concerns (umask, layout checks, permission
+warnings) live here, exactly as in ``sync``.
+
+Unlike sync, prune is plan-confirm by default: the failure mode inverts (a
+spurious sync build wastes hours; a spurious prune deletes a 14 GB cache
+another user's job is warming), so executing requires ``--yes`` or an
+interactive confirmation.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+from ..batch import (
+    execute_prune,
+    plan_prune,
+    render_prune_plan,
+    render_summary,
+)
+from ..layout import ensure_layout_compatible, write_layout_marker
+from ..manifest import ManifestError
+from ..operations import OperationError
+from .common import get_root_or_exit, resolve_cache_root, warn_on_permissions
+
+
+def _resolve_root(args) -> Path:
+    """``--root`` (or env/config fallback), with ``--cluster`` as a registry
+    bootstrap for admins driving a known cluster by name."""
+    if getattr(args, "cluster", None) and not args.root:
+        from ..clusters import get_root_for_cluster
+
+        return get_root_for_cluster(args.cluster)
+    return get_root_or_exit(args)
+
+
+def _confirm(say) -> bool:
+    """Interactive gate for the destructive path; never reached with --yes."""
+    if not sys.stdin.isatty():
+        print(
+            "Error: refusing to delete without --yes when stdin is not a tty "
+            "(use --dry-run to inspect the plan)",
+            file=sys.stderr,
+        )
+        return False
+    say("")
+    try:
+        answer = input("Proceed with deletion? [y/N] ")
+    except EOFError:
+        return False
+    return answer.strip().lower() in ("y", "yes")
+
+
+def cmd_prune(args) -> int:
+    """
+    Plan and execute the removal of undeclared state plus internal garbage.
+
+    Exit codes:
+        0: Pruned (or --dry-run, or nothing to prune, or user declined)
+        1: One or more delete items failed (re-run to retry)
+        2: Usage error
+    """
+    # Same shared-install stance as install/sync: the manifest and layout
+    # marker this rewrites must stay group-writable.
+    os.umask(0o002)
+
+    source_dir: Path | None = None
+    if args.source_dir:
+        source_dir = Path(args.source_dir)
+        if not source_dir.is_dir():
+            print(f"Error: {source_dir} is not a directory", file=sys.stderr)
+            return 2
+
+    if args.min_age < 0:
+        print("Error: --min-age must be >= 0", file=sys.stderr)
+        return 2
+
+    root = _resolve_root(args)
+
+    # Never write into a root laid out by a newer rootstock.
+    try:
+        ensure_layout_compatible(root)
+    except RuntimeError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    cache_root = resolve_cache_root(root)
+
+    # With --json the machine-readable document owns stdout; everything
+    # human-oriented (plan, progress, summary) moves to stderr.
+    say = (lambda line: print(line, file=sys.stderr)) if args.json else print
+
+    try:
+        plan = plan_prune(
+            root,
+            source_dir=source_dir,
+            envs=args.env,
+            checkpoints=args.checkpoint,
+            gc_only=args.gc_only,
+            deep=args.deep,
+            min_age_hours=args.min_age,
+            cache_root=cache_root,
+        )
+    except (OperationError, ManifestError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    render_prune_plan(plan, say=say, root=root, cache_root=cache_root)
+
+    if args.dry_run:
+        if args.json:
+            print(json.dumps({"root": str(root), "plan": plan.to_dict()}, indent=2))
+        return 0
+
+    if plan.is_empty:
+        if args.json:
+            print(json.dumps({"root": str(root), "plan": plan.to_dict(), "results": []}, indent=2))
+        return 0
+
+    if not args.yes and not _confirm(say):
+        say("Aborted; nothing was deleted.")
+        return 0
+
+    # Mutating-command duties: surface permission problems that would turn a
+    # half-executed plan into stranded state, and stamp the layout marker.
+    if not args.no_perm_check:
+        warn_on_permissions(root, cache_root)
+    write_layout_marker(root, cache_root=cache_root)
+
+    say("")
+    report = execute_prune(
+        root,
+        plan,
+        fail_fast=args.fail_fast,
+        push=not args.no_push,
+        cache_root=cache_root,
+        say=say,
+    )
+
+    render_summary(report, say=say)
+    if args.json:
+        print(
+            json.dumps(
+                {"root": str(root), "plan": plan.to_dict(), **report.to_dict()},
+                indent=2,
+            )
+        )
+
+    return 1 if report.failed else 0

--- a/rootstock/commands/prune.py
+++ b/rootstock/commands/prune.py
@@ -26,34 +26,7 @@ from ..batch import (
 from ..layout import ensure_layout_compatible, write_layout_marker
 from ..manifest import ManifestError
 from ..operations import OperationError
-from .common import get_root_or_exit, resolve_cache_root, warn_on_permissions
-
-
-def _resolve_root(args) -> Path:
-    """``--root`` (or env/config fallback), with ``--cluster`` as a registry
-    bootstrap for admins driving a known cluster by name."""
-    if getattr(args, "cluster", None) and not args.root:
-        from ..clusters import get_root_for_cluster
-
-        return get_root_for_cluster(args.cluster)
-    return get_root_or_exit(args)
-
-
-def _confirm(say) -> bool:
-    """Interactive gate for the destructive path; never reached with --yes."""
-    if not sys.stdin.isatty():
-        print(
-            "Error: refusing to delete without --yes when stdin is not a tty "
-            "(use --dry-run to inspect the plan)",
-            file=sys.stderr,
-        )
-        return False
-    say("")
-    try:
-        answer = input("Proceed with deletion? [y/N] ")
-    except EOFError:
-        return False
-    return answer.strip().lower() in ("y", "yes")
+from .common import resolve_cache_root, resolve_root, warn_on_permissions
 
 
 def cmd_prune(args) -> int:
@@ -61,9 +34,9 @@ def cmd_prune(args) -> int:
     Plan and execute the removal of undeclared state plus internal garbage.
 
     Exit codes:
-        0: Pruned (or --dry-run, or nothing to prune, or user declined)
+        0: Pruned (or --dry-run, or nothing to prune, or an interactive "no")
         1: One or more delete items failed (re-run to retry)
-        2: Usage error
+        2: Usage error (including no --yes without a tty to confirm on)
     """
     # Same shared-install stance as install/sync: the manifest and layout
     # marker this rewrites must stay group-writable.
@@ -80,7 +53,7 @@ def cmd_prune(args) -> int:
         print("Error: --min-age must be >= 0", file=sys.stderr)
         return 2
 
-    root = _resolve_root(args)
+    root = resolve_root(args)
 
     # Never write into a root laid out by a newer rootstock.
     try:
@@ -134,9 +107,26 @@ def cmd_prune(args) -> int:
             print(json.dumps({"root": str(root), "plan": plan.to_dict(), "results": []}, indent=2))
         return 0
 
-    if not args.yes and not _confirm(say):
-        say("Aborted; nothing was deleted.")
-        return 0
+    if not args.yes:
+        if not sys.stdin.isatty():
+            # A batch job that forgot --yes must fail loudly (usage error),
+            # not "succeed" having deleted nothing.
+            print(
+                "Error: refusing to delete without --yes when stdin is not a tty "
+                "(use --dry-run to inspect the plan)",
+                file=sys.stderr,
+            )
+            return 2
+        # Prompt via stderr: with --json, stdout belongs to the machine-
+        # readable document alone.
+        print("\nProceed with deletion? [y/N] ", end="", file=sys.stderr, flush=True)
+        try:
+            answer = input()
+        except EOFError:
+            answer = ""
+        if answer.strip().lower() not in ("y", "yes"):
+            say("Aborted; nothing was deleted.")
+            return 0
 
     # Mutating-command duties: surface permission problems that would turn a
     # half-executed plan into stranded state, and stamp the layout marker.

--- a/rootstock/commands/sync.py
+++ b/rootstock/commands/sync.py
@@ -16,17 +16,7 @@ from ..batch import PHASES, execute_sync, plan_sync, render_plan, render_summary
 from ..environment import CheckpointNotFoundError
 from ..layout import ensure_layout_compatible, write_layout_marker
 from ..operations import OperationError
-from .common import get_root_or_exit, resolve_cache_root, warn_on_permissions
-
-
-def _resolve_root(args) -> Path:
-    """``--root`` (or env/config fallback), with ``--cluster`` as a registry
-    bootstrap for admins driving a known cluster by name."""
-    if getattr(args, "cluster", None) and not args.root:
-        from ..clusters import get_root_for_cluster
-
-        return get_root_for_cluster(args.cluster)
-    return get_root_or_exit(args)
+from .common import resolve_cache_root, resolve_root, warn_on_permissions
 
 
 def _parse_phases(spec: str) -> tuple[str, ...]:
@@ -70,7 +60,7 @@ def cmd_sync(args) -> int:
             print(f"Error: {source_dir} is not a directory", file=sys.stderr)
             return 2
 
-    root = _resolve_root(args)
+    root = resolve_root(args)
 
     # Never write into a root laid out by a newer rootstock.
     try:

--- a/tests/cli/test_prune.py
+++ b/tests/cli/test_prune.py
@@ -1,0 +1,226 @@
+"""Tests for the ``rootstock prune`` CLI adapter.
+
+Planner and executor are mocked (they have their own tests under
+tests/commands/); what's under test is the adapter contract: the confirm
+gate, exit codes, --dry-run/--json behavior, knob forwarding, and the
+shared-install umask.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from rootstock.batch import ItemResult, PruneEnvItem, PrunePlan, SyncReport
+from rootstock.commands.prune import cmd_prune
+
+
+def _make_args(root: Path, **overrides):
+    args = SimpleNamespace()
+    args.source_dir = overrides.get("source_dir")
+    args.root = str(root)
+    args.cluster = overrides.get("cluster")
+    args.env = overrides.get("env")
+    args.checkpoint = overrides.get("checkpoint")
+    args.gc_only = overrides.get("gc_only", False)
+    args.deep = overrides.get("deep", False)
+    args.min_age = overrides.get("min_age", 24.0)
+    args.yes = overrides.get("yes", True)
+    args.dry_run = overrides.get("dry_run", False)
+    args.json = overrides.get("json", False)
+    args.fail_fast = overrides.get("fail_fast", False)
+    args.no_push = overrides.get("no_push", True)
+    args.no_perm_check = overrides.get("no_perm_check", True)
+    return args
+
+
+@pytest.fixture
+def stubbed(monkeypatch) -> dict:
+    """Stub the planner/executor; tests set the plan/report to return."""
+    state = {
+        "plan": PrunePlan(),
+        "report": SyncReport(),
+        "plan_calls": [],
+        "exec_calls": [],
+    }
+
+    def fake_plan(root, **kwargs):
+        state["plan_calls"].append((root, kwargs))
+        return state["plan"]
+
+    def fake_execute(root, plan, **kwargs):
+        state["exec_calls"].append((root, kwargs))
+        return state["report"]
+
+    monkeypatch.setattr("rootstock.commands.prune.plan_prune", fake_plan)
+    monkeypatch.setattr("rootstock.commands.prune.execute_prune", fake_execute)
+    return state
+
+
+ONE_ENV = PrunePlan(envs=[PruneEnvItem("orb", "no registered source")])
+ENV_OK = SyncReport(results=[ItemResult("env", "orb", None, "ok", "no registered source")])
+ENV_FAILED = SyncReport(results=[ItemResult("env", "orb", None, "failed", "boom")])
+
+
+def test_dry_run_plans_but_never_executes(tmp_path, stubbed):
+    stubbed["plan"] = ONE_ENV
+
+    rc = cmd_prune(_make_args(tmp_path, dry_run=True, yes=False))
+
+    assert rc == 0
+    assert len(stubbed["plan_calls"]) == 1
+    assert stubbed["exec_calls"] == []
+    # --dry-run must not stamp the layout marker.
+    assert not (tmp_path / "layout.json").exists()
+
+
+def test_empty_plan_short_circuits(tmp_path, stubbed, capsys):
+    rc = cmd_prune(_make_args(tmp_path))
+
+    assert rc == 0
+    assert stubbed["exec_calls"] == []
+    assert "Nothing to prune" in capsys.readouterr().out
+
+
+def test_no_yes_without_a_tty_is_a_usage_error(tmp_path, stubbed, capsys):
+    """A batch job that forgot --yes must fail loudly, not 'succeed' having
+    deleted nothing. (pytest's captured stdin is not a tty.)"""
+    stubbed["plan"] = ONE_ENV
+
+    rc = cmd_prune(_make_args(tmp_path, yes=False))
+
+    assert rc == 2
+    assert stubbed["exec_calls"] == []
+    assert "refusing to delete without --yes" in capsys.readouterr().err
+    assert not (tmp_path / "layout.json").exists()
+
+
+def test_interactive_decline_exits_0_without_executing(tmp_path, stubbed, monkeypatch, capsys):
+    stubbed["plan"] = ONE_ENV
+    monkeypatch.setattr("sys.stdin", SimpleNamespace(isatty=lambda: True))
+    monkeypatch.setattr("builtins.input", lambda: "n")
+
+    rc = cmd_prune(_make_args(tmp_path, yes=False))
+
+    assert rc == 0
+    assert stubbed["exec_calls"] == []
+    assert "Aborted" in capsys.readouterr().out
+
+
+def test_interactive_confirm_executes(tmp_path, stubbed, monkeypatch):
+    stubbed["plan"] = ONE_ENV
+    stubbed["report"] = ENV_OK
+    monkeypatch.setattr("sys.stdin", SimpleNamespace(isatty=lambda: True))
+    monkeypatch.setattr("builtins.input", lambda: "y")
+
+    rc = cmd_prune(_make_args(tmp_path, yes=False))
+
+    assert rc == 0
+    assert len(stubbed["exec_calls"]) == 1
+
+
+def test_execution_failure_exits_1(tmp_path, stubbed):
+    stubbed["plan"] = ONE_ENV
+    stubbed["report"] = ENV_FAILED
+
+    rc = cmd_prune(_make_args(tmp_path))
+
+    assert rc == 1
+    assert len(stubbed["exec_calls"]) == 1
+    assert (tmp_path / "layout.json").exists(), "a mutating run stamps the layout marker"
+
+
+def test_success_exits_0_and_forwards_knobs(tmp_path, stubbed):
+    stubbed["plan"] = ONE_ENV
+    stubbed["report"] = ENV_OK
+
+    rc = cmd_prune(
+        _make_args(
+            tmp_path,
+            env=["orb"],
+            checkpoint=["orb-v2"],
+            gc_only=True,
+            deep=True,
+            min_age=1.5,
+            fail_fast=True,
+        )
+    )
+
+    assert rc == 0
+    ((_, plan_kwargs),) = stubbed["plan_calls"]
+    assert plan_kwargs["envs"] == ["orb"]
+    assert plan_kwargs["checkpoints"] == ["orb-v2"]
+    assert plan_kwargs["gc_only"] is True
+    assert plan_kwargs["deep"] is True
+    assert plan_kwargs["min_age_hours"] == 1.5
+    ((_, exec_kwargs),) = stubbed["exec_calls"]
+    assert exec_kwargs["fail_fast"] is True
+    assert exec_kwargs["push"] is False  # from no_push=True
+
+
+def test_missing_source_dir_is_a_usage_error(tmp_path, stubbed):
+    rc = cmd_prune(_make_args(tmp_path, source_dir=str(tmp_path / "nope")))
+    assert rc == 2
+    assert stubbed["plan_calls"] == []
+
+
+def test_negative_min_age_is_a_usage_error(tmp_path, stubbed):
+    rc = cmd_prune(_make_args(tmp_path, min_age=-1))
+    assert rc == 2
+    assert stubbed["plan_calls"] == []
+
+
+def test_json_dry_run_emits_the_plan_on_stdout(tmp_path, stubbed, capsys):
+    stubbed["plan"] = ONE_ENV
+
+    rc = cmd_prune(_make_args(tmp_path, dry_run=True, json=True))
+
+    assert rc == 0
+    document = json.loads(capsys.readouterr().out)
+    assert document["plan"]["envs"][0]["env_name"] == "orb"
+
+
+def test_json_run_keeps_stdout_clean_even_with_a_confirm(tmp_path, stubbed, monkeypatch, capsys):
+    """With --json, stdout is exactly one JSON document: plan, progress, and
+    the confirm prompt all ride stderr."""
+    stubbed["plan"] = ONE_ENV
+    stubbed["report"] = ENV_OK
+    monkeypatch.setattr("sys.stdin", SimpleNamespace(isatty=lambda: True))
+    monkeypatch.setattr("builtins.input", lambda: "y")
+
+    rc = cmd_prune(_make_args(tmp_path, json=True, yes=False))
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    document = json.loads(captured.out)
+    assert document["counts"] == {"ok": 1, "failed": 0, "skipped": 0}
+    assert "Proceed with deletion?" in captured.err
+
+
+def test_prune_overrides_restrictive_umask(tmp_path, stubbed):
+    """The manifest and layout marker prune rewrites must stay group-writable,
+    whatever the maintainer's personal umask says."""
+    old = os.umask(0o077)
+    try:
+        assert cmd_prune(_make_args(tmp_path, dry_run=True)) == 0
+        assert os.umask(0o022) == 0o002
+    finally:
+        os.umask(old)
+
+
+def test_planner_errors_are_reported_cleanly(tmp_path, monkeypatch, capsys):
+    from rootstock.operations import OperationError
+
+    def exploding_plan(root, **kwargs):
+        raise OperationError("Unknown checkpoint id(s): nope")
+
+    monkeypatch.setattr("rootstock.commands.prune.plan_prune", exploding_plan)
+
+    rc = cmd_prune(_make_args(tmp_path, checkpoint=["nope"]))
+
+    assert rc == 1
+    assert "Unknown checkpoint id" in capsys.readouterr().err

--- a/tests/commands/test_prune_exec.py
+++ b/tests/commands/test_prune_exec.py
@@ -182,6 +182,24 @@ def test_record_drop_failure_blocks_weights_but_not_envs(tmp_path, refreshes, mo
     assert len(refreshes) == 1  # the env succeeded; state changed
 
 
+def test_vanished_manifest_fails_the_record_drop(tmp_path, refreshes):
+    """The plan's checkpoint items came from a manifest; it vanishing means
+    the world changed — deleting files anyway would break the record-first
+    invariant."""
+    weight_file = touch(tmp_path, "cache/mace/gone.pt")  # no manifest saved
+    plan = PrunePlan(
+        checkpoints=[
+            PruneCheckpointItem("mace", "gone", "not declared", files=["cache/mace/gone.pt"])
+        ]
+    )
+
+    report = execute_prune(tmp_path, plan, cache_root=tmp_path, say=lambda _: None)
+
+    assert statuses(report) == {("checkpoint", "mace/gone"): "failed"}
+    assert "manifest disappeared" in report.failed[0].reason
+    assert weight_file.exists()
+
+
 def test_gc_items_keep_going_past_failures(tmp_path, refreshes, monkeypatch):
     stale = tmp_path / ".build" / "mace.1"
     stale.mkdir(parents=True)

--- a/tests/commands/test_prune_exec.py
+++ b/tests/commands/test_prune_exec.py
@@ -1,0 +1,281 @@
+"""The ``rootstock prune`` executor.
+
+What's under test is the safety contract: checkpoint records drop (one
+manifest transaction) *before* any weight file is unlinked, envs disappear
+through a trash-rename, failures keep going without sinking the batch, and
+exactly one manifest refresh runs at the end when anything succeeded.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from rootstock.batch import (
+    GCItem,
+    PruneCheckpointItem,
+    PruneEnvItem,
+    PrunePlan,
+    PruneWeightDirItem,
+    execute_prune,
+)
+from rootstock.manifest import (
+    CheckpointInfo,
+    EnvironmentInfo,
+    create_manifest,
+    load_manifest,
+    save_manifest,
+)
+
+
+@pytest.fixture
+def refreshes(monkeypatch) -> list:
+    recorded: list = []
+    monkeypatch.setattr(
+        "rootstock.operations.update_and_push_manifest",
+        lambda root, **kwargs: recorded.append(kwargs) or True,
+    )
+    return recorded
+
+
+def save(root: Path, environments: dict[str, EnvironmentInfo]) -> None:
+    from rootstock.config import UserConfig
+
+    manifest = create_manifest(root, "test", UserConfig(name="t", email="t@t.t"))
+    manifest.environments = environments
+    save_manifest(manifest, root)
+
+
+def env_record(checkpoints: dict[str, CheckpointInfo] | None = None) -> EnvironmentInfo:
+    return EnvironmentInfo(
+        built_at="2026-07-01T00:00:00+00:00",
+        source_hash=None,
+        source="",
+        python_requires=">=3.11",
+        dependencies={},
+        checkpoints=checkpoints or {},
+    )
+
+
+def touch(root: Path, relpath: str, size: int = 4) -> Path:
+    target = root / relpath
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(b"x" * size)
+    return target
+
+
+def statuses(report) -> dict[tuple[str, str], str]:
+    return {(r.phase, r.label): r.status for r in report.results}
+
+
+def test_happy_path_drops_records_deletes_files_and_refreshes_once(tmp_path, refreshes):
+    save(
+        tmp_path,
+        {
+            "mace": env_record(
+                {"keep": CheckpointInfo(fetched_at="x"), "gone": CheckpointInfo(fetched_at="x")}
+            )
+        },
+    )
+    touch(tmp_path, "cache/mace/deep/nested/gone.pt")
+    touch(tmp_path, "cache/mace/keep.pt")
+    plan = PrunePlan(
+        checkpoints=[
+            PruneCheckpointItem(
+                "mace", "gone", "not declared", files=["cache/mace/deep/nested/gone.pt"]
+            )
+        ]
+    )
+
+    report = execute_prune(tmp_path, plan, cache_root=tmp_path, say=lambda _: None)
+
+    assert statuses(report) == {("checkpoint", "mace/gone"): "ok"}
+    manifest = load_manifest(tmp_path)
+    assert set(manifest.environments["mace"].checkpoints) == {"keep"}
+    assert not (tmp_path / "cache/mace/deep").exists()  # emptied parents pruned
+    assert (tmp_path / "cache/mace/keep.pt").exists()  # stops at first non-empty dir
+    assert (tmp_path / "cache").exists()
+    assert len(refreshes) == 1 and refreshes[0] == {"quiet": True, "push": True}
+
+
+def test_weight_dir_item_removes_the_whole_repo_dir(tmp_path, refreshes):
+    touch(tmp_path, "cache/huggingface/hub/models--a--b/blobs/aa")
+    touch(tmp_path, "cache/huggingface/hub/models--a--b/refs/main")
+    touch(tmp_path, "cache/huggingface/hub/models--keep--me/blobs/bb")
+    plan = PrunePlan(
+        weight_dirs=[
+            PruneWeightDirItem("cache/huggingface/hub/models--a--b", "released", ["uma-m"], 8)
+        ]
+    )
+
+    report = execute_prune(tmp_path, plan, cache_root=tmp_path, say=lambda _: None)
+
+    assert statuses(report) == {("weights", "models--a--b"): "ok"}
+    assert not (tmp_path / "cache/huggingface/hub/models--a--b").exists()
+    assert (tmp_path / "cache/huggingface/hub/models--keep--me/blobs/bb").exists()
+
+
+def test_env_removal_goes_through_trash_rename(tmp_path, refreshes, monkeypatch):
+    env_dir = tmp_path / "envs" / "orb"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+    source = touch(tmp_path, "environments/orb.py")
+    touch(tmp_path, "environments/orb.py.lock")
+    save(tmp_path, {"orb": env_record()})
+
+    removed: list[Path] = []
+    real_rmtree = shutil.rmtree
+
+    def spying_rmtree(path, *args, **kwargs):
+        removed.append(Path(path))
+        return real_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr("rootstock.batch.shutil.rmtree", spying_rmtree)
+    plan = PrunePlan(
+        envs=[PruneEnvItem("orb", "not declared", env_dir=True, source_file=str(source))]
+    )
+
+    report = execute_prune(tmp_path, plan, cache_root=tmp_path, say=lambda _: None)
+
+    assert statuses(report) == {("env", "orb"): "ok"}
+    assert not env_dir.exists()
+    # The rmtree target was the .trash rename, never the live envs/ path —
+    # a mid-spawn reader sees atomic disappearance, not a half-deleted tree.
+    assert len(removed) == 1
+    assert removed[0].parent == tmp_path / ".trash"
+    assert removed[0].name.startswith("orb.")
+    assert not source.exists()
+    assert not (tmp_path / "environments/orb.py.lock").exists()
+
+
+def test_record_drop_failure_blocks_weights_but_not_envs(tmp_path, refreshes, monkeypatch):
+    save(tmp_path, {"mace": env_record({"gone": CheckpointInfo(fetched_at="x")})})
+    weight_file = touch(tmp_path, "cache/mace/gone.pt")
+    env_dir = tmp_path / "envs" / "orb"
+    env_dir.mkdir(parents=True)
+
+    from rootstock.manifest import ManifestError
+
+    def broken_load(root):
+        raise ManifestError("corrupt")
+
+    monkeypatch.setattr("rootstock.batch.load_manifest", broken_load)
+    plan = PrunePlan(
+        checkpoints=[
+            PruneCheckpointItem("mace", "gone", "not declared", files=["cache/mace/gone.pt"])
+        ],
+        weight_dirs=[PruneWeightDirItem("cache/huggingface/hub/models--a--b", "released")],
+        envs=[PruneEnvItem("orb", "no registered source")],
+    )
+
+    report = execute_prune(tmp_path, plan, cache_root=tmp_path, say=lambda _: None)
+
+    got = statuses(report)
+    assert got[("checkpoint", "mace/gone")] == "failed"
+    assert got[("weights", "models--a--b")] == "skipped"
+    assert got[("env", "orb")] == "ok"
+    # Record-first ordering: with the record still standing, its files must survive.
+    assert weight_file.exists()
+    assert not env_dir.exists()
+    assert len(refreshes) == 1  # the env succeeded; state changed
+
+
+def test_gc_items_keep_going_past_failures(tmp_path, refreshes, monkeypatch):
+    stale = tmp_path / ".build" / "mace.1"
+    stale.mkdir(parents=True)
+    lock = touch(tmp_path, "environments/dead.py.lock")
+    monkeypatch.setattr("rootstock.batch.shutil.which", lambda _: None)  # uv "missing"
+    plan = PrunePlan(
+        gc=[
+            GCItem("uv-cache", str(tmp_path / ".uv-cache"), "delegate"),
+            GCItem("build", str(stale), "leftover"),
+            GCItem("lockfile", str(lock), "orphaned"),
+        ]
+    )
+
+    report = execute_prune(tmp_path, plan, cache_root=tmp_path, say=lambda _: None)
+
+    got = statuses(report)
+    assert got[("gc", "uv-cache:.uv-cache")] == "failed"
+    assert got[("gc", "build:mace.1")] == "ok"
+    assert got[("gc", "lockfile:dead.py.lock")] == "ok"
+    assert not stale.exists() and not lock.exists()
+
+
+def test_uv_cache_runs_uv_cache_prune_with_the_roots_cache_dir(tmp_path, refreshes, monkeypatch):
+    uv_cache = tmp_path / ".uv-cache"
+    uv_cache.mkdir()
+    calls: list = []
+
+    class Proc:
+        returncode = 0
+        stderr = ""
+        stdout = ""
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs["env"]["UV_CACHE_DIR"]))
+        return Proc()
+
+    monkeypatch.setattr("rootstock.batch.shutil.which", lambda _: "/usr/bin/uv")
+    monkeypatch.setattr("rootstock.batch.subprocess.run", fake_run)
+    plan = PrunePlan(gc=[GCItem("uv-cache", str(uv_cache), "delegate")])
+
+    report = execute_prune(tmp_path, plan, cache_root=tmp_path, say=lambda _: None)
+
+    assert statuses(report) == {("gc", "uv-cache:.uv-cache"): "ok"}
+    assert calls == [(["uv", "cache", "prune"], str(uv_cache))]
+
+
+def test_missing_files_are_tolerated_for_idempotent_reruns(tmp_path, refreshes):
+    save(tmp_path, {"mace": env_record({"gone": CheckpointInfo(fetched_at="x")})})
+    plan = PrunePlan(
+        checkpoints=[
+            PruneCheckpointItem(
+                "mace", "gone", "not declared", files=["cache/mace/already-gone.pt"]
+            )
+        ]
+    )
+
+    report = execute_prune(tmp_path, plan, cache_root=tmp_path, say=lambda _: None)
+
+    assert statuses(report) == {("checkpoint", "mace/gone"): "ok"}
+
+
+def test_nothing_succeeded_means_no_refresh(tmp_path, refreshes, monkeypatch):
+    monkeypatch.setattr("rootstock.batch.shutil.which", lambda _: None)
+    plan = PrunePlan(gc=[GCItem("uv-cache", str(tmp_path / ".uv-cache"), "delegate")])
+
+    report = execute_prune(tmp_path, plan, cache_root=tmp_path, say=lambda _: None)
+
+    assert [r.status for r in report.results] == ["failed"]
+    assert refreshes == []
+
+
+def test_fail_fast_skips_later_phases(tmp_path, refreshes, monkeypatch):
+    monkeypatch.setattr("rootstock.batch.shutil.which", lambda _: None)
+    env_dir = tmp_path / "envs" / "orb"
+    env_dir.mkdir(parents=True)
+    save(tmp_path, {"mace": env_record({"gone": CheckpointInfo(fetched_at="x")})})
+
+    from rootstock.manifest import ManifestError
+
+    def broken_load(root):
+        raise ManifestError("corrupt")
+
+    monkeypatch.setattr("rootstock.batch.load_manifest", broken_load)
+    plan = PrunePlan(
+        checkpoints=[PruneCheckpointItem("mace", "gone", "not declared")],
+        envs=[PruneEnvItem("orb", "no registered source")],
+        gc=[GCItem("build", str(tmp_path / ".build" / "x"), "leftover")],
+    )
+
+    report = execute_prune(tmp_path, plan, fail_fast=True, cache_root=tmp_path, say=lambda _: None)
+
+    got = statuses(report)
+    assert got[("checkpoint", "mace/gone")] == "failed"
+    assert got[("env", "orb")] == "skipped"
+    assert got[("gc", "build:x")] == "skipped"
+    assert env_dir.exists()
+    assert refreshes == []

--- a/tests/commands/test_prune_exec.py
+++ b/tests/commands/test_prune_exec.py
@@ -228,6 +228,39 @@ def test_uv_cache_runs_uv_cache_prune_with_the_roots_cache_dir(tmp_path, refresh
     assert calls == [(["uv", "cache", "prune"], str(uv_cache))]
 
 
+def test_execution_streams_each_action_live(tmp_path, refreshes):
+    """Deletes stream as they happen (serial phases use live output, not the
+    buffer-until-failure idiom sync's parallel phases need) — and each action
+    is logged *before* it runs, so a hung delete shows its target."""
+    save(tmp_path, {"mace": env_record({"gone": CheckpointInfo(fetched_at="x")})})
+    touch(tmp_path, "cache/mace/gone.pt")
+    touch(tmp_path, "cache/huggingface/hub/models--a--b/blobs/aa")
+    env_dir = tmp_path / "envs" / "orb"
+    env_dir.mkdir(parents=True)
+    plan = PrunePlan(
+        checkpoints=[
+            PruneCheckpointItem("mace", "gone", "not declared", files=["cache/mace/gone.pt"])
+        ],
+        weight_dirs=[PruneWeightDirItem("cache/huggingface/hub/models--a--b", "released")],
+        envs=[PruneEnvItem("orb", "no registered source")],
+    )
+
+    lines: list[str] = []
+    report = execute_prune(tmp_path, plan, cache_root=tmp_path, say=lines.append)
+
+    assert not report.failed
+    stripped = [line.strip() for line in lines]
+    assert any(line.startswith("dropping 1 checkpoint record") for line in stripped)
+    assert "rm cache/mace/gone.pt (4 B)" in stripped
+    assert any(line.startswith("rm -r cache/huggingface/hub/models--a--b") for line in stripped)
+    assert any(line.startswith("mv envs/orb -> .trash/orb.") for line in stripped)
+    assert any(line.startswith("refreshing manifest") for line in stripped)
+    # The live lines land *before* the item's completion mark.
+    assert stripped.index("rm cache/mace/gone.pt (4 B)") < next(
+        i for i, line in enumerate(stripped) if line.startswith("[checkpoint 1/1]")
+    )
+
+
 def test_missing_files_are_tolerated_for_idempotent_reruns(tmp_path, refreshes):
     save(tmp_path, {"mace": env_record({"gone": CheckpointInfo(fetched_at="x")})})
     plan = PrunePlan(

--- a/tests/commands/test_prune_plan.py
+++ b/tests/commands/test_prune_plan.py
@@ -346,7 +346,15 @@ def test_env_and_checkpoint_filters_limit_scope(tmp_path):
     assert [e.env_name for e in plan.envs] == ["orb"]
     assert [c.checkpoint for c in plan.checkpoints] == ["orb-v2"]
 
+    # --checkpoint alone narrows the run to checkpoint pruning: with --yes in
+    # a batch job, env deletion must not ride along uninvited.
     plan = plan_prune(tmp_path, checkpoints=["g1"], cache_root=tmp_path)
+    assert [c.checkpoint for c in plan.checkpoints] == ["g1"]
+    assert plan.envs == []
+
+    # --env restores env pruning, scoped to the named envs.
+    plan = plan_prune(tmp_path, envs=["gemnet"], checkpoints=["g1"], cache_root=tmp_path)
+    assert [e.env_name for e in plan.envs] == ["gemnet"]
     assert [c.checkpoint for c in plan.checkpoints] == ["g1"]
 
     with pytest.raises(OperationError, match="Unknown environment"):
@@ -465,13 +473,68 @@ def test_unattributed_cache_is_reported_not_deleted(tmp_path):
     assert reported == {"mystery": 10, "models--never--read": 7, "matgl": 5}
     assert plan.is_empty  # report-only: nothing to execute
 
-    deep = plan_prune(tmp_path, deep=True, cache_root=tmp_path)
+    deep = plan_prune(tmp_path, deep=True, min_age_hours=0, cache_root=tmp_path)
     assert deep.unattributed == []
     assert {Path(i.path).name for i in deep.gc if i.kind == "unattributed"} == {
         "mystery",
         "models--never--read",
         "matgl",
     }
+
+
+def test_deep_respects_min_age_via_newest_mtime_in_tree(tmp_path):
+    """An in-flight download is unattributed by definition (records land only
+    after setup succeeds), so --deep must honor the age guard — judged by the
+    newest mtime anywhere in the tree, because the download writes deep inside
+    the repo dir without bumping its top-level mtime."""
+    source = env_source("mace-mp-0-medium")
+    register(tmp_path, "mace", source)
+    build(tmp_path, "mace", source)
+    save(tmp_path, {"mace": record(tmp_path, "mace", checkpoints={"mace-mp-0-medium": fetched()})})
+    # Old top-level dir, fresh write deep inside — exactly what a running
+    # download looks like from another node.
+    weight(tmp_path, "cache/huggingface/hub/models--in--flight/blobs/partial")
+    for p in (
+        tmp_path / "cache/huggingface/hub/models--in--flight",
+        tmp_path / "cache/huggingface/hub/models--in--flight/blobs",
+    ):
+        age(p)
+
+    plan = plan_prune(tmp_path, deep=True, cache_root=tmp_path)
+
+    assert [i for i in plan.gc if i.kind == "unattributed"] == []
+    assert [Path(u["path"]).name for u in plan.unattributed] == ["models--in--flight"]
+    assert any("--deep" in note and "younger than --min-age" in note for note in plan.notes)
+
+
+def test_unrecorded_survivor_suppresses_repo_dir_release(tmp_path):
+    """A fetched survivor with no weight record could be using any repo dir
+    without appearing in the attribution map — whole-dir release would delete
+    its weights out from under it. Per-file refcounted deletion still runs."""
+    source = env_source("uma-s-1p1")  # uma-m was dropped; uma-s survives unrecorded
+    register(tmp_path, "uma", source)
+    build(tmp_path, "uma", source)
+    pruned_blob = weight(tmp_path, "cache/huggingface/hub/models--facebook--UMA/blobs/aa")
+    save(
+        tmp_path,
+        {
+            "uma": record(
+                tmp_path,
+                "uma",
+                checkpoints={
+                    "uma-s-1p1": fetched(recorded=False),  # pre-tracking survivor
+                    "uma-m": fetched(pruned_blob),
+                },
+            )
+        },
+    )
+
+    plan = plan_prune(tmp_path, cache_root=tmp_path)
+
+    assert plan.weight_dirs == []  # no whole-dir release while the map is blind
+    item = checkpoint_items(plan)["uma-m"]
+    assert item.files == [pruned_blob["path"]]  # per-file deletion still happens
+    assert any("per-file deletion only" in note for note in plan.notes)
 
 
 # -----------------------------------------------------------------------------

--- a/tests/commands/test_prune_plan.py
+++ b/tests/commands/test_prune_plan.py
@@ -472,3 +472,28 @@ def test_unattributed_cache_is_reported_not_deleted(tmp_path):
         "models--never--read",
         "matgl",
     }
+
+
+# -----------------------------------------------------------------------------
+# Progress
+# -----------------------------------------------------------------------------
+
+
+def test_planner_emits_progress_before_slow_tree_walks(tmp_path):
+    """Planning walks whole trees for byte counts; someone tailing a batch
+    job's outfile must see each walk announced before it starts."""
+    build(tmp_path, "orb", env_source("orb-v2"))  # unregistered: gets sized
+    save(tmp_path, {"orb": record(tmp_path, "orb")})
+    stale = tmp_path / ".build" / "orb.1"
+    stale.mkdir(parents=True)
+    age(stale)
+    weight(tmp_path, "cache/mystery/junk.bin")
+
+    lines: list[str] = []
+    plan_prune(tmp_path, cache_root=tmp_path, progress=lines.append)
+
+    assert any(line.startswith("reading install state") for line in lines)
+    assert "sizing envs/orb" in lines
+    assert any(line == f"sizing {stale}" for line in lines)
+    assert "scanning cache/home for unattributed contents" in lines
+    assert "sizing cache/mystery" in lines

--- a/tests/commands/test_prune_plan.py
+++ b/tests/commands/test_prune_plan.py
@@ -1,0 +1,474 @@
+"""The ``rootstock prune`` planner.
+
+The plan is ``actual − desired``: built envs with no registered source,
+checkpoint records no source declares (with their weight files refcounted
+against surviving checkpoints), plus the internal-GC tier that needs no
+declared state at all. These tests pin the cruft inventory and the safety
+constructions from the design (issue #199): refcounting, whole-HF-repo-dir
+release, graceful degradation without weight records, and the age guard.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from rootstock.batch import plan_prune
+from rootstock.manifest import (
+    CheckpointInfo,
+    EnvironmentInfo,
+    compute_source_hash,
+    create_manifest,
+    save_manifest,
+)
+from rootstock.operations import OperationError
+
+OLD = "2026-07-01T00:00:00+00:00"
+NEWER = "2026-07-02T00:00:00+00:00"
+TWO_DAYS_AGO = time.time() - 2 * 24 * 3600
+
+
+def env_source(*checkpoints: str) -> str:
+    entries = "".join(f"    {ckpt!r}: {ckpt!r},\n" for ckpt in checkpoints)
+    return (
+        f"CHECKPOINTS = {{\n{entries}}}\n\ndef setup(checkpoint, device='cuda'):\n    return None\n"
+    )
+
+
+def register(root: Path, name: str, source: str) -> Path:
+    env_file = root / "environments" / f"{name}.py"
+    env_file.parent.mkdir(parents=True, exist_ok=True)
+    env_file.write_text(source)
+    return env_file
+
+
+def build(root: Path, name: str, source: str) -> Path:
+    env_dir = root / "envs" / name
+    (env_dir / "bin").mkdir(parents=True, exist_ok=True)
+    (env_dir / "bin" / "python").touch()
+    (env_dir / "env_source.py").write_text(source)
+    return env_dir
+
+
+def record(
+    root: Path, name: str, *, checkpoints: dict[str, CheckpointInfo] | None = None
+) -> EnvironmentInfo:
+    return EnvironmentInfo(
+        built_at=OLD,
+        source_hash=compute_source_hash(root / "envs" / name / "env_source.py"),
+        source="",
+        python_requires=">=3.11",
+        dependencies={},
+        checkpoints=checkpoints or {},
+    )
+
+
+def save(root: Path, environments: dict[str, EnvironmentInfo]) -> None:
+    from rootstock.config import UserConfig
+
+    manifest = create_manifest(root, "test", UserConfig(name="t", email="t@t.t"))
+    manifest.environments = environments
+    save_manifest(manifest, root)
+
+
+def weight(root: Path, relpath: str, size: int = 4) -> dict:
+    """Write a fake weight file under the cache root; return its record entry."""
+    target = root / relpath
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(b"x" * size)
+    return {"path": relpath, "size": size}
+
+
+def fetched(*weight_entries: dict, recorded: bool = True) -> CheckpointInfo:
+    return CheckpointInfo(
+        fetched_at=OLD,
+        verified_at=NEWER,
+        verified_device="cuda",
+        weight_files=list(weight_entries) if recorded else None,
+    )
+
+
+def age(path: Path, when: float = TWO_DAYS_AGO) -> None:
+    os.utime(path, (when, when))
+
+
+def checkpoint_items(plan) -> dict[str, object]:
+    return {item.checkpoint: item for item in plan.checkpoints}
+
+
+# -----------------------------------------------------------------------------
+# Declarative tier: envs and checkpoints
+# -----------------------------------------------------------------------------
+
+
+def test_converged_root_plans_nothing(tmp_path):
+    source = env_source("mace-mp-0-medium")
+    register(tmp_path, "mace", source)
+    build(tmp_path, "mace", source)
+    entry = weight(tmp_path, "cache/mace/model.pt")
+    save(
+        tmp_path,
+        {"mace": record(tmp_path, "mace", checkpoints={"mace-mp-0-medium": fetched(entry)})},
+    )
+
+    plan = plan_prune(tmp_path, cache_root=tmp_path)
+
+    assert plan.is_empty
+    assert plan.unattributed == []
+    assert plan.notes == []
+
+
+def test_unregistered_built_env_is_pruned_with_its_checkpoints(tmp_path):
+    source = env_source("mace-mp-0-medium")
+    register(tmp_path, "mace", source)
+    build(tmp_path, "mace", source)
+    orphan_source = env_source("orb-v2")
+    build(tmp_path, "orb", orphan_source)  # built, never registered
+    entry = weight(tmp_path, "cache/orb/orb-v2.ckpt")
+    save(
+        tmp_path,
+        {
+            "mace": record(tmp_path, "mace"),
+            "orb": record(tmp_path, "orb", checkpoints={"orb-v2": fetched(entry)}),
+        },
+    )
+
+    plan = plan_prune(tmp_path, cache_root=tmp_path)
+
+    assert [(e.env_name, e.reason) for e in plan.envs] == [("orb", "no registered source")]
+    assert plan.envs[0].env_dir and plan.envs[0].source_file is None
+    item = checkpoint_items(plan)["orb-v2"]
+    assert item.reason == "env pruned"
+    assert item.files == ["cache/orb/orb-v2.ckpt"]
+    assert item.reclaim_bytes == 4
+
+
+def test_undeclared_checkpoint_refcounts_against_survivors(tmp_path):
+    source = env_source("mace-mp-0-medium")  # small was dropped from CHECKPOINTS
+    register(tmp_path, "mace", source)
+    build(tmp_path, "mace", source)
+    shared = weight(tmp_path, "cache/mace/shared.pt")
+    solo = weight(tmp_path, "cache/mace/small-only.pt")
+    save(
+        tmp_path,
+        {
+            "mace": record(
+                tmp_path,
+                "mace",
+                checkpoints={
+                    "mace-mp-0-medium": fetched(shared),
+                    "mace-mp-0-small": fetched(shared, solo),
+                },
+            )
+        },
+    )
+
+    plan = plan_prune(tmp_path, cache_root=tmp_path)
+
+    assert plan.envs == []
+    item = checkpoint_items(plan)["mace-mp-0-small"]
+    assert item.reason == "not declared"
+    assert item.files == ["cache/mace/small-only.pt"]  # shared.pt survives with medium
+
+
+def test_wholly_released_hf_repo_dir_is_removed_as_a_unit(tmp_path):
+    source = env_source("uma-s-1p1")  # uma-m was dropped
+    register(tmp_path, "uma", source)
+    build(tmp_path, "uma", source)
+    released = weight(tmp_path, "cache/huggingface/hub/models--facebook--UMA-m/blobs/aa")
+    weight(
+        tmp_path, "cache/huggingface/hub/models--facebook--UMA-m/refs/main"
+    )  # unrecorded residue
+    kept_blob = weight(tmp_path, "cache/huggingface/hub/models--facebook--UMA/blobs/bb")
+    save(
+        tmp_path,
+        {
+            "uma": record(
+                tmp_path,
+                "uma",
+                checkpoints={
+                    "uma-s-1p1": fetched(kept_blob),
+                    "uma-m": fetched(released, kept_blob),
+                },
+            )
+        },
+    )
+
+    plan = plan_prune(tmp_path, cache_root=tmp_path)
+
+    # The released repo dir goes whole (covering the unrecorded refs/ file);
+    # the shared repo survives because uma-s-1p1 still records into it.
+    assert [d.path for d in plan.weight_dirs] == ["cache/huggingface/hub/models--facebook--UMA-m"]
+    assert plan.weight_dirs[0].reclaim_bytes == 8
+    item = checkpoint_items(plan)["uma-m"]
+    assert item.files == []  # nothing left outside the dir item / survivors
+
+
+def test_unrecorded_checkpoint_degrades_to_record_drop(tmp_path):
+    source = env_source("mace-mp-0-medium")
+    register(tmp_path, "mace", source)
+    build(tmp_path, "mace", source)
+    weight(tmp_path, "cache/mace/mystery.pt")  # on disk, but no record attributes it
+    save(
+        tmp_path,
+        {
+            "mace": record(
+                tmp_path,
+                "mace",
+                checkpoints={
+                    "mace-mp-0-medium": fetched(recorded=True),
+                    "mace-off23-small": fetched(recorded=False),
+                },
+            )
+        },
+    )
+
+    plan = plan_prune(tmp_path, cache_root=tmp_path)
+
+    item = checkpoint_items(plan)["mace-off23-small"]
+    assert item.recorded is False
+    assert item.files == [] and item.reclaim_bytes == 0
+    # Its weights (which nothing attributes) surface in the tier-2 report.
+    assert [Path(u["path"]).name for u in plan.unattributed] == ["mace"]
+
+
+def test_hand_deleted_weights_prune_the_stale_record(tmp_path):
+    source = env_source("mace-mp-0-medium")
+    register(tmp_path, "mace", source)
+    build(tmp_path, "mace", source)
+    entry = {"path": "cache/mace/model.pt", "size": 4}  # recorded but never written
+    save(
+        tmp_path,
+        {"mace": record(tmp_path, "mace", checkpoints={"mace-mp-0-medium": fetched(entry)})},
+    )
+
+    plan = plan_prune(tmp_path, cache_root=tmp_path)
+
+    item = checkpoint_items(plan)["mace-mp-0-medium"]
+    assert item.reason == "weights missing on disk"
+    assert item.files == []
+
+
+def test_source_dir_mode_unregisters_beyond_the_declared_set(tmp_path):
+    for name in ("mace", "uma"):
+        source = env_source(f"{name}-ckpt")
+        register(tmp_path, name, source)
+        build(tmp_path, name, source)
+        (tmp_path / "environments" / f"{name}.py.lock").write_text("lock")
+    save(tmp_path, {"mace": record(tmp_path, "mace"), "uma": record(tmp_path, "uma")})
+    declared = tmp_path / "declared"
+    declared.mkdir()
+    (declared / "mace.py").write_text(env_source("mace-ckpt"))
+
+    plan = plan_prune(tmp_path, source_dir=declared, cache_root=tmp_path)
+
+    assert [(e.env_name, e.env_dir) for e in plan.envs] == [("uma", True)]
+    assert plan.envs[0].source_file == str(tmp_path / "environments" / "uma.py")
+    assert plan.envs[0].reason == f"not in {declared}"
+
+
+def test_empty_source_dir_is_an_error(tmp_path):
+    empty = tmp_path / "declared"
+    empty.mkdir()
+    with pytest.raises(OperationError, match="No \\*.py environment files"):
+        plan_prune(tmp_path, source_dir=empty, cache_root=tmp_path)
+
+
+def test_unparseable_checkpoints_keeps_records(tmp_path):
+    source = "CHECKPOINTS = 'not a dict'\n"
+    register(tmp_path, "mace", source)
+    build(tmp_path, "mace", source)
+    save(
+        tmp_path,
+        {"mace": record(tmp_path, "mace", checkpoints={"mace-mp-0-medium": fetched()})},
+    )
+
+    plan = plan_prune(tmp_path, cache_root=tmp_path)
+
+    # Sync skips *adding* on a parse error; prune must skip *removing*.
+    assert plan.checkpoints == []
+    assert any("keeping all of its checkpoint records" in note for note in plan.notes)
+
+
+def test_missing_environments_dir_gets_a_loud_note(tmp_path):
+    build(tmp_path, "mace", env_source("mace-mp-0-medium"))
+    save(tmp_path, {"mace": record(tmp_path, "mace")})
+
+    plan = plan_prune(tmp_path, cache_root=tmp_path)
+
+    assert [e.env_name for e in plan.envs] == ["mace"]
+    assert any("every built env counts as undeclared" in note for note in plan.notes)
+
+
+def test_suspicious_recorded_paths_are_refused(tmp_path):
+    source = env_source("mace-mp-0-medium")
+    register(tmp_path, "mace", source)
+    build(tmp_path, "mace", source)
+    save(
+        tmp_path,
+        {
+            "mace": record(
+                tmp_path,
+                "mace",
+                checkpoints={
+                    "gone": fetched(
+                        {"path": "../outside.pt", "size": 4},
+                        {"path": "/etc/passwd", "size": 4},
+                    )
+                },
+            )
+        },
+    )
+
+    plan = plan_prune(tmp_path, cache_root=tmp_path)
+
+    item = checkpoint_items(plan)["gone"]
+    assert item.files == []
+    assert sum("refusing suspicious recorded path" in note for note in plan.notes) == 2
+
+
+def test_env_and_checkpoint_filters_limit_scope(tmp_path):
+    register(tmp_path, "mace", env_source("mace-mp-0-medium"))
+    build(tmp_path, "orb", env_source("orb-v2"))
+    build(tmp_path, "gemnet", env_source("g1"))
+    save(
+        tmp_path,
+        {
+            "orb": record(tmp_path, "orb", checkpoints={"orb-v2": fetched()}),
+            "gemnet": record(tmp_path, "gemnet", checkpoints={"g1": fetched()}),
+        },
+    )
+
+    plan = plan_prune(tmp_path, envs=["orb"], cache_root=tmp_path)
+    assert [e.env_name for e in plan.envs] == ["orb"]
+    assert [c.checkpoint for c in plan.checkpoints] == ["orb-v2"]
+
+    plan = plan_prune(tmp_path, checkpoints=["g1"], cache_root=tmp_path)
+    assert [c.checkpoint for c in plan.checkpoints] == ["g1"]
+
+    with pytest.raises(OperationError, match="Unknown environment"):
+        plan_prune(tmp_path, envs=["nope"], cache_root=tmp_path)
+    with pytest.raises(OperationError, match="Unknown checkpoint id"):
+        plan_prune(tmp_path, checkpoints=["nope"], cache_root=tmp_path)
+
+
+# -----------------------------------------------------------------------------
+# Internal GC tier
+# -----------------------------------------------------------------------------
+
+
+def test_stale_build_and_trash_entries_are_collected(tmp_path):
+    stale_build = tmp_path / ".build" / "mace.12345"
+    stale_build.mkdir(parents=True)
+    age(stale_build)
+    fresh_build = tmp_path / ".build" / "uma.99999"
+    fresh_build.mkdir()
+    stale_trash = tmp_path / ".trash" / "orb.1720000000"
+    stale_trash.mkdir(parents=True)
+    age(stale_trash)
+
+    plan = plan_prune(tmp_path, cache_root=tmp_path)
+
+    collected = {(item.kind, Path(item.path).name) for item in plan.gc}
+    assert ("build", "mace.12345") in collected
+    assert ("trash", "orb.1720000000") in collected
+    assert ("build", "uma.99999") not in collected  # age guard
+    assert any("younger than --min-age" in note for note in plan.notes)
+
+
+def test_orphaned_interpreters_are_collected_live_ones_kept(tmp_path):
+    live = tmp_path / ".python" / "cpython-3.11.9-linux-x86_64-gnu"
+    (live / "bin").mkdir(parents=True)
+    (live / "bin" / "python3.11").touch()
+    orphan = tmp_path / ".python" / "cpython-3.10.14-linux-x86_64-gnu"
+    orphan.mkdir()
+    age(orphan)
+    stranded = tmp_path / ".python" / "cpython-3.12.1.installing.4242.1"
+    stranded.mkdir()
+    age(stranded)
+    source = env_source("mace-mp-0-medium")
+    register(tmp_path, "mace", source)
+    env_dir = tmp_path / "envs" / "mace"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").symlink_to(live / "bin" / "python3.11")
+    (env_dir / "env_source.py").write_text(source)
+    save(tmp_path, {"mace": record(tmp_path, "mace", checkpoints={"mace-mp-0-medium": fetched()})})
+
+    plan = plan_prune(tmp_path, cache_root=tmp_path)
+
+    by_name = {Path(item.path).name: item for item in plan.gc if item.kind == "interpreter"}
+    assert set(by_name) == {orphan.name, stranded.name}
+    assert by_name[stranded.name].reason == "stranded staging copy"
+
+
+def test_orphaned_lockfile_is_collected(tmp_path):
+    register(tmp_path, "mace", env_source("mace-mp-0-medium"))
+    build(tmp_path, "mace", env_source("mace-mp-0-medium"))
+    (tmp_path / "environments" / "mace.py.lock").write_text("lock")  # has a source: kept
+    orphan = tmp_path / "environments" / "deleted.py.lock"
+    orphan.write_text("lock")
+    age(orphan)
+    save(tmp_path, {"mace": record(tmp_path, "mace", checkpoints={"mace-mp-0-medium": fetched()})})
+
+    plan = plan_prune(tmp_path, cache_root=tmp_path)
+
+    assert [Path(i.path).name for i in plan.gc if i.kind == "lockfile"] == ["deleted.py.lock"]
+
+
+def test_uv_cache_delegates_to_uv(tmp_path):
+    (tmp_path / ".uv-cache").mkdir()
+
+    plan = plan_prune(tmp_path, cache_root=tmp_path)
+
+    items = [i for i in plan.gc if i.kind == "uv-cache"]
+    assert len(items) == 1
+    assert items[0].reclaim_bytes is None  # unknown until uv runs
+
+
+def test_gc_only_never_touches_envs_or_checkpoints(tmp_path):
+    build(tmp_path, "orb", env_source("orb-v2"))  # unregistered: declarative cruft
+    save(tmp_path, {"orb": record(tmp_path, "orb", checkpoints={"orb-v2": fetched()})})
+    stale = tmp_path / ".build" / "orb.1"
+    stale.mkdir(parents=True)
+    age(stale)
+
+    plan = plan_prune(tmp_path, gc_only=True, cache_root=tmp_path)
+
+    assert plan.envs == [] and plan.checkpoints == [] and plan.unattributed == []
+    assert [i.kind for i in plan.gc] == ["build"]
+
+
+# -----------------------------------------------------------------------------
+# Tier 2: unattributed cache
+# -----------------------------------------------------------------------------
+
+
+def test_unattributed_cache_is_reported_not_deleted(tmp_path):
+    source = env_source("mace-mp-0-medium")
+    register(tmp_path, "mace", source)
+    build(tmp_path, "mace", source)
+    entry = weight(tmp_path, "cache/mace/model.pt")
+    weight(tmp_path, "cache/mystery/leftover.bin", size=10)
+    weight(tmp_path, "cache/huggingface/hub/models--never--read/blobs/cc", size=7)
+    weight(tmp_path, "home/.cache/matgl/thing.pt", size=5)
+    save(
+        tmp_path,
+        {"mace": record(tmp_path, "mace", checkpoints={"mace-mp-0-medium": fetched(entry)})},
+    )
+
+    plan = plan_prune(tmp_path, cache_root=tmp_path)
+
+    reported = {Path(u["path"]).name: u["bytes"] for u in plan.unattributed}
+    assert reported == {"mystery": 10, "models--never--read": 7, "matgl": 5}
+    assert plan.is_empty  # report-only: nothing to execute
+
+    deep = plan_prune(tmp_path, deep=True, cache_root=tmp_path)
+    assert deep.unattributed == []
+    assert {Path(i.path).name for i in deep.gc if i.kind == "unattributed"} == {
+        "mystery",
+        "models--never--read",
+        "matgl",
+    }

--- a/tests/commands/test_prune_plan.py
+++ b/tests/commands/test_prune_plan.py
@@ -270,11 +270,26 @@ def test_source_dir_mode_unregisters_beyond_the_declared_set(tmp_path):
     assert plan.envs[0].reason == f"not in {declared}"
 
 
-def test_empty_source_dir_is_an_error(tmp_path):
+def test_empty_source_dir_declares_zero_environments(tmp_path):
+    """An existing-but-empty SOURCE_DIR is an affirmative declaration, not a
+    mistake: converge to zero environments. (A *nonexistent* SOURCE_DIR stays
+    a usage error in the adapter — that's a typo, not a declaration.)"""
+    source = env_source("mace-mp-0-medium")
+    register(tmp_path, "mace", source)
+    build(tmp_path, "mace", source)
+    save(
+        tmp_path,
+        {"mace": record(tmp_path, "mace", checkpoints={"mace-mp-0-medium": fetched()})},
+    )
     empty = tmp_path / "declared"
     empty.mkdir()
-    with pytest.raises(OperationError, match="No \\*.py environment files"):
-        plan_prune(tmp_path, source_dir=empty, cache_root=tmp_path)
+
+    plan = plan_prune(tmp_path, source_dir=empty, cache_root=tmp_path)
+
+    assert [(e.env_name, e.env_dir) for e in plan.envs] == [("mace", True)]
+    assert plan.envs[0].source_file == str(tmp_path / "environments" / "mace.py")
+    assert [c.checkpoint for c in plan.checkpoints] == ["mace-mp-0-medium"]
+    assert any("zero-environment state" in note for note in plan.notes)
 
 
 def test_unparseable_checkpoints_keeps_records(tmp_path):
@@ -293,14 +308,42 @@ def test_unparseable_checkpoints_keeps_records(tmp_path):
     assert any("keeping all of its checkpoint records" in note for note in plan.notes)
 
 
-def test_missing_environments_dir_gets_a_loud_note(tmp_path):
+def test_missing_environments_dir_degrades_to_gc_only(tmp_path):
+    """An absent registry declares nothing: there is no target state to
+    converge to, so envs, checkpoint records, weights, and the unattributed
+    tier are all left alone — only internal garbage (which needs no declared
+    state) is collected, with a note saying why."""
     build(tmp_path, "mace", env_source("mace-mp-0-medium"))
-    save(tmp_path, {"mace": record(tmp_path, "mace")})
+    entry = weight(tmp_path, "cache/mace/model.pt")
+    weight(tmp_path, "cache/mystery/junk.bin")
+    save(
+        tmp_path,
+        {"mace": record(tmp_path, "mace", checkpoints={"mace-mp-0-medium": fetched(entry)})},
+    )
+    stale = tmp_path / ".build" / "mace.1"
+    stale.mkdir(parents=True)
+    age(stale)
+
+    plan = plan_prune(tmp_path, deep=True, cache_root=tmp_path)
+
+    assert plan.envs == [] and plan.checkpoints == [] and plan.weight_dirs == []
+    assert plan.unattributed == []  # --deep must not act on a broken-looking root
+    assert [i.kind for i in plan.gc] == ["build"]
+    assert any("no declared state to converge to" in note for note in plan.notes)
+
+
+def test_empty_environments_dir_declares_zero_environments(tmp_path):
+    """Present-but-empty registry: the declarative retirement move taken to
+    its limit. Everything installed is undeclared, and the plan says so."""
+    (tmp_path / "environments").mkdir()
+    build(tmp_path, "mace", env_source("mace-mp-0-medium"))
+    save(tmp_path, {"mace": record(tmp_path, "mace", checkpoints={"mace-mp-0-medium": fetched()})})
 
     plan = plan_prune(tmp_path, cache_root=tmp_path)
 
     assert [e.env_name for e in plan.envs] == ["mace"]
-    assert any("every built env counts as undeclared" in note for note in plan.notes)
+    assert [c.checkpoint for c in plan.checkpoints] == ["mace-mp-0-medium"]
+    assert any("zero-environment state" in note for note in plan.notes)
 
 
 def test_suspicious_recorded_paths_are_refused(tmp_path):
@@ -545,6 +588,7 @@ def test_unrecorded_survivor_suppresses_repo_dir_release(tmp_path):
 def test_planner_emits_progress_before_slow_tree_walks(tmp_path):
     """Planning walks whole trees for byte counts; someone tailing a batch
     job's outfile must see each walk announced before it starts."""
+    register(tmp_path, "mace", env_source("mace-mp-0-medium"))
     build(tmp_path, "orb", env_source("orb-v2"))  # unregistered: gets sized
     save(tmp_path, {"orb": record(tmp_path, "orb")})
     stale = tmp_path / ".build" / "orb.1"


### PR DESCRIPTION
Closes #199. Builds on the weight-file records from #202 (now merged).

`sync` (#188) executes `desired − actual` and is deliberately additive, so a long-lived install accumulates cruft with no sanctioned remedy other than hand-`rm`. `prune` is the missing delete verb: it executes `actual − desired`, plus an internal-GC tier that needs no declared state at all. Same planner inputs, same keep-going executor idiom, one manifest refresh + push at the end.

## What it removes

**Undeclared state** (the opposite half of sync's diff):
- Built envs in `envs/` with no registered source. With a `SOURCE_DIR` positional (mirroring sync's), desired state is *exactly* that directory — registered source files beyond it are unregistered too, so `sync dir/ && prune dir/` converges a cluster to a declared set. That pair is the retirement story; an imperative `rootstock remove` stays punted.
- Manifest checkpoint records not in any declared `CHECKPOINTS` table (and records whose weights were hand-deleted), plus those checkpoints' weight files — **refcounted** against surviving checkpoints' `weight_files` records, since HF blobs are shared within a repo dir. A whole `models--*` repo dir is removed only when every checkpoint attributed to it is pruned (which also collects unrecorded snapshot residue in that dir).

**Internal garbage** (collected in every mode, age-guarded by `--min-age`, default 24h — pid-liveness is meaningless on a shared filesystem):
- `.build/*` leftovers from crashed builds, `.trash/*` from a crashed prune
- `.python/` interpreters no built env's `bin/python` resolves into, including `.installing.*` staging copies stranded by #186's publish path
- orphaned `environments/<name>.py.lock` files
- `.uv-cache`, delegated to `uv cache prune`

**Tier 2 — report only:** records capture the *read working set*, not the download set, so "delete everything unrecorded" would over-delete. Unattributed `cache/`/`home/` contents are printed with sizes; `--deep` graduates them to deletion once field data says the records are trustworthy.

## Safety mechanics

- **Plan-confirm by default** (inverting sync's just-go default, because the failure mode inverts): terraform-style plan with per-item reclaimed bytes, then a tty confirm or `--yes`. `--dry-run`/`--json` for inspection.
- **Records first, files second**: all pruned checkpoint records drop in one manifest transaction before any weight file is unlinked. A crash strands only unreferenced files (surfaced as unattributed next run); files-first would strand a `fetched_at` record pointing at nothing.
- **Envs disappear via trash-rename** (`envs/<name>` → `.trash/<name>.<ts>`, then rmtree): a mid-spawn reader sees atomic disappearance, and `.trash` residue is collected by the next run's GC. The manifest refresh already drops records for missing envs, so env deletion self-heals.
- **Degrades without records**: a checkpoint with no `weight_files` (pre-#202 install) gets record-drop only, its bytes reported as unattributed; one smoke-test run backfills records and the next prune can attribute.
- Recorded paths are validated against the cache root before deletion (a corrupted record must not become an `rm` outside the install); a missing/empty `environments/` dir — which reads as "delete every built env" — gets a loud plan note.

## Surface

```
rootstock prune [SOURCE_DIR] [--root PATH | --cluster NAME]
    [--env NAME ...] [--checkpoint ID ...]
    [--gc-only] [--deep] [--min-age HOURS]
    [--yes] [--dry-run] [--json] [--fail-fast] [--no-push] [--no-perm-check]
```

Exit codes match sync: 0 converged/declined, 1 items failed (re-run to retry), 2 usage.

## Testing

27 new tests (`tests/commands/test_prune_{plan,exec}.py`) pin the cruft inventory, refcounting, whole-repo-dir release, degradation without records, the age guard, scope filters, record-first ordering, trash-rename, keep-going/`--fail-fast`, and the single trailing refresh. Also exercised end-to-end against a synthetic install root: correct plan, correct deletions, and a second run converges to nothing-to-do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
