### PR TITLE
Add --verify-timeout to sync, smoke-test, and add

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -286,6 +286,7 @@ rootstock add esen-md-direct-all-omol --kwarg charge=-1 --kwarg enabled=true
 Options:
 
 - `--device <dev>`: Device for verification (default: `cuda`)
+- `--verify-timeout <seconds>`: Time allowed per verification — worker startup plus one forward pass (default: 600). Raise it on slow filesystems where cold reads of large checkpoints exceed the default. Also accepted by `sync` and `smoke-test`
 - `--no-verify`: Skip the verify phase (login-node escape hatch)
 - `--kwarg KEY=VAL`: Repeatable extra kwarg passed to `setup()`. Values are JSON-decoded first; on parse failure, fall back to a string
 - `--root <path>`: Root directory
@@ -305,6 +306,9 @@ rootstock smoke-test --env mace --checkpoint mace-mp-0-medium
 
 # JSON summary for cron
 rootstock smoke-test --json
+
+# Slow filesystem: allow more time per verification (default 600s)
+rootstock smoke-test --verify-timeout 1800
 ```
 
 Exit code is 0 if all tested checkpoints passed, 1 otherwise.

--- a/rootstock/batch.py
+++ b/rootstock/batch.py
@@ -28,6 +28,7 @@ from .environment import is_custom_checkpoint, parse_checkpoints_dict
 from .exceptions import RootstockError
 from .install_state import read_install_state
 from .manifest import compute_source_hash, is_verified
+from .verify import DEFAULT_VERIFY_TIMEOUT
 
 PHASES = ("build", "download", "verify")
 
@@ -358,6 +359,7 @@ def execute_sync(
     *,
     jobs: int = 4,
     verify_jobs: int = 1,
+    verify_timeout: float = DEFAULT_VERIFY_TIMEOUT,
     device: str = "cuda",
     upgrade: bool = False,
     fail_fast: bool = False,
@@ -478,6 +480,7 @@ def execute_sync(
                     cache_root=cache_root,
                     refresh=False,
                     progress=buffered.append,
+                    timeout=verify_timeout,
                 )
             finally:
                 device_pool.put(dev)

--- a/rootstock/cli.py
+++ b/rootstock/cli.py
@@ -92,6 +92,14 @@ from .commands import (
 from .commands.common import ROOTSTOCK_ROOT_ENV
 from .config import DEFAULT_CONFIG_FILE
 from .manifest import ManifestError
+from .verify import DEFAULT_VERIFY_TIMEOUT
+
+_VERIFY_TIMEOUT_HELP = (
+    "Seconds allowed per verification — worker startup (env import + model "
+    f"load) plus one forward pass (default: {DEFAULT_VERIFY_TIMEOUT:.0f}). "
+    "Raise on slow filesystems where cold reads of large checkpoints "
+    "exceed the default"
+)
 
 
 def main():
@@ -239,6 +247,13 @@ def main():
     )
     add_parser.add_argument("--device", default="cuda", help="Device for verify (default: cuda)")
     add_parser.add_argument(
+        "--verify-timeout",
+        type=float,
+        default=DEFAULT_VERIFY_TIMEOUT,
+        metavar="SECONDS",
+        help=_VERIFY_TIMEOUT_HELP,
+    )
+    add_parser.add_argument(
         "--no-verify",
         action="store_true",
         help="Skip the verify phase (download only). Login-node escape hatch.",
@@ -340,6 +355,13 @@ def main():
             "the GPU). With --device cuda, N workers round-robin cuda:0..N-1"
         ),
     )
+    sync_parser.add_argument(
+        "--verify-timeout",
+        type=float,
+        default=DEFAULT_VERIFY_TIMEOUT,
+        metavar="SECONDS",
+        help=_VERIFY_TIMEOUT_HELP,
+    )
     sync_parser.add_argument("--device", default="cuda", help="Device for verify (default: cuda)")
     sync_parser.add_argument(
         "--dry-run",
@@ -390,6 +412,13 @@ def main():
         ),
     )
     smoke_parser.add_argument("--device", default="cuda", help="Device (default: cuda)")
+    smoke_parser.add_argument(
+        "--verify-timeout",
+        type=float,
+        default=DEFAULT_VERIFY_TIMEOUT,
+        metavar="SECONDS",
+        help=_VERIFY_TIMEOUT_HELP,
+    )
     smoke_parser.add_argument("--json", action="store_true", help="Emit a JSON summary")
     smoke_parser.add_argument(
         "--root",

--- a/rootstock/commands/add.py
+++ b/rootstock/commands/add.py
@@ -81,6 +81,7 @@ def cmd_add(args) -> int:
             args.checkpoint,
             device=args.device,
             verify=not args.no_verify,
+            verify_timeout=args.verify_timeout,
             push=not args.no_push,
             force=args.force,
             setup_kwargs=setup_kwargs,

--- a/rootstock/commands/smoke_test.py
+++ b/rootstock/commands/smoke_test.py
@@ -164,6 +164,7 @@ def cmd_smoke_test(args) -> int:
     env_filter = args.env
     ckpt_filter = args.checkpoint
     device = args.device
+    verify_timeout = args.verify_timeout
     json_out = args.json
     no_push = args.no_push
 
@@ -243,6 +244,7 @@ def cmd_smoke_test(args) -> int:
                 cache_root=cache_root,
                 weights_capture_path=str(capture_path),
                 results=run_results,
+                timeout=verify_timeout,
             )
             weight_files = read_weights_capture(capture_path)
         elapsed = time.monotonic() - start
@@ -323,6 +325,7 @@ def cmd_smoke_test(args) -> int:
             cache_root=cache_root,
             checkpoint_path=str(weights_path),
             results=run_results,
+            timeout=verify_timeout,
         )
         if ok:
             mismatch = results_mismatch(baselines[key], run_results)

--- a/rootstock/commands/sync.py
+++ b/rootstock/commands/sync.py
@@ -130,6 +130,7 @@ def cmd_sync(args) -> int:
         plan,
         jobs=args.jobs,
         verify_jobs=args.verify_jobs,
+        verify_timeout=args.verify_timeout,
         device=args.device,
         upgrade=args.upgrade,
         fail_fast=args.fail_fast,

--- a/rootstock/operations.py
+++ b/rootstock/operations.py
@@ -60,7 +60,7 @@ from .pep723 import (
     validate_environment_file,
 )
 from .spawn import DOWNLOAD_WRAPPER, spawn_in_env
-from .verify import verify_checkpoint
+from .verify import DEFAULT_VERIFY_TIMEOUT, verify_checkpoint
 
 ROOTSTOCK_GITHUB_URL = "https://github.com/Garden-AI/rootstock.git"
 
@@ -1221,6 +1221,7 @@ def verify_fetched_checkpoint(
     refresh: bool = True,
     push: bool = True,
     progress: Progress | None = None,
+    timeout: float = DEFAULT_VERIFY_TIMEOUT,
 ) -> VerifyResult:
     """
     Verify a checkpoint on ``device`` and record the outcome in the manifest.
@@ -1258,6 +1259,7 @@ def verify_fetched_checkpoint(
             setup_kwargs,
             cache_root=cache_root,
             weights_capture_path=str(capture_path),
+            timeout=timeout,
         )
         weight_files = read_weights_capture(capture_path)
     with _manifest_transaction(root) as manifest:
@@ -1304,6 +1306,7 @@ def add_checkpoint(
     setup_kwargs: dict | None = None,
     cache_root: Path | None = None,
     progress: Progress | None = None,
+    verify_timeout: float = DEFAULT_VERIFY_TIMEOUT,
 ) -> AddResult:
     """
     Idempotent download-or-verify for a checkpoint by canonical id.
@@ -1349,6 +1352,7 @@ def add_checkpoint(
             cache_root=cache_root,
             refresh=False,
             progress=progress,
+            timeout=verify_timeout,
         )
 
     # Refresh + push (takes the lock for its own load -> refresh -> save)

--- a/rootstock/verify.py
+++ b/rootstock/verify.py
@@ -35,6 +35,12 @@ _FORCE_ZERO_THRESHOLD = 1e-8
 _ENERGY_ATOL = 1e-4  # eV
 _FORCES_ATOL = 1e-3  # eV/Å
 
+# Default envelope for one verification: worker startup (env import + model
+# load + socket connect) plus the single forward pass. Cold Lustre reads of
+# large checkpoints can exceed it — every layer up to the CLI's
+# --verify-timeout exposes an override.
+DEFAULT_VERIFY_TIMEOUT = 600.0
+
 
 def _smoke_test_atoms() -> "Atoms":  # noqa: UP037 — Atoms is TYPE_CHECKING-only
     """Hardcoded H2O-in-a-box used as input for every smoke test."""
@@ -69,6 +75,7 @@ def verify_checkpoint(
     checkpoint_path: str | None = None,
     weights_capture_path: str | None = None,
     results: dict | None = None,
+    timeout: float = DEFAULT_VERIFY_TIMEOUT,
 ) -> tuple[bool, str | None]:
     """
     Run a single forward pass to verify a checkpoint loads and computes.
@@ -89,6 +96,7 @@ def verify_checkpoint(
         results: When a dict is passed and verification succeeds, it receives
                     the computed ``energy``/``forces``/``virial`` so the
                     caller can compare runs (see ``results_mismatch``).
+        timeout: Seconds allowed for worker startup + the forward pass.
 
     Returns:
         (success, error_message). On success, error_message is None.
@@ -109,7 +117,7 @@ def verify_checkpoint(
         root=Path(root),
         cache_root=Path(cache_root) if cache_root is not None else None,
         setup_kwargs=setup_kwargs,
-        timeout=600.0,
+        timeout=timeout,
         checkpoint_path=checkpoint_path,
         weights_capture_path=weights_capture_path,
         # Verification sessions are synthetic — the nightly smoke-test cron

--- a/tests/cli/test_add.py
+++ b/tests/cli/test_add.py
@@ -93,6 +93,7 @@ def _make_args(root: Path, **overrides):
     args.list = overrides.get("list", False)
     args.kwarg = overrides.get("kwarg")
     args.device = overrides.get("device", "cuda")
+    args.verify_timeout = overrides.get("verify_timeout", 600.0)
     args.no_verify = overrides.get("no_verify", False)
     args.force = overrides.get("force", False)
     args.root = str(root)
@@ -127,6 +128,20 @@ def test_add_overrides_restrictive_umask(fake_root, monkeypatch):
         assert os.umask(0o022) == 0o002
     finally:
         os.umask(old)
+
+
+def test_add_forwards_verify_timeout(fake_root, monkeypatch):
+    monkeypatch.setattr(operations, "_run_download", lambda *a, **kw: (True, None))
+    captured = {}
+
+    def fake_verify(root, env_name, checkpoint, device, setup_kwargs, **kwargs):
+        captured.update(kwargs)
+        return True, None
+
+    monkeypatch.setattr(operations, "verify_checkpoint", fake_verify)
+
+    assert cmd_add(_make_args(fake_root, verify_timeout=1800.0)) == 0
+    assert captured["timeout"] == 1800.0
 
 
 def test_add_then_add_is_idempotent(fake_root, monkeypatch):

--- a/tests/cli/test_dispatch.py
+++ b/tests/cli/test_dispatch.py
@@ -45,6 +45,29 @@ def test_non_benchmark_commands_reject_unknown_args(monkeypatch):
     assert _run_main(monkeypatch, ["list", "--bogus"]) == 2
 
 
+def test_verify_timeout_flag_parses_on_all_three_commands(monkeypatch):
+    seen = {}
+
+    def capture(name):
+        def cmd(args):
+            seen[name] = args.verify_timeout
+            return 0
+
+        return cmd
+
+    monkeypatch.setattr(cli, "cmd_sync", capture("sync"))
+    monkeypatch.setattr(cli, "cmd_smoke_test", capture("smoke-test"))
+    monkeypatch.setattr(cli, "cmd_add", capture("add"))
+
+    assert _run_main(monkeypatch, ["sync", "--verify-timeout", "1800"]) == 0
+    assert _run_main(monkeypatch, ["smoke-test", "--verify-timeout", "45.5"]) == 0
+    assert _run_main(monkeypatch, ["add", "mace-mp-0-medium", "--verify-timeout", "1800"]) == 0
+    assert seen == {"sync": 1800.0, "smoke-test": 45.5, "add": 1800.0}
+
+    _run_main(monkeypatch, ["smoke-test"])
+    assert seen["smoke-test"] == 600.0, "default must stay at 600s"
+
+
 def test_manifest_subcommands_dispatch_directly(monkeypatch):
     """Each manifest subparser binds its own func — no re-dispatch layer."""
     called = []

--- a/tests/cli/test_smoke_test.py
+++ b/tests/cli/test_smoke_test.py
@@ -71,6 +71,7 @@ def _make_args(root: Path, **overrides):
     args.env = overrides.get("env")
     args.checkpoint = overrides.get("checkpoint")
     args.device = overrides.get("device", "cuda")
+    args.verify_timeout = overrides.get("verify_timeout", 600.0)
     args.json = overrides.get("json", False)
     args.root = str(root)
     args.no_push = overrides.get("no_push", True)
@@ -109,6 +110,20 @@ def test_smoke_test_always_uses_empty_kwargs(populated_root, monkeypatch):
     cmd_smoke_test(_make_args(populated_root))
     assert captured  # at least one verify happened
     assert all(k == {} for k in captured)
+
+
+def test_smoke_test_forwards_verify_timeout(populated_root, monkeypatch):
+    captured: list[float] = []
+
+    def fake_verify(root, env_name, checkpoint, device, setup_kwargs, timeout, **_):
+        captured.append(timeout)
+        return True, None
+
+    monkeypatch.setattr(smoke_module, "verify_checkpoint", fake_verify)
+
+    cmd_smoke_test(_make_args(populated_root, verify_timeout=1800.0))
+    assert captured  # at least one verify happened
+    assert all(t == 1800.0 for t in captured)
 
 
 def test_smoke_test_marks_pass_and_fail(populated_root, monkeypatch):
@@ -323,6 +338,7 @@ def _fake_verify_factory(calls: list[dict], custom_energy_offset: float = 0.0, f
         checkpoint_path=None,
         weights_capture_path=None,
         results=None,
+        timeout=None,
     ):
         calls.append(
             {"env": env_name, "checkpoint": checkpoint, "checkpoint_path": checkpoint_path}

--- a/tests/cli/test_sync.py
+++ b/tests/cli/test_sync.py
@@ -32,6 +32,7 @@ def _make_args(root: Path, **overrides):
     args.phases = overrides.get("phases", "build,download,verify")
     args.jobs = overrides.get("jobs", 4)
     args.verify_jobs = overrides.get("verify_jobs", 1)
+    args.verify_timeout = overrides.get("verify_timeout", 600.0)
     args.device = overrides.get("device", "cuda")
     args.dry_run = overrides.get("dry_run", False)
     args.json = overrides.get("json", False)
@@ -103,13 +104,22 @@ def test_success_exits_0_and_forwards_knobs(tmp_path, stubbed):
     stubbed["report"] = SyncReport(results=[ItemResult("build", "mace", None, "ok", "not built")])
 
     rc = cmd_sync(
-        _make_args(tmp_path, jobs=8, verify_jobs=2, device="cuda", fail_fast=True, upgrade=True)
+        _make_args(
+            tmp_path,
+            jobs=8,
+            verify_jobs=2,
+            verify_timeout=1800.0,
+            device="cuda",
+            fail_fast=True,
+            upgrade=True,
+        )
     )
 
     assert rc == 0
     ((_, kwargs),) = stubbed["exec_calls"]
     assert kwargs["jobs"] == 8
     assert kwargs["verify_jobs"] == 2
+    assert kwargs["verify_timeout"] == 1800.0
     assert kwargs["fail_fast"] is True
     assert kwargs["upgrade"] is True
     assert kwargs["push"] is False  # from no_push=True

--- a/tests/commands/test_add_split.py
+++ b/tests/commands/test_add_split.py
@@ -213,6 +213,22 @@ def test_verify_forwards_device_and_kwargs(fake_root, refresh_calls, monkeypatch
     assert _ckpt(fake_root).verified_device == "cuda:1"
 
 
+def test_verify_forwards_timeout(fake_root, refresh_calls, monkeypatch):
+    captured = {}
+
+    def fake_verify(root, env_name, checkpoint, device, setup_kwargs, **kwargs):
+        captured.update(kwargs)
+        return True, None
+
+    monkeypatch.setattr(operations, "verify_checkpoint", fake_verify)
+
+    verify_fetched_checkpoint(fake_root, "mace-mp-0-medium", timeout=1800.0)
+    assert captured["timeout"] == 1800.0
+
+    verify_fetched_checkpoint(fake_root, "mace-mp-0-medium")
+    assert captured["timeout"] == 600.0, "default must stay at 600s"
+
+
 # ---------- add_checkpoint (the composition) ---------------------------------
 
 
@@ -236,6 +252,20 @@ def test_add_no_verify_skips_verify_fields(fake_root, refresh_calls, monkeypatch
     assert result.verified_at is None
     assert result.verified_device is None
     assert len(refresh_calls) == 1
+
+
+def test_add_forwards_verify_timeout(fake_root, refresh_calls, monkeypatch):
+    monkeypatch.setattr(operations, "_run_download", lambda *a, **kw: (True, None))
+    captured = {}
+
+    def fake_verify(root, env_name, checkpoint, device, setup_kwargs, **kwargs):
+        captured.update(kwargs)
+        return True, None
+
+    monkeypatch.setattr(operations, "verify_checkpoint", fake_verify)
+
+    add_checkpoint(fake_root, "mace-mp-0-medium", verify_timeout=1800.0)
+    assert captured["timeout"] == 1800.0
 
 
 def test_add_failure_skips_the_trailing_refresh(fake_root, refresh_calls, monkeypatch):

--- a/tests/commands/test_sync_exec.py
+++ b/tests/commands/test_sync_exec.py
@@ -152,6 +152,22 @@ def test_verify_devices_round_robin_with_plain_cuda(tmp_path, calls):
     assert len(calls["verify"]) == 6
 
 
+def test_verify_timeout_reaches_each_verify(tmp_path, calls):
+    plan = plan_for(verifies=(("mace", "m1"), ("mace", "m2")))
+
+    execute_sync(tmp_path, plan, verify_timeout=1800.0, say=lambda _: None)
+
+    assert [kw["timeout"] for _, kw in calls["verify"]] == [1800.0, 1800.0]
+
+
+def test_verify_timeout_defaults_to_600(tmp_path, calls):
+    plan = plan_for(verifies=(("mace", "m1"),))
+
+    execute_sync(tmp_path, plan, say=lambda _: None)
+
+    assert [kw["timeout"] for _, kw in calls["verify"]] == [600.0]
+
+
 def test_explicit_device_is_never_rewritten(tmp_path, calls):
     plan = plan_for(verifies=(("mace", "m1"), ("mace", "m2")))
 

--- a/tests/verify/test_verify_checkpoint.py
+++ b/tests/verify/test_verify_checkpoint.py
@@ -153,6 +153,30 @@ def test_verify_defaults_checkpoint_path_to_none(monkeypatch):
     assert captured["checkpoint_path"] is None
 
 
+def test_verify_forwards_timeout(monkeypatch):
+    captured = {}
+
+    def factory(**ctor_kwargs):
+        captured.update(ctor_kwargs)
+        return _StubServer(energy=-10.5, forces=_ok_forces(), virial=_ok_virial())
+
+    monkeypatch.setattr("rootstock.server.RootstockServer", factory)
+    verify.verify_checkpoint(Path("/tmp"), "mace", "mace-mp-0-medium", "cuda", timeout=1800.0)
+    assert captured["timeout"] == 1800.0
+
+
+def test_verify_default_timeout_is_600(monkeypatch):
+    captured = {}
+
+    def factory(**ctor_kwargs):
+        captured.update(ctor_kwargs)
+        return _StubServer(energy=-10.5, forces=_ok_forces(), virial=_ok_virial())
+
+    monkeypatch.setattr("rootstock.server.RootstockServer", factory)
+    verify.verify_checkpoint(Path("/tmp"), "mace", "mace-mp-0-medium", "cuda")
+    assert captured["timeout"] == verify.DEFAULT_VERIFY_TIMEOUT == 600.0
+
+
 def test_verify_rejects_all_zero_forces(stub_server):
     """The silent-failure guard — model returned zeros for everything."""
     stub_server(energy=-1.0, forces=np.zeros((3, 3)), virial=_ok_virial())


### PR DESCRIPTION
Closes #191.

The verification envelope (worker startup: env import + model load + socket connect, plus one forward pass) was a hardcoded 600 s literal in `verify_checkpoint`'s `RootstockServer` construction, with no override anywhere up the chain. Cold Lustre reads of large checkpoints exceed it — 8 of 45 verifies died at the cap during the 2026-07-30 Delta sync sweep, every one the first verify against a freshly rebuilt env — and the only workaround was patching site-packages.

This plumbs a timeout through every layer, defaulting to the same 600 s:

```
cli --verify-timeout
  -> commands/{sync,smoke_test,add}
  -> batch.execute_sync(verify_timeout=)
  -> operations.verify_fetched_checkpoint(timeout=) /
     operations.add_checkpoint(verify_timeout=)
  -> verify.verify_checkpoint(timeout=)
  -> RootstockServer(timeout=)
```

The default now lives in one place (`verify.DEFAULT_VERIFY_TIMEOUT`). The smoke-test custom-weights legs (#204) honor the flag too.

Not included: the issue's optional suggestion to auto-scale the timeout for envs rebuilt in the same sync run — `--verify-timeout 1800` on the sync invocation covers that case operationally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)