### PR TITLE
Point sophia/polaris at the new /eagle/projects/Rootstock install root

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,8 +117,8 @@ predate the declaration. Most clusters use the same path for both.
 | Cluster | Install Root | Cache Root (if split) |
 |---------|--------------|-----------------------|
 | `della` | `/scratch/gpfs/ROSENGROUP/common/rootstock` | (same as install root) |
-| `sophia` | `/eagle/Garden-Ai/rootstock` | (same as install root) |
-| `polaris` | `/eagle/Garden-Ai/rootstock` (shared with sophia) | (same as install root) |
+| `sophia` | `/eagle/projects/Rootstock/rootstock` | (same as install root) |
+| `polaris` | `/eagle/projects/Rootstock/rootstock` (shared with sophia) | (same as install root) |
 | `perlmutter` | `/global/cfs/cdirs/m5268/rootstock` | `/pscratch/sd/o/oprice/rootstock-cache` |
 | `delta` | `/work/hdd/data/rootstock` | (same as install root) |
 | `frontier` | `/sw/frontier/ums/ums047/rootstock` | `/lustre/orion/ums047/world-shared/rootstock-cache` |

--- a/rootstock/clusters.py
+++ b/rootstock/clusters.py
@@ -38,12 +38,12 @@ CLUSTER_REGISTRY: dict[str, Cluster] = {
         root=Path("/scratch/gpfs/ROSENGROUP/common/rootstock"),
     ),
     "sophia": Cluster(
-        root=Path("/eagle/Garden-Ai/rootstock"),
+        root=Path("/eagle/projects/Rootstock/rootstock"),
     ),
     # Polaris mounts the same Eagle filesystem as Sophia, so both ALCF
     # machines share one install.
     "polaris": Cluster(
-        root=Path("/eagle/Garden-Ai/rootstock"),
+        root=Path("/eagle/projects/Rootstock/rootstock"),
     ),
     "perlmutter": Cluster(
         root=Path("/global/cfs/cdirs/m5268/rootstock"),

--- a/scripts/runbooks/sophia-polaris-delta.md
+++ b/scripts/runbooks/sophia-polaris-delta.md
@@ -8,7 +8,7 @@ tree once, but run the compute-node check on both machines.
 
 ```bash
 # sophia/polaris:
-#   ROOT=/eagle/Garden-Ai/rootstock    GROUP=<eagle project group>
+#   ROOT=/eagle/projects/Rootstock/rootstock    GROUP=Rootstock
 # delta:
 #   ROOT=/work/hdd/data/rootstock      GROUP=<delta project group>
 ROOT=changeme


### PR DESCRIPTION
## Summary

ALCF granted a dedicated project space for Rootstock, and the old `/eagle/Garden-Ai/rootstock` install is dead (slated to be wiped wholesale). This points the in-package registry at the new root:

- `CLUSTER_REGISTRY` in `rootstock/clusters.py`: both `sophia` and its `polaris` alias now resolve to `/eagle/projects/Rootstock/rootstock` (the two machines share the one Eagle install).
- The Known Clusters table in `CLAUDE.md` updated to match.
- `scripts/runbooks/sophia-polaris-delta.md`: example `ROOT`/`GROUP` values updated (`GROUP=Rootstock`, the owning group of the new project space).

The remaining `frontier`/`delta`/`perlmutter` registry entries were checked against our deployment records and are already correct.

## Test plan

- [x] `uv run pytest tests/test_clusters.py tests/cache/test_cache_root.py` (41 passed — includes the sophia/polaris shared-root assertions)
- [x] `uv run ruff check` / `ruff format --check` on the touched Python

🤖 Generated with [Claude Code](https://claude.com/claude-code)