### PR TITLE
Split shared-install manifests per cluster (sophia/polaris)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ predate the declaration. Most clusters use the same path for both.
 | `sophia` | `/eagle/projects/Rootstock/rootstock` | (same as install root) |
 | `polaris` | `/eagle/projects/Rootstock/rootstock` (shared with sophia) | (same as install root) |
 
-sophia/polaris share one install and one manifest (`clusters: ["sophia", "polaris"]`), but verification records and pushed manifests are per-cluster; verify-recording commands there need `--cluster`. An env source may declare `CLUSTERS = ["polaris"]` to ship a cluster-specific variant (see `docs/environments.md`).
+sophia/polaris share one install and one manifest (`clusters: ["sophia", "polaris"]`), but verification records and pushed manifests are per-cluster; verify-recording commands there need `--cluster`. An env source may declare `CLUSTERS = ["polaris"]` to ship a cluster-specific variant (see `docs/environments.md`); smoke-test selection and the pushed payloads are checkpoint-first — each id is tested and reported via the env it resolves to on that cluster.
 | `perlmutter` | `/global/cfs/cdirs/m5268/rootstock` | `/pscratch/sd/o/oprice/rootstock-cache` |
 | `delta` | `/work/hdd/data/rootstock` | (same as install root) |
 | `frontier` | `/sw/frontier/ums/ums047/rootstock` | `/lustre/orion/ums047/world-shared/rootstock-cache` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Rootstock runs MLIP (Machine Learning Interatomic Potential) calculators in isolated pre-built Python environments on HPC clusters, communicating via the i-PI protocol over Unix sockets.
 
-Versioning is dynamic (git tags via uv-dynamic-versioning) — check `rootstock --version`. Manifest schema v5 (older schemas migrate in place on load); canonical-checkpoint-id API.
+Versioning is dynamic (git tags via uv-dynamic-versioning) — check `rootstock --version`. Manifest schema v6 (older schemas migrate in place on load; verification is per-cluster, and shared installs like sophia/polaris push one manifest per cluster); canonical-checkpoint-id API.
 
 ## Commands
 
@@ -26,8 +26,9 @@ rootstock add <checkpoint-id> [--kwarg key=val ...] [--device cuda] [--no-verify
 
 # Re-verify all fetched checkpoints, plus each '<family>:custom' weights= path
 # (re-loads a same-family checkpoint's cached weights and compares results).
-# Suitable for nightly cron.
-rootstock smoke-test [--env ENV] [--checkpoint CKPT] [--device cuda] [--json]
+# Suitable for nightly cron. --cluster names the machine (required on shared
+# installs like sophia/polaris; add/sync take it too).
+rootstock smoke-test [--env ENV] [--checkpoint CKPT] [--device cuda] [--cluster NAME] [--json]
 
 # Show status (per-checkpoint verified/stale grid; --json for machine-readable)
 rootstock status [--root <path>] [--json]
@@ -119,6 +120,8 @@ predate the declaration. Most clusters use the same path for both.
 | `della` | `/scratch/gpfs/ROSENGROUP/common/rootstock` | (same as install root) |
 | `sophia` | `/eagle/projects/Rootstock/rootstock` | (same as install root) |
 | `polaris` | `/eagle/projects/Rootstock/rootstock` (shared with sophia) | (same as install root) |
+
+sophia/polaris share one install and one manifest (`clusters: ["sophia", "polaris"]`), but verification records and pushed manifests are per-cluster; verify-recording commands there need `--cluster`. An env source may declare `CLUSTERS = ["polaris"]` to ship a cluster-specific variant (see `docs/environments.md`).
 | `perlmutter` | `/global/cfs/cdirs/m5268/rootstock` | `/pscratch/sd/o/oprice/rootstock-cache` |
 | `delta` | `/work/hdd/data/rootstock` | (same as install root) |
 | `frontier` | `/sw/frontier/ums/ums047/rootstock` | `/lustre/orion/ums047/world-shared/rootstock-cache` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,11 +120,11 @@ predate the declaration. Most clusters use the same path for both.
 | `della` | `/scratch/gpfs/ROSENGROUP/common/rootstock` | (same as install root) |
 | `sophia` | `/eagle/projects/Rootstock/rootstock` | (same as install root) |
 | `polaris` | `/eagle/projects/Rootstock/rootstock` (shared with sophia) | (same as install root) |
-
-sophia/polaris share one install and one manifest (`clusters: ["sophia", "polaris"]`), but verification records and pushed manifests are per-cluster; verify-recording commands there need `--cluster`. An env source may declare `CLUSTERS = ["polaris"]` to ship a cluster-specific variant (see `docs/environments.md`); smoke-test selection and the pushed payloads are checkpoint-first — each id is tested and reported via the env it resolves to on that cluster.
 | `perlmutter` | `/global/cfs/cdirs/m5268/rootstock` | `/pscratch/sd/o/oprice/rootstock-cache` |
 | `delta` | `/work/hdd/data/rootstock` | (same as install root) |
 | `frontier` | `/sw/frontier/ums/ums047/rootstock` | `/lustre/orion/ums047/world-shared/rootstock-cache` |
+
+sophia/polaris share one install and one manifest (`clusters: ["sophia", "polaris"]`), but verification records and pushed manifests are per-cluster; verify-recording commands there need `--cluster`. An env source may declare `CLUSTERS = ["polaris"]` to ship a cluster-specific variant (see `docs/environments.md`); smoke-test selection and the pushed payloads are checkpoint-first — each id is tested and reported via the env it resolves to on that cluster.
 
 ## API
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -352,4 +352,8 @@ rootstock manifest push
 # Initialize new manifest
 rootstock manifest init --cluster delta
 rootstock manifest init --cluster delta --force
+
+# Shared install (one root, several clusters): --cluster is repeatable;
+# registry siblings of the root are included automatically
+rootstock manifest init --cluster sophia --cluster polaris
 ```

--- a/docs/cluster-setup.md
+++ b/docs/cluster-setup.md
@@ -277,6 +277,24 @@ rootstock manifest init --cluster delta --force
 rootstock manifest init --cluster delta --no-push
 ```
 
+#### Shared installs (one root, several clusters)
+
+When several machines mount the same install (sophia and polaris share one
+Eagle root), the install keeps **one** manifest listing every cluster it
+serves — `--cluster` is repeatable, and registry siblings of the root are
+included automatically:
+
+```bash
+rootstock manifest init --cluster sophia --cluster polaris
+```
+
+Build and fetch state is shared (one filesystem), but **verification is
+per-cluster**: passing on sophia says nothing about polaris. Commands that
+record verification (`add`, `smoke-test`, `sync`) therefore need to know
+which machine they are on — pass `--cluster <name>`; single-cluster installs
+need no flag. Pushes send one manifest per cluster to the dashboard, each
+carrying that machine's own verification results.
+
 ## Verifying the installation
 
 After setup, verify that everything works:

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -169,6 +169,32 @@ construction, so a rebuild (`rootstock install --force`) from a source that
 dropped `setup_from_path` fails immediately with a maintainer-facing hint —
 never as an opaque error inside the worker.
 
+### `CLUSTERS` list (optional — cluster-specific variants on shared installs)
+
+Some installs serve more than one machine (sophia and polaris mount the same
+Eagle root). When an env runs on one of them but not the other — different
+node image, different driver stack — declare a **variant**: a second env file
+with the *same* canonical ids, different pins or `setup()`, and a module-level
+
+```python
+CLUSTERS = ["polaris"]
+```
+
+Resolution is cluster-aware: on the clusters a variant lists, it beats the
+unrestricted env for the ids both declare; every other cluster keeps the
+original untouched. Users pass `cluster="polaris"` (which they already do) and
+get the right env; `root=`-only construction resolves unrestricted envs and
+asks for a cluster when only variants declare an id. The two envs share
+downloaded weights automatically — the cache is keyed by checkpoint, not env.
+
+If the original env genuinely *cannot* run on one machine, restrict it too
+(`CLUSTERS = ["sophia"]` on the original): that cluster's smoke-test then
+skips it and its manifest no longer advertises it there.
+
+Absent `CLUSTERS` (the normal case) means the env serves every cluster its
+install does. Like `CHECKPOINTS`, the list is AST-parsed — string literals
+only, and an empty list is an authoring error.
+
 ## Examples
 
 ### MACE (MP-0 and OFF23 in one env)
@@ -263,7 +289,7 @@ The canonical ids in `CHECKPOINTS` are the join key with the Almanac. If the Alm
 
 The same model rarely drops onto every cluster unchanged. Driver and CUDA versions, the available Python, and filesystem behavior all vary, so adapting a sample's dependency pins or `setup()` for a given cluster is routine, not exceptional. A file can also declare a strict subset of the canonical ids the standard sample carries — keys it doesn't list simply won't resolve to it, and `rootstock add` finds the right env for each id.
 
-When an entire hardware class needs a different dependency stack (a non-NVIDIA GPU, say), that belongs in its own sample folder alongside `nvidia_configs/`, rather than as a one-off edit to an existing file.
+When an entire hardware class needs a different dependency stack (a non-NVIDIA GPU, say), that belongs in its own sample folder alongside `nvidia_configs/`, rather than as a one-off edit to an existing file. When two machines *share one install* and only one of them needs the different stack, ship a variant env with a `CLUSTERS` restriction instead — see [`CLUSTERS` list](#clusters-list-optional--cluster-specific-variants-on-shared-installs).
 
 A `setup()`-only fix to an env that is already deployed does not require a rebuild at all — see [Hotfixing `setup()` without a rebuild](cluster-setup.md#hotfixing-setup-without-a-rebuild).
 

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -187,9 +187,14 @@ get the right env; `root=`-only construction resolves unrestricted envs and
 asks for a cluster when only variants declare an id. The two envs share
 downloaded weights automatically — the cache is keyed by checkpoint, not env.
 
-If the original env genuinely *cannot* run on one machine, restrict it too
-(`CLUSTERS = ["sophia"]` on the original): that cluster's smoke-test then
-skips it and its manifest no longer advertises it there.
+`smoke-test` and the pushed manifests follow the same per-id resolution
+(checkpoint-first): on the variant's clusters, each overridden id is tested
+via the variant and listed under it in that cluster's manifest — the
+universal env's copy is shadowed there, never reported as a permanently
+failing row. Ids the variant doesn't declare keep resolving to (and being
+tested via) the universal env. Restricting the original with
+`CLUSTERS = ["sophia"]` is only needed in the rare case where *every* id it
+declares is broken on a machine and the variant doesn't cover them all.
 
 Absent `CLUSTERS` (the normal case) means the env serves every cluster its
 install does. Like `CHECKPOINTS`, the list is AST-parsed — string literals

--- a/rootstock/batch.py
+++ b/rootstock/batch.py
@@ -222,7 +222,10 @@ def plan_sync(
 
     # ---- cluster-restricted envs (#208) --------------------------------------
     # Only a machine an env serves can verify it; builds and downloads are
-    # shared artifacts and proceed regardless.
+    # shared artifacts and proceed regardless. This skip is env-level and
+    # conservative; smoke-test resolves per id (checkpoint-first), which is
+    # the eventual model here too — a universal env's overridden ids would
+    # then verify via the variant instead of being planned twice.
     unservable: set[str] = set()
     if cluster is not None:
         for name in sorted(desired):

--- a/rootstock/batch.py
+++ b/rootstock/batch.py
@@ -35,7 +35,7 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
 from . import operations as ops
-from .environment import is_custom_checkpoint, parse_checkpoints_dict
+from .environment import is_custom_checkpoint, parse_checkpoints_dict, parse_clusters_list
 from .exceptions import RootstockError
 from .install_state import read_install_state
 from .layout import resolve_cache_root
@@ -136,6 +136,7 @@ def plan_sync(
     checkpoints: list[str] | None = None,
     rebuild: bool = False,
     phases: Sequence[str] = PHASES,
+    cluster: str | None = None,
 ) -> SyncPlan:
     """Compute the work needed to converge ``root`` to its declared state.
 
@@ -144,7 +145,14 @@ def plan_sync(
         ``env_source.py``; or ``rebuild``.
       - download: declared (non-``:custom``) checkpoint with no ``fetched_at``.
       - verify: newly fetched or rebuilt this run, or ``verified_at`` missing
-        or older than ``built_at`` (the existing staleness rule).
+        or older than ``built_at`` (the existing staleness rule), judged
+        against the current cluster's verification record (#208).
+
+    ``cluster`` is the machine this sync runs on; resolved from the manifest
+    or registry when omitted (an error on shared installs, where verification
+    must not be attributed by guess). Envs whose CLUSTERS excludes it are
+    still built and their checkpoints downloaded — those artifacts are shared
+    — but their verifies are skipped with a note.
 
     Rootstock-pin drift is reported as a note, never acted on implicitly —
     otherwise installing a newer CLI and syncing to add one checkpoint would
@@ -153,6 +161,8 @@ def plan_sync(
     from . import __version__
 
     root = Path(root)
+    if cluster is None and "verify" in phases:
+        cluster = ops.resolve_current_cluster(root)
     state = read_install_state(root)
     plan = SyncPlan()
 
@@ -210,6 +220,25 @@ def plan_sync(
             )
         declared = {key: None for key in declared if key[1] in checkpoints}
 
+    # ---- cluster-restricted envs (#208) --------------------------------------
+    # Only a machine an env serves can verify it; builds and downloads are
+    # shared artifacts and proceed regardless.
+    unservable: set[str] = set()
+    if cluster is not None:
+        for name in sorted(desired):
+            _, parse_path = desired[name]
+            try:
+                restriction = parse_clusters_list(parse_path)
+            except ValueError as exc:
+                plan.notes.append(f"{name}: cannot parse CLUSTERS ({exc}); skipping its verifies")
+                unservable.add(name)
+                continue
+            if restriction is not None and cluster not in restriction:
+                plan.notes.append(
+                    f"{name}: serves only {', '.join(restriction)} — skipping verify on {cluster}"
+                )
+                unservable.add(name)
+
     # ---- download / verify items -------------------------------------------
     manifest = state.manifest
     for env_name, ckpt_id in declared:
@@ -221,13 +250,20 @@ def plan_sync(
         if needs_download:
             plan.downloads.append(CheckpointItem(env_name, ckpt_id, "not fetched"))
 
+        if env_name in unservable:
+            continue
+        verified_at = (
+            ckpt_record.verification(cluster).verified_at
+            if ckpt_record is not None and cluster is not None
+            else None
+        )
         if env_name in rebuilt_envs:
             verify_reason = "stale after rebuild"
         elif needs_download:
             verify_reason = "newly fetched"
-        elif ckpt_record is None or ckpt_record.verified_at is None:
+        elif verified_at is None or ckpt_record is None or cluster is None:
             verify_reason = "never verified"
-        elif record is not None and not is_verified(record, ckpt_record):
+        elif record is not None and not is_verified(record, ckpt_record, cluster):
             verify_reason = "stale (verified before last build)"
         else:
             continue
@@ -409,6 +445,7 @@ def execute_sync(
     fail_fast: bool = False,
     push: bool = True,
     cache_root: Path | None = None,
+    cluster: str | None = None,
     say: Say = print,
 ) -> SyncReport:
     """Execute a plan: build → download → verify, then one manifest refresh.
@@ -468,6 +505,7 @@ def execute_sync(
                 item.checkpoint,
                 cache_root=cache_root,
                 refresh=False,
+                cluster=cluster,
                 progress=buffered.append,
             )
 
@@ -523,6 +561,7 @@ def execute_sync(
                     device=dev,
                     cache_root=cache_root,
                     refresh=False,
+                    cluster=cluster,
                     progress=buffered.append,
                     timeout=verify_timeout,
                 )

--- a/rootstock/calculator.py
+++ b/rootstock/calculator.py
@@ -192,8 +192,12 @@ class RootstockCalculator(Calculator):
         self.checkpoint = checkpoint
         self.device = device
         self.timeout = timeout
+        # Kept beyond root resolution: on a shared install (sophia/polaris)
+        # the cluster name also picks the right env among cluster-specific
+        # variants and attributes the session's usage record (#208).
+        self.cluster = cluster
 
-        # Resolve the install root: the cluster name is only a name -> path
+        # Resolve the install root: the cluster name is a name -> path
         # bootstrap. Everything else about the install (including where its
         # cache lives) is read from the install itself, identically for both
         # entry points — see resolve_cache_root.
@@ -224,7 +228,7 @@ class RootstockCalculator(Calculator):
         # Resolve the checkpoint id: env-declared ids, canonical and
         # ':custom' entries alike. Raises CheckpointNotFoundError with a
         # listing if nothing matches.
-        resolved = resolve_checkpoint(self.root, checkpoint)
+        resolved = resolve_checkpoint(self.root, checkpoint, cluster)
         self.env_name = resolved.env_name
         # Enforce the ':custom' / weights= pairing (both directions — a
         # misspelled weights kwarg is absorbed by ASE, and with a custom id
@@ -256,6 +260,7 @@ class RootstockCalculator(Calculator):
                 setup_kwargs=self.setup_kwargs,
                 timeout=self.timeout,
                 checkpoint_path=self.checkpoint_path,
+                cluster=self.cluster,
             )
             server.start()
         return server

--- a/rootstock/cli.py
+++ b/rootstock/cli.py
@@ -285,6 +285,16 @@ def main():
         help=f"Root directory (default: ${ROOTSTOCK_ROOT_ENV})",
     )
     add_parser.add_argument(
+        "--cluster",
+        help=(
+            "Cluster this machine is (e.g. 'sophia'). Required to verify on "
+            "a shared install — sophia/polaris serve one root, and results "
+            "must be recorded for the right machine. Also picks the right "
+            "env among cluster-specific variants (CLUSTERS). Single-cluster "
+            "installs need no flag."
+        ),
+    )
+    add_parser.add_argument(
         "--no-push",
         action="store_true",
         help="Don't push manifest to backend",
@@ -320,7 +330,11 @@ def main():
     )
     sync_parser.add_argument(
         "--cluster",
-        help="Resolve the root from the cluster registry instead of --root",
+        help=(
+            "Resolve the root from the cluster registry instead of --root; "
+            "also names the machine verification results are recorded for "
+            "(required to verify on a shared install like sophia/polaris)"
+        ),
     )
     sync_parser.add_argument(
         "--env",
@@ -541,6 +555,15 @@ def main():
     )
     smoke_parser.add_argument("--json", action="store_true", help="Emit a JSON summary")
     smoke_parser.add_argument(
+        "--cluster",
+        help=(
+            "Cluster this machine is (e.g. 'sophia'). Required on a shared "
+            "install — sophia/polaris serve one root, and results must be "
+            "recorded (and pushed) for the right machine. Single-cluster "
+            "installs need no flag."
+        ),
+    )
+    smoke_parser.add_argument(
         "--root",
         default=os.environ.get(ROOTSTOCK_ROOT_ENV),
         help=f"Root directory (default: ${ROOTSTOCK_ROOT_ENV})",
@@ -758,6 +781,14 @@ def main():
             "checkpoint id; loaded via the env's setup_from_path hook."
         ),
     )
+    serve_parser.add_argument(
+        "--cluster",
+        help=(
+            "Cluster this machine is (e.g. 'polaris'). Only needed on shared "
+            "installs whose envs declare cluster-specific variants (CLUSTERS) "
+            "— picks the variant serving this machine."
+        ),
+    )
     serve_parser.set_defaults(func=cmd_serve)
 
     # benchmark command. Everything after the subcommand is forwarded to the
@@ -815,7 +846,7 @@ def main():
     # manifest init
     manifest_init_parser = manifest_subparsers.add_parser(
         "init",
-        help="Initialize manifest for a cluster",
+        help="Initialize manifest for the cluster(s) an install serves",
     )
     manifest_init_parser.add_argument(
         "--root",
@@ -825,7 +856,12 @@ def main():
     manifest_init_parser.add_argument(
         "--cluster",
         required=True,
-        help="Cluster name (e.g., delta or perlmutter)",
+        action="append",
+        help=(
+            "Cluster name (e.g., delta). Repeatable for shared installs "
+            "(--cluster sophia --cluster polaris); registry siblings of the "
+            "root are included automatically."
+        ),
     )
     manifest_init_parser.add_argument(
         "--force",

--- a/rootstock/client.py
+++ b/rootstock/client.py
@@ -11,7 +11,7 @@ from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 from .config import UserConfig
-from .manifest import Manifest
+from .manifest import Manifest, manifest_push_payload
 
 
 class RootstockClient:
@@ -26,12 +26,10 @@ class RootstockClient:
         """
         self.config = config
 
-    def push_manifest(self, manifest: Manifest) -> tuple[bool, str]:
+    def push_manifest_payload(self, payload: dict) -> tuple[bool, str]:
         """
-        Push manifest to backend API.
-
-        Args:
-            manifest: Manifest to push
+        Push one cluster's manifest payload (see ``manifest_push_payload``)
+        to the backend API, which files it under ``payload["cluster"]``.
 
         Returns:
             (success, message) tuple
@@ -43,7 +41,24 @@ class RootstockClient:
         if not self.config.api_url:
             return False, "API URL not configured"
 
-        return self._post(self.config.api_url, manifest.to_dict(), "Manifest pushed successfully")
+        return self._post(self.config.api_url, payload, "Manifest pushed successfully")
+
+    def push_manifest(self, manifest: Manifest) -> tuple[bool, str]:
+        """
+        Push a manifest to the backend API: one payload per cluster the
+        install serves (the backend keys each on its single cluster name).
+
+        Returns:
+            (success, message) tuple — success only when every cluster's
+            push succeeded; the message reports each cluster.
+        """
+        ok = True
+        parts = []
+        for cluster in manifest.clusters:
+            success, message = self.push_manifest_payload(manifest_push_payload(manifest, cluster))
+            ok = ok and success
+            parts.append(f"{cluster}: {'ok' if success else message}")
+        return ok, "; ".join(parts)
 
     def push_usage(self, cluster: str, rows: list[dict]) -> tuple[bool, str]:
         """

--- a/rootstock/clusters.py
+++ b/rootstock/clusters.py
@@ -82,6 +82,16 @@ def get_cache_root_for_cluster(cluster: str) -> Path:
     return get_cluster(cluster).resolved_cache_root
 
 
+def get_clusters_for_root(root: Path | str) -> list[str]:
+    """Reverse lookup: every registered cluster served by an install root.
+
+    More than one entry means a shared install (e.g. sophia/polaris on
+    Eagle); empty means the root is unknown to the registry.
+    """
+    root_str = str(root)
+    return [name for name, info in CLUSTER_REGISTRY.items() if str(info.root) == root_str]
+
+
 def get_cluster_for_root(root: Path | str) -> str | None:
     """Reverse lookup: cluster name for a given install root path.
 
@@ -90,8 +100,7 @@ def get_cluster_for_root(root: Path | str) -> str | None:
     which case picking one by registry order would be a guess. Callers that
     need a definite identity must ask for an explicit cluster name.
     """
-    root_str = str(root)
-    matches = [name for name, info in CLUSTER_REGISTRY.items() if str(info.root) == root_str]
+    matches = get_clusters_for_root(root)
     if len(matches) == 1:
         return matches[0]
     return None

--- a/rootstock/commands/add.py
+++ b/rootstock/commands/add.py
@@ -84,6 +84,7 @@ def cmd_add(args) -> int:
             verify_timeout=args.verify_timeout,
             push=not args.no_push,
             force=args.force,
+            cluster=args.cluster,
             setup_kwargs=setup_kwargs,
             progress=print,
         )

--- a/rootstock/commands/init.py
+++ b/rootstock/commands/init.py
@@ -6,7 +6,7 @@ import os
 import sys
 from pathlib import Path
 
-from ..clusters import CLUSTER_REGISTRY, get_cluster_for_root
+from ..clusters import CLUSTER_REGISTRY, get_clusters_for_root
 from ..config import DEFAULT_CONFIG_FILE, load_config, save_config
 from ..layout import write_layout_marker
 from ..manifest import create_manifest, manifest_lock, save_manifest
@@ -117,16 +117,21 @@ def cmd_init(args) -> int:
         print("Error: Root directory is required.", file=sys.stderr)
         return 1
 
-    # Check if input is a cluster name
+    # Check if input is a cluster name. A shared root serves every registry
+    # sibling (sophia/polaris), so the manifest records them all (#208).
     if root_input in CLUSTER_REGISTRY:
-        cluster = root_input
         root = CLUSTER_REGISTRY[root_input].root
-        print(f"  -> Using cluster '{cluster}' root: {root}")
+        siblings = [c for c in get_clusters_for_root(root) if c != root_input]
+        clusters = [root_input, *siblings]
+        print(f"  -> Using cluster '{root_input}' root: {root}")
+        if siblings:
+            print(f"  -> This root also serves: {', '.join(siblings)}")
     else:
         root = Path(root_input).expanduser().resolve()
-        cluster = get_cluster_for_root(root)
-        if cluster:
-            print(f"  -> Detected cluster: {cluster}")
+        clusters = get_clusters_for_root(root)
+        if clusters:
+            print(f"  -> Detected cluster(s): {', '.join(clusters)}")
+    cluster = clusters[0] if clusters else None
 
     config.root = str(root)
 
@@ -205,10 +210,10 @@ def cmd_init(args) -> int:
             print(f"  Skipped (no permission): {root / 'layout.json'}")
 
     # Initialize manifest if we have a cluster
-    if cluster and not args.skip_manifest:
+    if clusters and not args.skip_manifest:
         print("\nInitializing manifest...")
         with manifest_lock(root):
-            manifest = create_manifest(root, cluster, config)
+            manifest = create_manifest(root, clusters, config)
             # Scan for existing built environments
             manifest = refresh_manifest_environments(manifest, root)
             save_manifest(manifest, root)

--- a/rootstock/commands/manifest.py
+++ b/rootstock/commands/manifest.py
@@ -27,7 +27,7 @@ def cmd_manifest_show(args) -> int:
     else:
         print(f"Manifest: {root}/manifest.json")
         print(f"  Schema version:    {manifest.schema_version}")
-        print(f"  Cluster:           {manifest.cluster}")
+        print(f"  Clusters:          {', '.join(manifest.clusters)}")
         print(f"  Root:              {manifest.root}")
         print(f"  Rootstock version: {manifest.rootstock_version}")
         print(f"  Python version:    {manifest.python_version}")
@@ -40,6 +40,8 @@ def cmd_manifest_show(args) -> int:
         print(f"  Environments ({len(manifest.environments)}):")
         for name, env in manifest.environments.items():
             print(f"    {name}:")
+            if env.clusters is not None:
+                print(f"      Clusters:     {', '.join(env.clusters)} only")
             print(f"      Built at:     {env.built_at}")
             hash_desc = f"{env.source_hash[:20]}..." if env.source_hash else "none"
             print(f"      Source hash:  {hash_desc}")
@@ -90,9 +92,21 @@ def cmd_manifest_push(args) -> int:
 
 
 def cmd_manifest_init(args) -> int:
-    """Initialize manifest for a cluster."""
+    """Initialize manifest for the cluster(s) an install serves."""
+    from ..clusters import get_clusters_for_root
+
     root = get_root_or_exit(args)
-    cluster = args.cluster
+    # --cluster is repeatable for shared installs. Registry siblings of this
+    # root are appended automatically — forgetting one is exactly the
+    # mislabeled-manifest bug this exists to prevent (#208).
+    clusters = list(args.cluster)
+    siblings = [c for c in get_clusters_for_root(root) if c not in clusters]
+    if siblings:
+        print(
+            f"Note: this root also serves {', '.join(siblings)} per the "
+            f"cluster registry — including them."
+        )
+        clusters.extend(siblings)
     config = load_config()
 
     # Check if manifest already exists
@@ -112,12 +126,12 @@ def cmd_manifest_init(args) -> int:
 
     # Create and save manifest
     with manifest_lock(root):
-        manifest = create_manifest(root, cluster, config)
+        manifest = create_manifest(root, clusters, config)
         manifest = refresh_manifest_environments(manifest, root)
         save_manifest(manifest, root)
 
     print(f"Manifest initialized: {root}/manifest.json")
-    print(f"  Cluster: {cluster}")
+    print(f"  Clusters: {', '.join(clusters)}")
     print(f"  Environments: {len(manifest.environments)}")
 
     # Skip push if explicitly disabled

--- a/rootstock/commands/serve.py
+++ b/rootstock/commands/serve.py
@@ -40,6 +40,9 @@ def cmd_serve(args) -> int:
     checkpoint = args.checkpoint
     device = args.device
     weights = getattr(args, "weights", None)
+    # Which machine this serve runs on — picks the right env among
+    # cluster-specific variants and attributes the usage record (#208).
+    cluster = getattr(args, "cluster", None)
 
     try:
         cli_kwargs = parse_setup_kwargs(getattr(args, "kwarg", None))
@@ -48,7 +51,7 @@ def cmd_serve(args) -> int:
         return 2
 
     try:
-        resolved = resolve_checkpoint(root, checkpoint)
+        resolved = resolve_checkpoint(root, checkpoint, cluster)
     except CheckpointNotFoundError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
@@ -126,5 +129,6 @@ def cmd_serve(args) -> int:
         started_at=started_at,
         duration_s=time.monotonic() - started,
         n_calculations=None,
+        cluster=cluster,
     )
     return rc

--- a/rootstock/commands/smoke_test.py
+++ b/rootstock/commands/smoke_test.py
@@ -21,12 +21,14 @@ from ..environment import (
     CUSTOM_CHECKPOINT_SUFFIX,
     is_custom_checkpoint,
     parse_checkpoints_dict,
+    parse_clusters_list,
     parse_custom_checkpoint_ids,
 )
 from ..manifest import (
     CheckpointInfo,
     EnvironmentInfo,
     Manifest,
+    VerificationRecord,
     is_verified,
     load_manifest,
     manifest_lock,
@@ -35,8 +37,10 @@ from ..manifest import (
 )
 from ..operations import (
     _WEIGHTS_BYTE_FLOOR,
+    OperationError,
     apply_weights_record,
     read_weights_capture,
+    resolve_current_cluster,
     update_and_push_manifest,
     weights_capture_file,
 )
@@ -44,13 +48,31 @@ from ..verify import results_mismatch, verify_checkpoint
 from .common import get_root_or_exit, resolve_cache_root
 
 
+def _serves_here(root: Path, env_name: str, env: EnvironmentInfo, cluster: str) -> bool:
+    """Whether an env serves the cluster this run is on: the live source's
+    CLUSTERS when readable (so a fresh restriction takes effect this run, not
+    after the next refresh), else the manifest record."""
+    source = root / "envs" / env_name / "env_source.py"
+    if source.exists():
+        try:
+            restriction = parse_clusters_list(source)
+        except ValueError:
+            return env.serves(cluster)
+        return restriction is None or cluster in restriction
+    return env.serves(cluster)
+
+
 def _select(
-    manifest, env_filter: str | None, checkpoint_filter: str | None
+    root: Path, manifest, env_filter: str | None, checkpoint_filter: str | None, cluster: str
 ) -> list[tuple[str, str, EnvironmentInfo, CheckpointInfo]]:
     """Pick which (env, checkpoint) pairs to test."""
     selected: list[tuple[str, str, EnvironmentInfo, CheckpointInfo]] = []
     for env_name, env in manifest.environments.items():
         if env_filter is not None and env_name != env_filter:
+            continue
+        if not _serves_here(root, env_name, env, cluster):
+            # A cluster-restricted variant can only be verified by a machine
+            # it serves (#208); its own cluster's chain covers it.
             continue
         for ckpt_name, ckpt in env.checkpoints.items():
             if checkpoint_filter is not None and ckpt_name != checkpoint_filter:
@@ -96,6 +118,7 @@ def _plan_custom_legs(
     manifest: Manifest,
     env_filter: str | None,
     ckpt_filter: str | None,
+    cluster: str,
 ) -> tuple[list[CustomLeg], list[tuple[str, str, str]]]:
     """Plan one weights= leg per ``<family>:custom`` entry declared by a
     manifest env's built source (#200).
@@ -109,6 +132,8 @@ def _plan_custom_legs(
     skipped: list[tuple[str, str, str]] = []
     for env_name, env in manifest.environments.items():
         if env_filter is not None and env_name != env_filter:
+            continue
+        if not _serves_here(root, env_name, env, cluster):
             continue
         source = Path(root) / "envs" / env_name / "env_source.py"
         if not source.exists():
@@ -177,20 +202,31 @@ def cmd_smoke_test(args) -> int:
         print(f"Error: no manifest at {root}/manifest.json", file=sys.stderr)
         return 1
 
-    custom_legs, custom_skips = _plan_custom_legs(root, manifest, env_filter, ckpt_filter)
+    # Which machine is this? Results are recorded (and pushed) under this
+    # cluster's name; on a shared install it must be given explicitly (#208).
+    try:
+        cluster = resolve_current_cluster(root, args.cluster)
+    except OperationError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
 
-    selected = _select(manifest, env_filter, ckpt_filter)
+    custom_legs, custom_skips = _plan_custom_legs(root, manifest, env_filter, ckpt_filter, cluster)
+
+    selected = _select(root, manifest, env_filter, ckpt_filter, cluster)
     if ckpt_filter is not None and is_custom_checkpoint(ckpt_filter):
         # A ':custom' filter matches no canonical row; run just the base
         # checkpoint(s) the leg needs for its comparison.
         needed = {(leg.env_name, leg.base) for leg in custom_legs}
-        selected = [t for t in _select(manifest, env_filter, None) if (t[0], t[1]) in needed]
+        selected = [
+            t for t in _select(root, manifest, env_filter, None, cluster) if (t[0], t[1]) in needed
+        ]
 
     if not selected and not custom_legs:
         if json_out:
             print(
                 json.dumps(
                     {
+                        "cluster": cluster,
                         "results": [],
                         "passed": 0,
                         "failed": 0,
@@ -258,25 +294,24 @@ def cmd_smoke_test(args) -> int:
         # report reflects this run.
         if ok:
             passed_keys.add((env_name, ckpt_name))
-            ckpt.verified_at = now_iso()
-            ckpt.verified_device = device
-            ckpt.last_error = None
+            ckpt.verifications[cluster] = VerificationRecord(
+                verified_at=now_iso(), verified_device=device
+            )
             n_passed += 1
         else:
-            ckpt.verified_at = None
-            ckpt.verified_device = None
-            ckpt.last_error = f"smoke-test: {err}"
+            ckpt.verifications[cluster] = VerificationRecord(last_error=f"smoke-test: {err}")
             n_failed += 1
 
         results.append(
             {
                 "env": env_name,
                 "checkpoint": ckpt_name,
+                "cluster": cluster,
                 "device": device,
                 "passed": ok,
                 "elapsed_s": round(elapsed, 2),
                 "error": err,
-                "verified_current": is_verified(env, ckpt),
+                "verified_current": is_verified(env, ckpt, cluster),
             }
         )
 
@@ -337,14 +372,12 @@ def cmd_smoke_test(args) -> int:
         env = manifest.environments[leg.env_name]
         ckpt = env.checkpoints.setdefault(leg.custom_id, CheckpointInfo())
         if ok:
-            ckpt.verified_at = now_iso()
-            ckpt.verified_device = device
-            ckpt.last_error = None
+            ckpt.verifications[cluster] = VerificationRecord(
+                verified_at=now_iso(), verified_device=device
+            )
             n_passed += 1
         else:
-            ckpt.verified_at = None
-            ckpt.verified_device = None
-            ckpt.last_error = f"smoke-test: {err}"
+            ckpt.verifications[cluster] = VerificationRecord(last_error=f"smoke-test: {err}")
             n_failed += 1
 
         results.append(
@@ -352,11 +385,12 @@ def cmd_smoke_test(args) -> int:
                 "env": leg.env_name,
                 "checkpoint": leg.custom_id,
                 "base_checkpoint": leg.base,
+                "cluster": cluster,
                 "device": device,
                 "passed": ok,
                 "elapsed_s": round(elapsed, 2),
                 "error": err,
-                "verified_current": is_verified(env, ckpt),
+                "verified_current": is_verified(env, ckpt, cluster),
             }
         )
 
@@ -383,13 +417,13 @@ def cmd_smoke_test(args) -> int:
                 if ckpt_record is None:
                     continue  # env/checkpoint removed while we were testing
                 if ok:
-                    ckpt_record.verified_at = now_iso()
-                    ckpt_record.verified_device = device
-                    ckpt_record.last_error = None
+                    ckpt_record.verifications[cluster] = VerificationRecord(
+                        verified_at=now_iso(), verified_device=device
+                    )
                 else:
-                    ckpt_record.verified_at = None
-                    ckpt_record.verified_device = None
-                    ckpt_record.last_error = f"smoke-test: {err}"
+                    ckpt_record.verifications[cluster] = VerificationRecord(
+                        last_error=f"smoke-test: {err}"
+                    )
                 apply_weights_record(
                     ckpt_record,
                     weight_files,
@@ -404,13 +438,13 @@ def cmd_smoke_test(args) -> int:
                 # so nothing else ever writes them into the manifest.
                 ckpt_record = env_record.checkpoints.setdefault(custom_id, CheckpointInfo())
                 if ok:
-                    ckpt_record.verified_at = now_iso()
-                    ckpt_record.verified_device = device
-                    ckpt_record.last_error = None
+                    ckpt_record.verifications[cluster] = VerificationRecord(
+                        verified_at=now_iso(), verified_device=device
+                    )
                 else:
-                    ckpt_record.verified_at = None
-                    ckpt_record.verified_device = None
-                    ckpt_record.last_error = f"smoke-test: {err}"
+                    ckpt_record.verifications[cluster] = VerificationRecord(
+                        last_error=f"smoke-test: {err}"
+                    )
             save_manifest(fresh, root)
     update_and_push_manifest(root, quiet=True, push=not no_push)
 
@@ -420,6 +454,7 @@ def cmd_smoke_test(args) -> int:
         print(
             json.dumps(
                 {
+                    "cluster": cluster,
                     "results": results,
                     "passed": n_passed,
                     "failed": n_failed,

--- a/rootstock/commands/smoke_test.py
+++ b/rootstock/commands/smoke_test.py
@@ -1,5 +1,11 @@
 """``rootstock smoke-test`` — re-verify checkpoints already in the manifest.
 
+Selection is checkpoint-first (#208): each canonical id declared by a built
+env serving this cluster is resolved with the same cluster-aware resolution
+the calculator uses, and tested in the env it resolves to — so a
+cluster-specific variant shadows the universal env per id, exactly as users
+experience it.
+
 Besides re-verifying every fetched canonical checkpoint, each run exercises
 the custom-weights path (#200): for every ``<family>:custom`` entry an env
 declares, the weights file a same-family canonical checkpoint already has on
@@ -19,10 +25,13 @@ from pathlib import Path
 
 from ..environment import (
     CUSTOM_CHECKPOINT_SUFFIX,
+    CheckpointNotFoundError,
+    find_env_for_checkpoint,
     is_custom_checkpoint,
     parse_checkpoints_dict,
     parse_clusters_list,
     parse_custom_checkpoint_ids,
+    resolve_checkpoint,
 )
 from ..manifest import (
     CheckpointInfo,
@@ -62,19 +71,115 @@ def _serves_here(root: Path, env_name: str, env: EnvironmentInfo, cluster: str) 
     return env.serves(cluster)
 
 
+def _declared_ids(root: Path, env_name: str) -> list[str] | None:
+    """Canonical ids the env's built source declares, in declaration order —
+    or ``None`` when there is no source on disk to parse (a pre-source-copy
+    build), telling the caller to fall back to the env's manifest records.
+    A malformed source contributes nothing, matching
+    ``list_declared_checkpoints``."""
+    source = root / "envs" / env_name / "env_source.py"
+    if not source.exists():
+        return None
+    try:
+        return list(parse_checkpoints_dict(source))
+    except ValueError:
+        return []
+
+
+def _fetched_record(manifest: Manifest, ckpt_id: str) -> CheckpointInfo | None:
+    """Any env's record showing ``ckpt_id`` was fetched. The weights cache is
+    shared and keyed by checkpoint, not env — one env's download serves them
+    all — so fetched anywhere is fetched."""
+    for env in manifest.environments.values():
+        record = env.checkpoints.get(ckpt_id)
+        if record is not None and record.fetched_at:
+            return record
+    return None
+
+
+def _resolves_to(root: Path, ckpt_id: str, cluster: str, env_name: str) -> bool:
+    """Whether ``ckpt_id`` resolves to ``env_name`` on ``cluster``."""
+    try:
+        return find_env_for_checkpoint(root, ckpt_id, cluster)[0] == env_name
+    except CheckpointNotFoundError:
+        return False
+
+
 def _select(
     root: Path, manifest, env_filter: str | None, checkpoint_filter: str | None, cluster: str
-) -> list[tuple[str, str, EnvironmentInfo, CheckpointInfo]]:
-    """Pick which (env, checkpoint) pairs to test."""
+) -> tuple[list[tuple[str, str, EnvironmentInfo, CheckpointInfo]], list[tuple[str, str, str]]]:
+    """Pick which (env, checkpoint) pairs to test — checkpoint-first (#208).
+
+    The unit of testing is the canonical id, not the env record: collect the
+    ids declared by built envs serving this cluster, resolve each one exactly
+    like the calculator would (a cluster-specific variant beats the universal
+    env), and test it in the env it resolves to — also the env whose record
+    the outcome lands in. Per-id shadowing falls out: the variant's override
+    is what gets tested on its cluster, while ids the variant doesn't declare
+    keep being tested via the universal env. ``env_filter`` therefore means
+    "ids that resolve to that env on this cluster".
+
+    An id counts as fetched when *any* env's record says so (the cache is
+    shared, keyed by checkpoint); the resolved env's record inherits the
+    donor's ``fetched_at`` so it never reads "verified but never fetched".
+    Ids fetched nowhere are skipped — smoke-test never downloads.
+
+    Envs built before sources were copied into the env dir have nothing to
+    parse; their manifest records are tested in place (the old env-first
+    walk).
+
+    Returns the selection plus ``(env, checkpoint, reason)`` notes for ids
+    that fail to resolve (e.g. declared by two same-specificity envs) — a
+    nightly run reports those and keeps testing everything else.
+    """
     selected: list[tuple[str, str, EnvironmentInfo, CheckpointInfo]] = []
+    skipped: list[tuple[str, str, str]] = []
+    seen: set[str] = set()
+    sourceless: list[tuple[str, EnvironmentInfo]] = []
+
     for env_name, env in manifest.environments.items():
-        if env_filter is not None and env_name != env_filter:
-            continue
         if not _serves_here(root, env_name, env, cluster):
             # A cluster-restricted variant can only be verified by a machine
             # it serves (#208); its own cluster's chain covers it.
             continue
+        declared = _declared_ids(root, env_name)
+        if declared is None:
+            sourceless.append((env_name, env))
+            continue
+        for ckpt_id in declared:
+            if ckpt_id in seen:
+                continue
+            seen.add(ckpt_id)
+            if checkpoint_filter is not None and ckpt_id != checkpoint_filter:
+                continue
+            try:
+                resolved, _ = find_env_for_checkpoint(root, ckpt_id, cluster)
+            except CheckpointNotFoundError as exc:
+                if env_filter is None or env_name == env_filter:
+                    skipped.append((env_name, ckpt_id, str(exc)))
+                continue
+            if env_filter is not None and resolved != env_filter:
+                continue
+            host = manifest.environments.get(resolved)
+            if host is None:
+                skipped.append((resolved, ckpt_id, "resolved env is not in the manifest"))
+                continue
+            donor = _fetched_record(manifest, ckpt_id)
+            if donor is None:
+                # Smoke-test never downloads. Skip checkpoints that have never
+                # been fetched by any env.
+                continue
+            record = host.checkpoints.setdefault(ckpt_id, CheckpointInfo())
+            if record.fetched_at is None:
+                record.fetched_at = donor.fetched_at
+            selected.append((resolved, ckpt_id, host, record))
+
+    for env_name, env in sourceless:
+        if env_filter is not None and env_name != env_filter:
+            continue
         for ckpt_name, ckpt in env.checkpoints.items():
+            if ckpt_name in seen:
+                continue  # already tested via the env it resolves to
             if checkpoint_filter is not None and ckpt_name != checkpoint_filter:
                 continue
             if is_custom_checkpoint(ckpt_name):
@@ -82,10 +187,10 @@ def _select(
                 # no shipped weights for the canonical loop to verify.
                 continue
             if ckpt.fetched_at is None:
-                # Smoke-test never downloads. Skip checkpoints that have never been fetched.
                 continue
             selected.append((env_name, ckpt_name, env, ckpt))
-    return selected
+
+    return selected, skipped
 
 
 @dataclass(frozen=True)
@@ -120,49 +225,78 @@ def _plan_custom_legs(
     ckpt_filter: str | None,
     cluster: str,
 ) -> tuple[list[CustomLeg], list[tuple[str, str, str]]]:
-    """Plan one weights= leg per ``<family>:custom`` entry declared by a
-    manifest env's built source (#200).
+    """Plan one weights= leg per ``<family>:custom`` id declared by a built
+    source serving this cluster (#200).
 
-    The base is the first canonical id (in CHECKPOINTS declaration order —
-    env authors lead with the family's plainest-loading checkpoint) of the
-    same family that the manifest records as fetched. Returns the legs plus
+    Like the canonical selection, planning is checkpoint-first (#208): each
+    custom id is resolved for this cluster, and the leg runs in — and is
+    recorded on — the env it resolves to. The base is the first canonical id
+    (in the resolved env's CHECKPOINTS declaration order — env authors lead
+    with the family's plainest-loading checkpoint) of the same family that
+    is fetched anywhere and resolves to the same env, so the canonical loop
+    is guaranteed to have produced its baseline. Returns the legs plus
     ``(env, custom_id, reason)`` for entries that can't run this time.
     """
     legs: list[CustomLeg] = []
     skipped: list[tuple[str, str, str]] = []
+    seen: set[str] = set()
     for env_name, env in manifest.environments.items():
-        if env_filter is not None and env_name != env_filter:
-            continue
         if not _serves_here(root, env_name, env, cluster):
             continue
         source = Path(root) / "envs" / env_name / "env_source.py"
         if not source.exists():
             continue
         try:
-            declared = parse_checkpoints_dict(source)
             custom_ids = parse_custom_checkpoint_ids(source)
         except ValueError:
             continue
-        families = [c.removesuffix(CUSTOM_CHECKPOINT_SUFFIX) for c in custom_ids]
-        fetched = [
-            ckpt_id
-            for ckpt_id in declared
-            if (record := env.checkpoints.get(ckpt_id)) and record.fetched_at
-        ]
-        for custom_id, family in zip(custom_ids, families):
+        for custom_id in custom_ids:
+            if custom_id in seen:
+                continue
+            seen.add(custom_id)
             if ckpt_filter is not None and ckpt_filter != custom_id:
                 continue
-            base = next((c for c in fetched if _family_of(c, families) == family), None)
+            try:
+                resolved = resolve_checkpoint(root, custom_id, cluster).env_name
+            except CheckpointNotFoundError as exc:
+                if env_filter is None or env_name == env_filter:
+                    skipped.append((env_name, custom_id, str(exc)))
+                continue
+            if env_filter is not None and resolved != env_filter:
+                continue
+            if resolved not in manifest.environments:
+                skipped.append((resolved, custom_id, "resolved env is not in the manifest"))
+                continue
+            host_source = Path(root) / "envs" / resolved / "env_source.py"
+            try:
+                declared = parse_checkpoints_dict(host_source)
+                families = [
+                    c.removesuffix(CUSTOM_CHECKPOINT_SUFFIX)
+                    for c in parse_custom_checkpoint_ids(host_source)
+                ]
+            except (OSError, ValueError):
+                continue
+            family = custom_id.removesuffix(CUSTOM_CHECKPOINT_SUFFIX)
+            base = next(
+                (
+                    c
+                    for c in declared
+                    if _family_of(c, families) == family
+                    and _fetched_record(manifest, c) is not None
+                    and _resolves_to(root, c, cluster, resolved)
+                ),
+                None,
+            )
             if base is None:
                 skipped.append(
                     (
-                        env_name,
+                        resolved,
                         custom_id,
                         f"no fetched '{family}' checkpoint to borrow weights from",
                     )
                 )
                 continue
-            legs.append(CustomLeg(env_name, custom_id, base))
+            legs.append(CustomLeg(resolved, custom_id, base))
     return legs, skipped
 
 
@@ -212,14 +346,17 @@ def cmd_smoke_test(args) -> int:
 
     custom_legs, custom_skips = _plan_custom_legs(root, manifest, env_filter, ckpt_filter, cluster)
 
-    selected = _select(root, manifest, env_filter, ckpt_filter, cluster)
+    selected, resolve_skips = _select(root, manifest, env_filter, ckpt_filter, cluster)
     if ckpt_filter is not None and is_custom_checkpoint(ckpt_filter):
         # A ':custom' filter matches no canonical row; run just the base
         # checkpoint(s) the leg needs for its comparison.
         needed = {(leg.env_name, leg.base) for leg in custom_legs}
         selected = [
-            t for t in _select(root, manifest, env_filter, None, cluster) if (t[0], t[1]) in needed
+            t
+            for t in _select(root, manifest, env_filter, None, cluster)[0]
+            if (t[0], t[1]) in needed
         ]
+    custom_skips = resolve_skips + custom_skips
 
     if not selected and not custom_legs:
         if json_out:
@@ -253,7 +390,7 @@ def cmd_smoke_test(args) -> int:
     # loaded* manifest in one locked cycle afterwards — mutating the manifest
     # loaded before the loop and saving it at the end would silently revert
     # anything a co-maintainer wrote in between.
-    outcomes: list[tuple[str, str, bool, str | None, list[dict] | None]] = []
+    outcomes: list[tuple[str, str, bool, str | None, list[dict] | None, str | None]] = []
 
     # The custom legs reuse the canonical loop's work: its results are the
     # comparison baseline, and its fresh weight capture names the file on
@@ -284,7 +421,7 @@ def cmd_smoke_test(args) -> int:
             )
             weight_files = read_weights_capture(capture_path)
         elapsed = time.monotonic() - start
-        outcomes.append((env_name, ckpt_name, ok, err, weight_files))
+        outcomes.append((env_name, ckpt_name, ok, err, weight_files, ckpt.fetched_at))
 
         if (env_name, ckpt_name) in base_keys:
             baselines[(env_name, ckpt_name)] = run_results
@@ -411,11 +548,17 @@ def cmd_smoke_test(args) -> int:
     with manifest_lock(root):
         fresh = load_manifest(root)
         if fresh is not None:
-            for env_name, ckpt_name, ok, err, weight_files in outcomes:
+            for env_name, ckpt_name, ok, err, weight_files, fetched_at in outcomes:
                 env_record = fresh.environments.get(env_name)
-                ckpt_record = env_record.checkpoints.get(ckpt_name) if env_record else None
-                if ckpt_record is None:
-                    continue  # env/checkpoint removed while we were testing
+                if env_record is None:
+                    continue  # env removed while we were testing
+                # Created on first pass when the resolved env has no record of
+                # an id it now hosts (a variant tested checkpoint-first for
+                # the first time, #208); the donor's fetch stamp rides along
+                # so the record never reads "verified but never fetched".
+                ckpt_record = env_record.checkpoints.setdefault(ckpt_name, CheckpointInfo())
+                if ckpt_record.fetched_at is None:
+                    ckpt_record.fetched_at = fetched_at
                 if ok:
                     ckpt_record.verifications[cluster] = VerificationRecord(
                         verified_at=now_iso(), verified_device=device

--- a/rootstock/commands/status.py
+++ b/rootstock/commands/status.py
@@ -17,7 +17,24 @@ def _short_date(iso: str | None) -> str:
     return iso[:10]
 
 
-def _checkpoint_line(env, ckpt_name: str, ckpt) -> str:
+def _verification_fragment(env, ckpt, cluster: str, label: bool) -> tuple[str, str]:
+    """One cluster's verification cell: ``(text, marker)``. ``label`` appends
+    the cluster name — used on shared installs, where one flat cell would
+    hide which machine the result came from (#208)."""
+    v = ckpt.verification(cluster)
+    suffix = f" on {cluster}" if label else ""
+    if v.verified_at is None:
+        return f"not verified{suffix}", "⚠"
+    if is_verified(env, ckpt, cluster):
+        return f"verified {_short_date(v.verified_at)} ({v.verified_device}){suffix}", "✓"
+    return (
+        f"verified {_short_date(v.verified_at)} ({v.verified_device}){suffix}  "
+        f"⚠ stale (env rebuilt {_short_date(env.built_at)})",
+        "",
+    )
+
+
+def _checkpoint_line(env, ckpt_name: str, ckpt, clusters: list[str]) -> str:
     if is_custom_checkpoint(ckpt_name):
         # ':custom' rows record smoke-test's weights= leg (#200) — there is
         # nothing to fetch, the user supplies the weights file.
@@ -28,22 +45,27 @@ def _checkpoint_line(env, ckpt_name: str, ckpt) -> str:
             # Never successfully fetched.
             return f"    {ckpt_name:<24}  not fetched   ⚠  {ckpt.last_error}"
 
-    if ckpt.verified_at is None:
-        verified = "not verified"
-        marker = "⚠"
-    elif is_verified(env, ckpt):
-        verified = f"verified {_short_date(ckpt.verified_at)} ({ckpt.verified_device})"
+    # One verification cell per cluster the env serves (just one on
+    # single-cluster installs, unlabeled — the common case reads as before).
+    served = [c for c in clusters if env.serves(c)] or ["unknown"]
+    fragments = [_verification_fragment(env, ckpt, c, label=len(served) > 1) for c in served]
+    verified = " · ".join(text for text, _ in fragments)
+    markers = [m for _, m in fragments]
+    if all(m == "✓" for m in markers):
         marker = "✓"
+    elif any(m == "⚠" for m in markers):
+        marker = "⚠"
     else:
-        verified = (
-            f"verified {_short_date(ckpt.verified_at)} ({ckpt.verified_device})  "
-            f"⚠ stale (env rebuilt {_short_date(env.built_at)})"
-        )
         marker = ""
 
     line = f"    {ckpt_name:<24}  {fetched}  {verified}  {marker}".rstrip()
     if ckpt.last_error:
         line += f"\n      last error: {ckpt.last_error}"
+    for c in served:
+        v_err = ckpt.verification(c).last_error
+        if v_err:
+            where = f" ({c})" if len(served) > 1 else ""
+            line += f"\n      last error{where}: {v_err}"
     return line
 
 
@@ -56,6 +78,9 @@ def cmd_status(args) -> int:
         return _cmd_status_json(state)
 
     print(f"Rootstock root: {root}")
+    clusters = state.manifest.clusters if state.manifest else []
+    if len(clusters) > 1:
+        print(f"Serves clusters: {', '.join(clusters)}")
 
     # List environment sources
     print("\nEnvironment sources:")
@@ -72,7 +97,10 @@ def cmd_status(args) -> int:
     else:
         for name, env in state.envs.items():
             status = "ready" if env.source_file is not None else "incomplete"
-            print(f"  {name:<20} [{status}]")
+            restriction = ""
+            if env.record is not None and env.record.clusters is not None:
+                restriction = f"  [{', '.join(env.record.clusters)} only]"
+            print(f"  {name:<20} [{status}]{restriction}")
 
             if env.source_hash_drifted:
                 print(
@@ -88,7 +116,7 @@ def cmd_status(args) -> int:
             print(f"    Built: {env.record.built_at}")
             print(f"    Checkpoints ({len(env.record.checkpoints)}):")
             for ckpt_name, ckpt in env.record.checkpoints.items():
-                print(_checkpoint_line(env.record, ckpt_name, ckpt))
+                print(_checkpoint_line(env.record, ckpt_name, ckpt, clusters))
 
         # Records the manifest still carries for envs that are gone from disk.
         for name in sorted(state.manifest_only_envs):
@@ -144,13 +172,20 @@ def _cmd_status_json(state: InstallState) -> int:
     is joined in where it exists. Manifest records for envs no longer on
     disk are listed separately rather than passed off as installed.
     """
+    manifest = state.manifest
+    clusters = manifest.clusters if manifest else []
+
     environments = {}
     for name, env in state.envs.items():
         checkpoints = {}
         if env.record is not None:
             for ckpt_name, ckpt in env.record.checkpoints.items():
                 ckpt_data = ckpt.to_dict()
-                ckpt_data["verified_current"] = is_verified(env.record, ckpt)
+                # verified_current per cluster the env serves — one flat bool
+                # can't say *where* a checkpoint is verified (#208).
+                ckpt_data["verified_current"] = {
+                    c: is_verified(env.record, ckpt, c) for c in clusters if env.record.serves(c)
+                }
                 checkpoints[ckpt_name] = ckpt_data
         environments[name] = {
             "has_source": env.source_file is not None,
@@ -160,13 +195,13 @@ def _cmd_status_json(state: InstallState) -> int:
             "in_manifest": env.record is not None,
             "built_at": env.record.built_at if env.record else None,
             "manifest_source_hash": env.record.source_hash if env.record else None,
+            "clusters": env.record.clusters if env.record else None,
             "checkpoints": checkpoints,
         }
 
-    manifest = state.manifest
     payload = {
         "root": str(state.root),
-        "cluster": manifest.cluster if manifest else None,
+        "clusters": clusters or None,
         "maintainer": manifest.maintainer.to_dict() if manifest else None,
         "rootstock_version": manifest.rootstock_version if manifest else None,
         "last_updated": manifest.last_updated if manifest else None,

--- a/rootstock/commands/sync.py
+++ b/rootstock/commands/sync.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from ..batch import PHASES, execute_sync, plan_sync, render_plan, render_summary
 from ..environment import CheckpointNotFoundError
 from ..layout import ensure_layout_compatible, write_layout_marker
-from ..operations import OperationError
+from ..operations import OperationError, resolve_current_cluster
 from .common import resolve_cache_root, resolve_root, warn_on_permissions
 
 
@@ -79,6 +79,17 @@ def cmd_sync(args) -> int:
 
     cache_root = resolve_cache_root(root)
 
+    # The verification identity: --cluster doubles as the machine name, so
+    # on a shared install (sophia/polaris) results land under the right
+    # cluster (#208). Resolved strictly only when this run verifies.
+    cluster = args.cluster
+    if "verify" in phases:
+        try:
+            cluster = resolve_current_cluster(root, cluster)
+        except OperationError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 2
+
     # With --json the machine-readable document owns stdout; everything
     # human-oriented (progress, plan, summary) moves to stderr.
     say = (lambda line: print(line, file=sys.stderr)) if args.json else print
@@ -91,6 +102,7 @@ def cmd_sync(args) -> int:
             checkpoints=args.checkpoint,
             rebuild=args.rebuild,
             phases=phases,
+            cluster=cluster,
         )
     except (OperationError, CheckpointNotFoundError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
@@ -126,6 +138,7 @@ def cmd_sync(args) -> int:
         fail_fast=args.fail_fast,
         push=not args.no_push,
         cache_root=cache_root,
+        cluster=cluster,
         say=say,
     )
 

--- a/rootstock/commands/usage.py
+++ b/rootstock/commands/usage.py
@@ -122,11 +122,11 @@ def cmd_usage_push(args) -> int:
         return 1
 
     manifest = load_manifest(root)
-    if manifest is None or not manifest.cluster:
+    if manifest is None or not manifest.clusters:
         print(
-            f"No manifest at {root}/manifest.json — the push is filed under "
-            "the manifest's cluster name; run 'rootstock manifest init "
-            "--cluster <name>' first.",
+            f"No manifest at {root}/manifest.json — pushes are filed under "
+            "cluster names; run 'rootstock manifest init --cluster <name>' "
+            "first.",
             file=sys.stderr,
         )
         return 1
@@ -143,19 +143,32 @@ def cmd_usage_push(args) -> int:
         print("No usage recorded yet — nothing to push.")
         return 0
 
+    # Rows carry the cluster their sessions ran on — on a shared install
+    # (sophia/polaris) one spool holds several machines' usage, so each
+    # cluster gets its own push (#208). Rows predating the per-session stamp
+    # (or from root=-only sessions) fall back to the install's home cluster.
+    home = manifest.clusters[0]
+    by_cluster: dict[str, list[dict]] = {}
+    for row in summary.rows:
+        by_cluster.setdefault(row.get("cluster") or home, []).append(row)
+
     if args.dry_run:
-        payload = {"cluster": manifest.cluster, "rows": summary.rows}
-        print(f"Would POST to {url}:")
-        print(json.dumps(payload, indent=2))
+        for cluster, rows in sorted(by_cluster.items()):
+            payload = {"cluster": cluster, "rows": rows}
+            print(f"Would POST to {url}:")
+            print(json.dumps(payload, indent=2))
         return 0
 
     client = RootstockClient(config)
-    success, message = client.push_usage(manifest.cluster, summary.rows)
-    if not success:
-        print(f"Error: {message}", file=sys.stderr)
-        return 1
-    print(message)
-    return 0
+    all_ok = True
+    for cluster, rows in sorted(by_cluster.items()):
+        success, message = client.push_usage(cluster, rows)
+        if success:
+            print(message)
+        else:
+            print(f"Error ({cluster}): {message}", file=sys.stderr)
+            all_ok = False
+    return 0 if all_ok else 1
 
 
 def cmd_usage_compact(args) -> int:

--- a/rootstock/environment.py
+++ b/rootstock/environment.py
@@ -275,6 +275,48 @@ def parse_custom_checkpoint_ids(env_source_path: Path) -> list[str]:
     return _parse_checkpoints(env_source_path)[1]
 
 
+def parse_clusters_list(env_source_path: Path) -> list[str] | None:
+    """AST-extract the optional module-level ``CLUSTERS`` list literal.
+
+    ``CLUSTERS = ["polaris"]`` restricts an env to those clusters — a
+    cluster-specific variant on a shared install (#208): declare the same
+    canonical ids as the family's main env, and resolution picks the variant
+    on its clusters while the other machines keep the main env. Absent (the
+    normal case) means the env serves every cluster its install does.
+
+    Items must be string literals; an empty list — an env nobody could
+    serve — is an authoring error. Raises ValueError on either, matching
+    ``parse_checkpoints_dict``.
+    """
+    tree = ast.parse(env_source_path.read_text(), filename=str(env_source_path))
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            targets, value = node.targets, node.value
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            targets, value = [node.target], node.value
+        else:
+            continue
+        if not (
+            len(targets) == 1 and isinstance(targets[0], ast.Name) and targets[0].id == "CLUSTERS"
+        ):
+            continue
+        if not isinstance(value, (ast.List, ast.Tuple)):
+            raise ValueError(f"{env_source_path}: CLUSTERS must be a list literal.")
+        clusters: list[str] = []
+        for item in value.elts:
+            if not (isinstance(item, ast.Constant) and isinstance(item.value, str)):
+                raise ValueError(f"{env_source_path}: CLUSTERS items must be string literals.")
+            clusters.append(item.value)
+        if not clusters:
+            raise ValueError(
+                f"{env_source_path}: CLUSTERS is empty — no cluster could "
+                f"serve this env. Remove the declaration to serve every "
+                f"cluster, or list the clusters it runs on."
+            )
+        return clusters
+    return None
+
+
 def declares_setup_from_path(env_source_path: Path) -> bool:
     """
     Return True when the env source declares a module-level ``setup_from_path``.
@@ -431,10 +473,78 @@ def list_custom_checkpoints(root: Path | str) -> dict[str, list[str]]:
     return declared
 
 
-def find_env_for_checkpoint(root: Path | str, checkpoint_id: str) -> tuple[str, dict[str, str]]:
+def _pick_hosting_env(
+    root: Path,
+    candidates: list[str],
+    checkpoint_id: str,
+    cluster: str | None,
+) -> str:
+    """Choose the hosting env among ``candidates`` that declare the same id,
+    honoring each env's CLUSTERS restriction.
+
+    With a known ``cluster``, a cluster-specific env beats an unrestricted
+    one — that is the variant override (#208). Without one, only
+    unrestricted envs are eligible: picking a variant would silently assume
+    a machine. Several eligible envs at the same specificity is an authoring
+    error and raises, rather than resolving by directory order.
+    """
+    restrictions: dict[str, list[str] | None] = {}
+    for env_name in candidates:
+        source = root / "envs" / env_name / "env_source.py"
+        try:
+            restrictions[env_name] = parse_clusters_list(source)
+        except (OSError, ValueError):
+            # A missing source or malformed CLUSTERS must never widen a
+            # variant to universal; drop the env from contention, like the
+            # checkpoint listings drop malformed CHECKPOINTS.
+            continue
+
+    if cluster is not None:
+        serving = {e: r for e, r in restrictions.items() if r is None or cluster in r}
+        pool = [e for e, r in serving.items() if r is not None] or list(serving)
+        if not pool:
+            details = (
+                "; ".join(f"{e} serves {', '.join(r)}" for e, r in restrictions.items() if r)
+                or "no readable candidates"
+            )
+            raise CheckpointNotFoundError(
+                f"No env serves checkpoint '{checkpoint_id}' on cluster "
+                f"'{cluster}' — it is declared only by envs restricted to "
+                f"other clusters ({details})."
+            )
+    else:
+        pool = [e for e, r in restrictions.items() if r is None]
+        if not pool:
+            details = (
+                "; ".join(f"{e} serves {', '.join(r)}" for e, r in restrictions.items() if r)
+                or "no readable candidates"
+            )
+            raise CheckpointNotFoundError(
+                f"Checkpoint '{checkpoint_id}' is declared only by "
+                f"cluster-specific envs ({details}). Say which machine you "
+                f"are on (cluster= in Python, --cluster on the CLI) so the "
+                f"right variant can be picked."
+            )
+
+    if len(pool) > 1:
+        where = f" on cluster '{cluster}'" if cluster is not None else ""
+        raise CheckpointNotFoundError(
+            f"Checkpoint '{checkpoint_id}' is declared by several envs that "
+            f"all serve{where}: {', '.join(sorted(pool))}. Ids must resolve "
+            f"to one env — restrict the variants with CLUSTERS in their env "
+            f"sources."
+        )
+    return pool[0]
+
+
+def find_env_for_checkpoint(
+    root: Path | str, checkpoint_id: str, cluster: str | None = None
+) -> tuple[str, dict[str, str]]:
     """
     Return ``(env_name, CHECKPOINTS)`` for the installed env that declares
-    ``checkpoint_id``.
+    ``checkpoint_id`` — honoring CLUSTERS restrictions when several envs
+    declare it (``cluster`` names the machine being resolved for; see
+    :func:`_pick_hosting_env`).
 
     Raises ``CheckpointNotFoundError`` with a message listing every canonical
     id declared by any installed env, plus a hint to ``rootstock install`` if
@@ -442,9 +552,10 @@ def find_env_for_checkpoint(root: Path | str, checkpoint_id: str) -> tuple[str, 
     """
     root = Path(root)
     declared = list_declared_checkpoints(root)
-    for env_name, ckpts in declared.items():
-        if checkpoint_id in ckpts:
-            return env_name, ckpts
+    candidates = [env_name for env_name, ckpts in declared.items() if checkpoint_id in ckpts]
+    if candidates:
+        env_name = _pick_hosting_env(root, candidates, checkpoint_id, cluster)
+        return env_name, declared[env_name]
 
     if declared:
         # The ':custom' entries are part of the menu — list them alongside
@@ -488,19 +599,23 @@ class ResolvedCheckpoint:
     is_custom: bool = False
 
 
-def _resolve_custom(root: Path | str, checkpoint_id: str) -> ResolvedCheckpoint:
+def _resolve_custom(
+    root: Path | str, checkpoint_id: str, cluster: str | None = None
+) -> ResolvedCheckpoint:
     """
     Resolve a ``<family>:custom`` checkpoint via the entries installed envs
     declare in ``CHECKPOINTS``.
 
     The entry carries no weights (its value is ``None``) — the user's
     ``weights`` file is bound at the call site. Which env hosts the id is
-    determined by which env's dict declares it, exactly like a canonical id.
+    determined by which env's dict declares it, exactly like a canonical id
+    (including CLUSTERS restrictions).
     """
     declared = list_custom_checkpoints(root)
-    for env_name, custom_ids in declared.items():
-        if checkpoint_id in custom_ids:
-            return ResolvedCheckpoint(checkpoint=checkpoint_id, env_name=env_name, is_custom=True)
+    candidates = [env_name for env_name, ids in declared.items() if checkpoint_id in ids]
+    if candidates:
+        env_name = _pick_hosting_env(Path(root), candidates, checkpoint_id, cluster)
+        return ResolvedCheckpoint(checkpoint=checkpoint_id, env_name=env_name, is_custom=True)
 
     if declared:
         listing = "\n".join(f"  {env}: {', '.join(ids)}" for env, ids in declared.items())
@@ -519,11 +634,17 @@ def _resolve_custom(root: Path | str, checkpoint_id: str) -> ResolvedCheckpoint:
     raise CheckpointNotFoundError(msg)
 
 
-def resolve_checkpoint(root: Path | str, checkpoint_id: str) -> ResolvedCheckpoint:
+def resolve_checkpoint(
+    root: Path | str, checkpoint_id: str, cluster: str | None = None
+) -> ResolvedCheckpoint:
     """
     Resolve a checkpoint id to its hosting env. A ``<family>:custom`` id
     looks up the ``:custom`` entries, everything else the canonical ids (the
     two can't collide: canonical ids may not contain ``:``).
+
+    ``cluster`` names the machine being resolved for; it only matters when
+    envs restrict themselves with CLUSTERS (cluster-specific variants on a
+    shared install), where the variant serving ``cluster`` wins.
 
     Deliberately does not check that the env is built — resolution is also
     used for metadata lookups; callers that spawn a worker check before
@@ -532,8 +653,8 @@ def resolve_checkpoint(root: Path | str, checkpoint_id: str) -> ResolvedCheckpoi
     Raises CheckpointNotFoundError when nothing matches.
     """
     if is_custom_checkpoint(checkpoint_id):
-        return _resolve_custom(root, checkpoint_id)
-    env_name, _ = find_env_for_checkpoint(root, checkpoint_id)
+        return _resolve_custom(root, checkpoint_id, cluster)
+    env_name, _ = find_env_for_checkpoint(root, checkpoint_id, cluster)
     return ResolvedCheckpoint(checkpoint=checkpoint_id, env_name=env_name)
 
 

--- a/rootstock/manifest.py
+++ b/rootstock/manifest.py
@@ -28,7 +28,7 @@ from pathlib import Path
 from .config import UserConfig
 from .exceptions import RootstockError
 
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 6
 
 # manifest_lock defaults. The lock is only held across a load → mutate → save
 # cycle (plus the env refresh, which shells out to `uv pip list` per env), so
@@ -121,6 +121,57 @@ def _migrate_v4_to_v5(data: dict) -> tuple[dict, str | None]:
     return data, None
 
 
+def _migrate_v5_to_v6(data: dict) -> tuple[dict, str | None]:
+    """v6 made cluster identity plural and verification per-cluster (#208).
+
+    A shared install (sophia/polaris on Eagle) serves machines that differ in
+    node image and drivers, so one flat ``verified_at`` misattributes results.
+    ``cluster: str`` becomes ``clusters: list[str]``, seeded from the cluster
+    registry so a root known to serve several machines starts serving them all
+    without a manual re-init. Each checkpoint's flat verification fields move
+    under ``verifications[<old cluster>]`` — pre-v6 results can't be
+    attributed to any other cluster, so siblings start unverified. The mixed
+    ``last_error`` splits by its writer's prefix: ``download:`` errors stay on
+    the (shared) checkpoint, everything else was a verification error.
+    EnvironmentInfo gains ``clusters`` (None = serves every cluster), picked
+    up from each env source's CLUSTERS on the next refresh.
+    """
+    from .clusters import get_clusters_for_root
+
+    old = data.pop("cluster", None) or "unknown"
+    siblings = get_clusters_for_root(data.get("root", ""))
+    data["clusters"] = [old] + [c for c in siblings if c != old]
+
+    for env in data.get("environments", {}).values():
+        env.setdefault("clusters", None)
+        for ckpt in (env.get("checkpoints") or {}).values():
+            verified_at = ckpt.pop("verified_at", None)
+            verified_device = ckpt.pop("verified_device", None)
+            last_error = ckpt.pop("last_error", None)
+            is_fetch_error = last_error is not None and last_error.startswith("download:")
+            ckpt["last_error"] = last_error if is_fetch_error else None
+            verify_error = None if is_fetch_error else last_error
+            ckpt["verifications"] = {}
+            if verified_at is not None or verify_error is not None:
+                ckpt["verifications"][old] = {
+                    "verified_at": verified_at,
+                    "verified_device": verified_device,
+                    "last_error": verify_error,
+                }
+
+    data["schema_version"] = 6
+
+    note = None
+    if len(data["clusters"]) > 1:
+        others = ", ".join(data["clusters"][1:])
+        note = (
+            f"this root also serves {others} (per the cluster registry); "
+            f"prior verification history stays attributed to '{old}' and the "
+            f"other cluster(s) start unverified."
+        )
+    return data, note
+
+
 # One entry per historical schema version, upgrading one step. A schema bump
 # without a migration here strands every deployed manifest of that vintage —
 # add the migration in the same change as the bump.
@@ -129,6 +180,7 @@ MIGRATIONS = {
     2: _migrate_v2_to_v3,
     3: _migrate_v3_to_v4,
     4: _migrate_v4_to_v5,
+    5: _migrate_v5_to_v6,
 }
 
 
@@ -199,13 +251,41 @@ class Maintainer:
 
 
 @dataclass
-class CheckpointInfo:
-    """Metadata for a single checkpoint registered with an environment."""
+class VerificationRecord:
+    """One cluster's verification state for a checkpoint.
 
-    fetched_at: str | None = None  # ISO 8601, set when download succeeds
+    Verification is per-cluster (v6, #208): a shared install serves machines
+    that differ in node image and drivers, so passing on one says nothing
+    about the others.
+    """
+
     verified_at: str | None = None  # ISO 8601, set when smoke test passes
     verified_device: str | None = None  # "cuda", "cpu", etc.
-    last_error: str | None = None  # most recent error from add or smoke-test
+    last_error: str | None = None  # most recent verify/smoke-test error here
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> VerificationRecord:
+        return cls(
+            verified_at=data.get("verified_at"),
+            verified_device=data.get("verified_device"),
+            last_error=data.get("last_error"),
+        )
+
+
+@dataclass
+class CheckpointInfo:
+    """Metadata for a single checkpoint registered with an environment.
+
+    Fetch state is shared across clusters — the weights cache is one
+    filesystem however many machines mount it — while verification is
+    recorded per cluster in ``verifications``.
+    """
+
+    fetched_at: str | None = None  # ISO 8601, set when download succeeds
+    last_error: str | None = None  # most recent download error (shared)
     # Weight files this checkpoint's setup() actually touched, captured at
     # add/verify/smoke-test time (#177): list of {"path", "size"} dicts with
     # paths relative to the cache root (so records survive split-cache
@@ -215,6 +295,13 @@ class CheckpointInfo:
     # cgroup, over-warming evicts the pages the worker needs.
     weight_files: list[dict] | None = None
     weights_recorded_at: str | None = None  # ISO 8601
+    # Per-cluster verification state, keyed by cluster name. Absent key =
+    # never verified there.
+    verifications: dict[str, VerificationRecord] = field(default_factory=dict)
+
+    def verification(self, cluster: str) -> VerificationRecord:
+        """This cluster's verification state (empty record if never verified)."""
+        return self.verifications.get(cluster) or VerificationRecord()
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -223,11 +310,13 @@ class CheckpointInfo:
     def from_dict(cls, data: dict) -> CheckpointInfo:
         return cls(
             fetched_at=data.get("fetched_at"),
-            verified_at=data.get("verified_at"),
-            verified_device=data.get("verified_device"),
             last_error=data.get("last_error"),
             weight_files=data.get("weight_files"),
             weights_recorded_at=data.get("weights_recorded_at"),
+            verifications={
+                cluster: VerificationRecord.from_dict(v)
+                for cluster, v in (data.get("verifications") or {}).items()
+            },
         )
 
 
@@ -252,9 +341,17 @@ class EnvironmentInfo:
     # rootstock or because the env defeats universal resolution — and can
     # only be re-resolved, not faithfully rebuilt.
     lock_hash: str | None = None
+    # Clusters this env serves, mirrored from the source's CLUSTERS at
+    # refresh time. None = serves every cluster the install does; a list
+    # restricts it (a cluster-specific variant on a shared install, #208).
+    clusters: list[str] | None = None
     # Field order is the JSON key order (asdict): lock_hash stays ahead of
     # checkpoints to match the layout pushed manifests have always had.
     checkpoints: dict[str, CheckpointInfo] = field(default_factory=dict)
+
+    def serves(self, cluster: str) -> bool:
+        """Whether this env serves ``cluster`` (unrestricted envs serve all)."""
+        return self.clusters is None or cluster in self.clusters
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -274,22 +371,30 @@ class EnvironmentInfo:
             dependencies=data["dependencies"],
             checkpoints=checkpoints,
             lock_hash=data.get("lock_hash"),
+            clusters=data.get("clusters"),
         )
 
 
-def is_verified(env: EnvironmentInfo, ckpt: CheckpointInfo) -> bool:
-    """Return True if checkpoint was verified after the env was last built."""
-    if ckpt.verified_at is None:
+def is_verified(env: EnvironmentInfo, ckpt: CheckpointInfo, cluster: str) -> bool:
+    """True if the checkpoint was verified on ``cluster`` after the env was
+    last built."""
+    verified_at = ckpt.verification(cluster).verified_at
+    if verified_at is None:
         return False
-    return ckpt.verified_at > env.built_at  # ISO 8601 sorts lexically
+    return verified_at > env.built_at  # ISO 8601 sorts lexically
 
 
 @dataclass
 class Manifest:
-    """Root manifest for a rootstock installation."""
+    """Root manifest for a rootstock installation.
+
+    One file per install, however many clusters mount it: build/fetch state
+    is genuinely shared, so splitting the file would just invite drift. The
+    per-cluster split happens at push time — see :func:`manifest_push_payload`.
+    """
 
     schema_version: int
-    cluster: str
+    clusters: list[str]  # every cluster this install serves; first = "home"
     root: str
     maintainer: Maintainer
     rootstock_version: str
@@ -310,7 +415,7 @@ class Manifest:
 
         return cls(
             schema_version=data["schema_version"],
-            cluster=data["cluster"],
+            clusters=list(data["clusters"]),
             root=data["root"],
             maintainer=Maintainer.from_dict(data["maintainer"]),
             rootstock_version=data["rootstock_version"],
@@ -329,8 +434,8 @@ class Manifest:
         # Check required fields
         if not self.schema_version:
             return False, "Missing schema_version"
-        if not self.cluster:
-            return False, "Missing cluster"
+        if not self.clusters:
+            return False, "Missing clusters"
         if not self.root:
             return False, "Missing root"
         if not self.maintainer.name:
@@ -339,6 +444,57 @@ class Manifest:
             return False, "Missing maintainer email"
 
         return True, "OK"
+
+
+def manifest_push_payload(manifest: Manifest, cluster: str) -> dict:
+    """Project the manifest into one cluster's wire payload.
+
+    The backend files each pushed payload under its single ``cluster`` string
+    and the almanac reads the flat pre-v6 checkpoint shape, and a per-cluster
+    projection *is* exactly the manifest a dedicated single-cluster install
+    would have written — so the wire format stays schema v5 and neither needs
+    any change. Envs that don't serve ``cluster`` are omitted; each
+    checkpoint carries only this cluster's verification state (its verify
+    error, or the shared download error when there is none).
+
+    Key order matters only cosmetically, but it is kept identical to a v5
+    manifest so dumps diff cleanly across the transition.
+    """
+    environments: dict[str, dict] = {}
+    for env_name, env in manifest.environments.items():
+        if not env.serves(cluster):
+            continue
+        checkpoints = {}
+        for ckpt_name, ckpt in env.checkpoints.items():
+            v = ckpt.verification(cluster)
+            checkpoints[ckpt_name] = {
+                "fetched_at": ckpt.fetched_at,
+                "verified_at": v.verified_at,
+                "verified_device": v.verified_device,
+                "last_error": v.last_error or ckpt.last_error,
+                "weight_files": ckpt.weight_files,
+                "weights_recorded_at": ckpt.weights_recorded_at,
+            }
+        environments[env_name] = {
+            "built_at": env.built_at,
+            "source_hash": env.source_hash,
+            "source": env.source,
+            "python_requires": env.python_requires,
+            "dependencies": env.dependencies,
+            "lock_hash": env.lock_hash,
+            "checkpoints": checkpoints,
+        }
+
+    return {
+        "schema_version": 5,  # the flat single-cluster shape the wire has always carried
+        "cluster": cluster,
+        "root": manifest.root,
+        "maintainer": manifest.maintainer.to_dict(),
+        "rootstock_version": manifest.rootstock_version,
+        "python_version": manifest.python_version,
+        "last_updated": manifest.last_updated,
+        "environments": environments,
+    }
 
 
 def compute_source_hash(source_path: Path) -> str:
@@ -634,7 +790,7 @@ def save_manifest(manifest: Manifest, root: Path) -> None:
 
 def create_manifest(
     root: Path,
-    cluster: str,
+    clusters: list[str],
     config: UserConfig,
 ) -> Manifest:
     """
@@ -642,7 +798,9 @@ def create_manifest(
 
     Args:
         root: Rootstock root directory
-        cluster: Cluster name (e.g., "delta", "perlmuter")
+        clusters: Every cluster this install serves (e.g. ["delta"], or
+            ["sophia", "polaris"] for a shared root); first entry is the
+            install's "home" cluster
         config: User config with maintainer info
 
     Returns:
@@ -652,7 +810,7 @@ def create_manifest(
 
     return Manifest(
         schema_version=SCHEMA_VERSION,
-        cluster=cluster,
+        clusters=list(clusters),
         root=str(root),
         maintainer=Maintainer(
             name=config.name or "Unknown",

--- a/rootstock/manifest.py
+++ b/rootstock/manifest.py
@@ -457,15 +457,38 @@ def manifest_push_payload(manifest: Manifest, cluster: str) -> dict:
     checkpoint carries only this cluster's verification state (its verify
     error, or the shared download error when there is none).
 
+    Cluster-specific variants shadow per id (#208): when a variant serving
+    ``cluster`` records a checkpoint id, the universal env's row for that id
+    is omitted from this cluster's payload. Smoke-test tests the variant's
+    copy there (checkpoint-first selection), so keeping the universal row
+    would advertise a permanently-unverified checkpoint. Shadowing reads the
+    manifest's *records*, not the source declarations — this stays a pure
+    function of the manifest, no disk access — so until the first
+    checkpoint-first smoke-test/add run on that cluster writes the variant's
+    record, an overridden id may transiently still appear under the universal
+    env; that gap self-heals on the first run. Equal specificity (two
+    universal envs, or two variants both serving the cluster) never shadows:
+    resolution errors on that authoring mistake anyway, and a loud duplicate
+    in the almanac beats silently dropping one.
+
     Key order matters only cosmetically, but it is kept identical to a v5
     manifest so dumps diff cleanly across the transition.
     """
+    # Ids recorded by cluster-specific envs serving this cluster — these
+    # shadow the universal envs' rows below.
+    variant_ids: set[str] = set()
+    for env in manifest.environments.values():
+        if env.clusters is not None and cluster in env.clusters:
+            variant_ids.update(env.checkpoints)
+
     environments: dict[str, dict] = {}
     for env_name, env in manifest.environments.items():
         if not env.serves(cluster):
             continue
         checkpoints = {}
         for ckpt_name, ckpt in env.checkpoints.items():
+            if env.clusters is None and ckpt_name in variant_ids:
+                continue
             v = ckpt.verification(cluster)
             checkpoints[ckpt_name] = {
                 "fetched_at": ckpt.fetched_at,

--- a/rootstock/operations.py
+++ b/rootstock/operations.py
@@ -31,12 +31,13 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from .client import RootstockClient
-from .clusters import get_cluster_for_root
+from .clusters import get_clusters_for_root
 from .config import load_config
 from .environment import (
     declares_setup_from_path,
     find_env_for_checkpoint,
     parse_checkpoints_dict,
+    parse_clusters_list,
     parse_custom_checkpoint_ids,
 )
 from .exceptions import RootstockError
@@ -45,6 +46,7 @@ from .manifest import (
     CheckpointInfo,
     EnvironmentInfo,
     Manifest,
+    VerificationRecord,
     built_at_estimate,
     create_manifest,
     get_installed_versions,
@@ -206,6 +208,14 @@ def refresh_manifest_environments(
         # Get checkpoints (from existing manifest if available)
         checkpoints = env.record.checkpoints if env.record else {}
 
+        # Mirror the source's CLUSTERS restriction (#208). A malformed
+        # declaration keeps the previous record rather than silently widening
+        # a variant to every cluster.
+        try:
+            env_clusters = parse_clusters_list(env.source_file)
+        except ValueError:
+            env_clusters = env.record.clusters if env.record else None
+
         if env_name == built_env:
             built_at = now_iso()
         elif env.record:
@@ -221,6 +231,7 @@ def refresh_manifest_environments(
             dependencies=dependencies,
             checkpoints=checkpoints,
             lock_hash=env.lock_hash,
+            clusters=env_clusters,
         )
 
     # The filesystem is the truth for what's installed: a record whose env
@@ -237,7 +248,7 @@ def refresh_manifest_environments(
 
 def update_and_push_manifest(
     root: Path,
-    cluster: str | None = None,
+    clusters: list[str] | None = None,
     quiet: bool = False,
     push: bool = True,
     built_env: str | None = None,
@@ -245,11 +256,13 @@ def update_and_push_manifest(
     """
     Update manifest with current state and optionally push to backend.
 
-    Called after any state-changing operation.
+    Called after any state-changing operation. The push sends one payload
+    per cluster the install serves (see ``manifest_push_payload``).
 
     Args:
         root: Rootstock root directory
-        cluster: Cluster name (optional, will try to detect)
+        clusters: Clusters the install serves (optional; detected from the
+            existing manifest, then the registry)
         quiet: Suppress output
         push: Whether to push to backend (default True)
         built_env: Env name that was (re)built by the calling command, if any;
@@ -267,14 +280,14 @@ def update_and_push_manifest(
     with manifest_lock(root):
         manifest = load_manifest(root)
 
-        # Determine cluster: provided > existing manifest > detect from path
-        if cluster is None:
+        # Determine clusters: provided > existing manifest > detect from path
+        if clusters is None:
             if manifest is not None:
-                cluster = manifest.cluster
+                clusters = manifest.clusters
             else:
-                cluster = get_cluster_for_root(root)
+                clusters = get_clusters_for_root(root)
 
-        if cluster is None:
+        if not clusters:
             if not quiet:
                 print(
                     "Warning: Cannot update manifest - cluster not specified and "
@@ -286,7 +299,7 @@ def update_and_push_manifest(
 
         # Create manifest if it doesn't exist
         if manifest is None:
-            manifest = create_manifest(root, cluster, config)
+            manifest = create_manifest(root, clusters, config)
 
         # Refresh environment info from current state
         manifest = refresh_manifest_environments(manifest, root, built_env=built_env)
@@ -1049,6 +1062,45 @@ def apply_weights_record(
     _say(progress, f"  recorded {len(files)} weight files ({total / 1e6:.0f} MB)")
 
 
+def resolve_current_cluster(root: Path, cluster: str | None = None) -> str:
+    """The cluster name verification results should be recorded under.
+
+    Explicit wins; otherwise the manifest's (or registry's) sole cluster.
+    On a shared install (several clusters, e.g. sophia/polaris) there is no
+    honest default — the caller must say which machine it is on, or results
+    get attributed to the wrong cluster (#208).
+
+    Raises OperationError when ambiguous, or when an explicit name isn't one
+    the install serves (a typo would otherwise mint a new verification key).
+    """
+    known = None
+    manifest = load_manifest(root)
+    if manifest is not None:
+        known = manifest.clusters
+    if not known:
+        known = get_clusters_for_root(root)
+
+    if cluster is not None:
+        if known and cluster not in known:
+            raise OperationError(
+                f"cluster '{cluster}' is not one this install serves "
+                f"({', '.join(known)}). Re-run 'rootstock manifest init' if "
+                f"the install now serves it."
+            )
+        return cluster
+    if len(known) == 1:
+        return known[0]
+    if not known:
+        # Matches the "unknown" identity _manifest_transaction mints when no
+        # manifest exists and the root isn't registered.
+        return "unknown"
+    raise OperationError(
+        f"this install serves several clusters ({', '.join(known)}) — pass "
+        f"--cluster (cluster= in Python) to record results for the machine "
+        f"you are on."
+    )
+
+
 @contextmanager
 def _manifest_transaction(root: Path, cluster_hint: str | None = None):
     """Lock → load-fresh (or create) → yield → save-once → unlock.
@@ -1062,7 +1114,8 @@ def _manifest_transaction(root: Path, cluster_hint: str | None = None):
         manifest = load_manifest(root)
         if manifest is None:
             config = load_config()
-            manifest = create_manifest(root, cluster_hint or "unknown", config)
+            clusters = get_clusters_for_root(root) or [cluster_hint or "unknown"]
+            manifest = create_manifest(root, clusters, config)
         yield manifest
         save_manifest(manifest, root)
 
@@ -1102,11 +1155,11 @@ def _ensure_manifest_entry(
     return env, env.checkpoints[checkpoint]
 
 
-def _resolve_built_env(root: Path, checkpoint: str) -> str:
+def _resolve_built_env(root: Path, checkpoint: str, cluster: str | None = None) -> str:
     """Resolve the hosting env for a checkpoint id, failing fast when it
     isn't built (checked again inside each transaction by
     :func:`_ensure_manifest_entry`, whose refresh needs it too)."""
-    env_name, _ = find_env_for_checkpoint(root, checkpoint)
+    env_name, _ = find_env_for_checkpoint(root, checkpoint, cluster)
     env_dir = root / "envs" / env_name
     if not (env_dir / "bin" / "python").exists():
         raise OperationError(
@@ -1125,6 +1178,7 @@ def fetch_checkpoint(
     refresh: bool = True,
     push: bool = True,
     force: bool = False,
+    cluster: str | None = None,
     progress: Progress | None = None,
 ) -> FetchResult:
     """
@@ -1145,6 +1199,10 @@ def fetch_checkpoint(
     that stamped anyway). The underlying download is cache-aware, so a
     forced fetch of an intact checkpoint costs a cache hit, not a transfer.
 
+    ``cluster`` only matters for resolving cluster-specific env variants
+    (CLUSTERS, #208) — the fetch itself is shared: one weights cache,
+    however many machines mount it.
+
     Raises CheckpointNotFoundError when no installed env declares the id,
     and OperationError when the download fails (also recorded in the
     manifest's ``last_error``).
@@ -1154,7 +1212,7 @@ def fetch_checkpoint(
     if cache_root is None:
         cache_root = resolve_cache_root(root)
 
-    env_name = _resolve_built_env(root, checkpoint)
+    env_name = _resolve_built_env(root, checkpoint, cluster)
 
     # Unlocked peek for idempotence; every write below loads fresh inside
     # its own transaction, so a racing writer costs at most a redundant
@@ -1220,6 +1278,7 @@ def verify_fetched_checkpoint(
     cache_root: Path | None = None,
     refresh: bool = True,
     push: bool = True,
+    cluster: str | None = None,
     progress: Progress | None = None,
     timeout: float = DEFAULT_VERIFY_TIMEOUT,
 ) -> VerifyResult:
@@ -1233,10 +1292,12 @@ def verify_fetched_checkpoint(
     ``device``, so a batch driver must bound its concurrency, unlike the
     freely-parallel fetch.
 
-    Success stamps ``verified_at``/``verified_device`` and clears
-    ``last_error``; failure clears the verified stamps and records the error.
-    ``refresh=False`` skips the trailing full manifest refresh (+ push), for
-    batch drivers that refresh once at the end.
+    The outcome is recorded under the current cluster's verification record
+    (#208): success stamps ``verified_at``/``verified_device``, failure
+    clears them and records the error. On a shared install ``cluster`` is
+    required — see :func:`resolve_current_cluster`. ``refresh=False`` skips
+    the trailing full manifest refresh (+ push), for batch drivers that
+    refresh once at the end.
 
     Raises CheckpointNotFoundError when no installed env declares the id,
     and OperationError when verification fails.
@@ -1246,7 +1307,8 @@ def verify_fetched_checkpoint(
     if cache_root is None:
         cache_root = resolve_cache_root(root)
 
-    env_name = _resolve_built_env(root, checkpoint)
+    cluster = resolve_current_cluster(root, cluster)
+    env_name = _resolve_built_env(root, checkpoint, cluster)
 
     # ---- Verify (runs outside the lock) ---------------------------------
     _say(progress, f"Verifying {env_name}/{checkpoint} on {device}...")
@@ -1265,14 +1327,12 @@ def verify_fetched_checkpoint(
     with _manifest_transaction(root) as manifest:
         _, ckpt = _ensure_manifest_entry(manifest, root, env_name, checkpoint)
         if ok:
-            ckpt.verified_at = now_iso()
-            ckpt.verified_device = device
-            ckpt.last_error = None
-            verified_at = ckpt.verified_at
+            verified_at = now_iso()
+            ckpt.verifications[cluster] = VerificationRecord(
+                verified_at=verified_at, verified_device=device
+            )
         else:
-            ckpt.verified_at = None
-            ckpt.verified_device = None
-            ckpt.last_error = f"verify: {err}"
+            ckpt.verifications[cluster] = VerificationRecord(last_error=f"verify: {err}")
         # Recorded even when verification fails: the capture only exists if
         # setup() completed, and the load working set it saw is real whether
         # or not the forward pass then produced good forces.
@@ -1281,7 +1341,7 @@ def verify_fetched_checkpoint(
         )
     if not ok:
         raise OperationError(f"verify failed: {err}")
-    _say(progress, f"  verified_at = {verified_at} ({device})")
+    _say(progress, f"  verified_at = {verified_at} ({device}, cluster {cluster})")
 
     if refresh:
         # Refresh + push (takes the lock for its own load -> refresh -> save)
@@ -1303,6 +1363,7 @@ def add_checkpoint(
     verify: bool = True,
     push: bool = True,
     force: bool = False,
+    cluster: str | None = None,
     setup_kwargs: dict | None = None,
     cache_root: Path | None = None,
     progress: Progress | None = None,
@@ -1330,6 +1391,11 @@ def add_checkpoint(
     if cache_root is None:
         cache_root = resolve_cache_root(root)
 
+    if verify:
+        # Resolve the identity up front so a missing --cluster on a shared
+        # install fails before the download, not after it.
+        cluster = resolve_current_cluster(root, cluster)
+
     fetched = fetch_checkpoint(
         root,
         checkpoint,
@@ -1337,6 +1403,7 @@ def add_checkpoint(
         cache_root=cache_root,
         refresh=False,
         force=force,
+        cluster=cluster,
         progress=progress,
     )
 
@@ -1351,6 +1418,7 @@ def add_checkpoint(
             setup_kwargs=setup_kwargs,
             cache_root=cache_root,
             refresh=False,
+            cluster=cluster,
             progress=progress,
             timeout=verify_timeout,
         )

--- a/rootstock/server.py
+++ b/rootstock/server.py
@@ -99,6 +99,7 @@ class RootstockServer:
         checkpoint_path: str | None = None,
         usage_client: str | None = "calculator",
         weights_capture_path: str | None = None,
+        cluster: str | None = None,
     ):
         """
         Initialize the server.
@@ -134,6 +135,9 @@ class RootstockServer:
                 path the moment the load completes (see weights_capture.py).
                 Verification uses this to keep per-checkpoint weight records
                 fresh in the manifest (#177).
+            cluster: Cluster name for the usage record. On a shared install
+                (sophia/polaris) the root reverse-maps to no single cluster,
+                so the caller's knowledge is the only honest source (#208).
         """
         if root is None:
             raise ValueError("root is required for pre-built environments")
@@ -154,6 +158,7 @@ class RootstockServer:
         self.setup_kwargs = setup_kwargs or {}
         self.usage_client = usage_client
         self.weights_capture_path = weights_capture_path
+        self.cluster = cluster
 
         self._server_socket: socket.socket | None = None
         self._client_socket: socket.socket | None = None
@@ -485,6 +490,7 @@ class RootstockServer:
             started_at=started_at,
             duration_s=duration_s,
             n_calculations=self._n_calculations,
+            cluster=self.cluster,
         )
 
     def stop(self):

--- a/rootstock/usage.py
+++ b/rootstock/usage.py
@@ -112,6 +112,7 @@ def record_session(
     started_at: str,
     duration_s: float,
     n_calculations: int | None,
+    cluster: str | None = None,
 ) -> Path | None:
     """Best-effort: write one usage record for a finished worker session.
 
@@ -119,8 +120,11 @@ def record_session(
     spool directory not provisioned, or any error at all. Never raises.
 
     Args:
-        root: Install root (identifies "where" alongside the cluster name,
-            which is reverse-looked-up from it).
+        root: Install root (identifies "where" alongside the cluster name).
+        cluster: Cluster the session ran on, when the caller knows it (the
+            user's ``cluster=`` / ``--cluster``). Falls back to a reverse
+            lookup from ``root`` — which is honest only for single-cluster
+            roots; a shared root (sophia/polaris) reverse-maps to None (#208).
         cache_root: Resolved cache root; the spool lives under it.
         env_name: Pre-built environment that hosted the session.
         checkpoint: The checkpoint id, recorded verbatim. Both forms are
@@ -154,7 +158,7 @@ def record_session(
             "schema_version": RECORD_SCHEMA_VERSION,
             "started_at": started_at,
             "duration_s": round(duration_s, 1),
-            "cluster": get_cluster_for_root(root),
+            "cluster": cluster or get_cluster_for_root(root),
             "root": str(root),
             "env": env_name,
             "checkpoint": checkpoint,

--- a/scripts/nightly_smoke_test.pbs
+++ b/scripts/nightly_smoke_test.pbs
@@ -36,6 +36,11 @@ set -euo pipefail
 # --- Knobs (override via env: qsub -v VAR=val) ------------------------------
 export ROOTSTOCK_ROOT="${ROOTSTOCK_ROOT:-/CHANGEME/path/to/rootstock}"
 
+# Cluster this chain runs on. REQUIRED on shared installs (sophia/polaris
+# serve one root): each machine's chain must record and push results under
+# its own name. Leave empty on single-cluster installs.
+CLUSTER="${CLUSTER:-}"
+
 # Cadence. Default weekly at RUN_HOUR, drift-free wall-clock (not "now+24h").
 # Set CADENCE_DAYS=1 for nightly. PBS -a takes [[CC]YY]MMDDhhmm.
 CADENCE_DAYS="${CADENCE_DAYS:-7}"
@@ -87,11 +92,23 @@ fi
 #   source ~/.venvs/rootstock/bin/activate
 
 nvidia-smi | head -4 || true
-echo "=== rootstock smoke-test (root=$ROOTSTOCK_ROOT) ==="
+echo "=== rootstock smoke-test (root=$ROOTSTOCK_ROOT cluster=${CLUSTER:-<default>}) ==="
+
+# Feature-detect --cluster (ships in the release carrying manifest schema
+# v6) so a not-yet-upgraded CLI generation still runs.
+cluster_args=()
+if [[ -n "$CLUSTER" ]]; then
+  if rootstock smoke-test --help 2>/dev/null | grep -q -- '--cluster'; then
+    cluster_args=(--cluster "$CLUSTER")
+  else
+    echo "WARNING: this rootstock predates --cluster; results record under the manifest default." >&2
+  fi
+fi
 
 # Re-verify every fetched checkpoint on GPU and PUSH the manifest (no
 # --no-push): unattended substitute for CI, must leave the backend as CI would.
 rootstock smoke-test \
   --device cuda \
+  ${cluster_args[@]+"${cluster_args[@]}"} \
   --json \
   | tee "rootstock-nightly-${PBS_JOBID:-manual}.json"

--- a/scripts/nightly_smoke_test.sbatch
+++ b/scripts/nightly_smoke_test.sbatch
@@ -37,6 +37,11 @@ set -euo pipefail
 # manifest.json here. Required.
 export ROOTSTOCK_ROOT="${ROOTSTOCK_ROOT:-/CHANGEME/path/to/rootstock}"
 
+# Cluster this chain runs on. REQUIRED on shared installs (e.g. two machines
+# mounting one root): each machine's chain must record and push results under
+# its own name. Leave empty on single-cluster installs.
+CLUSTER="${CLUSTER:-}"
+
 # Cadence. Default weekly: drift-free wall-clock time CADENCE_DAYS ahead at
 # RUN_HOUR (not "now+24h", which would creep later every run). Set
 # CADENCE_DAYS=1 for nightly. RESCHEDULE_BEGIN overrides the whole computation
@@ -96,7 +101,18 @@ fi
 #   source ~/.venvs/rootstock/bin/activate
 
 nvidia-smi | head -4 || true
-echo "=== rootstock smoke-test (root=$ROOTSTOCK_ROOT) ==="
+echo "=== rootstock smoke-test (root=$ROOTSTOCK_ROOT cluster=${CLUSTER:-<default>}) ==="
+
+# Feature-detect --cluster (ships in the release carrying manifest schema
+# v6) so a not-yet-upgraded CLI generation still runs.
+cluster_args=()
+if [[ -n "$CLUSTER" ]]; then
+  if rootstock smoke-test --help 2>/dev/null | grep -q -- '--cluster'; then
+    cluster_args=(--cluster "$CLUSTER")
+  else
+    echo "WARNING: this rootstock predates --cluster; results record under the manifest default." >&2
+  fi
+fi
 
 # Re-verify every fetched checkpoint on GPU and PUSH the manifest (no
 # --no-push): this is an unattended substitute for CI and must leave the
@@ -104,5 +120,6 @@ echo "=== rootstock smoke-test (root=$ROOTSTOCK_ROOT) ==="
 # alongside the streaming SLURM .out log.
 rootstock smoke-test \
   --device cuda \
+  ${cluster_args[@]+"${cluster_args[@]}"} \
   --json \
   | tee "rootstock-nightly-${SLURM_JOB_ID:-manual}.json"

--- a/tests/cli/test_add.py
+++ b/tests/cli/test_add.py
@@ -74,7 +74,7 @@ def fake_root(tmp_path: Path, monkeypatch) -> Path:
     from rootstock.manifest import create_manifest, save_manifest
 
     cfg = UserConfig(name="t", email="t@t.t")
-    save_manifest(create_manifest(root, "test", cfg), root)
+    save_manifest(create_manifest(root, ["test"], cfg), root)
 
     # Stub update_and_push_manifest — not under test here.
     monkeypatch.setattr(
@@ -98,6 +98,7 @@ def _make_args(root: Path, **overrides):
     args.force = overrides.get("force", False)
     args.root = str(root)
     args.no_push = overrides.get("no_push", True)
+    args.cluster = overrides.get("cluster")
     return args
 
 
@@ -110,7 +111,7 @@ def test_add_no_verify_sets_fetched_at(fake_root, monkeypatch):
     m = load_manifest(fake_root)
     ckpt = m.environments["mace"].checkpoints["mace-mp-0-medium"]
     assert ckpt.fetched_at is not None
-    assert ckpt.verified_at is None
+    assert ckpt.verification("test").verified_at is None
     assert ckpt.last_error is None
 
 
@@ -170,9 +171,11 @@ def test_add_then_add_is_idempotent(fake_root, monkeypatch):
     m = load_manifest(fake_root)
     ckpt = m.environments["mace"].checkpoints["mace-mp-0-medium"]
     assert ckpt.fetched_at is not None
-    assert ckpt.verified_at is not None
-    assert ckpt.verified_device == "cuda"
+    record = ckpt.verification("test")
+    assert record.verified_at is not None
+    assert record.verified_device == "cuda"
     assert ckpt.last_error is None
+    assert record.last_error is None
 
 
 def test_add_force_redownloads(fake_root, monkeypatch):
@@ -221,10 +224,11 @@ def test_add_records_verify_failure_and_returns_1(fake_root, monkeypatch):
     m = load_manifest(fake_root)
     ckpt = m.environments["mace"].checkpoints["mace-mp-0-medium"]
     assert ckpt.fetched_at is not None  # download succeeded, was preserved
-    assert ckpt.verified_at is None
-    assert ckpt.verified_device is None
-    assert "CUDA OOM" in ckpt.last_error
-    assert ckpt.last_error.startswith("verify:")
+    record = ckpt.verification("test")
+    assert record.verified_at is None
+    assert record.verified_device is None
+    assert "CUDA OOM" in record.last_error
+    assert record.last_error.startswith("verify:")
 
 
 def test_add_clears_last_error_on_success(fake_root, monkeypatch):
@@ -239,7 +243,8 @@ def test_add_clears_last_error_on_success(fake_root, monkeypatch):
     cmd_add(_make_args(fake_root, no_verify=False))
 
     m = load_manifest(fake_root)
-    assert m.environments["mace"].checkpoints["mace-mp-0-medium"].last_error is not None
+    ckpt = m.environments["mace"].checkpoints["mace-mp-0-medium"]
+    assert ckpt.verification("test").last_error is not None
 
     # Second attempt: verify succeeds. last_error should clear.
     monkeypatch.setattr(operations, "verify_checkpoint", lambda *a, **kw: (True, None))
@@ -247,7 +252,9 @@ def test_add_clears_last_error_on_success(fake_root, monkeypatch):
     assert rc == 0
 
     m = load_manifest(fake_root)
-    assert m.environments["mace"].checkpoints["mace-mp-0-medium"].last_error is None
+    ckpt = m.environments["mace"].checkpoints["mace-mp-0-medium"]
+    assert ckpt.verification("test").last_error is None
+    assert ckpt.last_error is None
 
 
 def test_add_forwards_kwargs_to_download_and_verify(fake_root, monkeypatch):
@@ -286,7 +293,9 @@ def test_add_errors_when_no_envs_installed(tmp_path):
     from rootstock.config import UserConfig
     from rootstock.manifest import create_manifest, save_manifest
 
-    save_manifest(create_manifest(tmp_path, "test", UserConfig(name="t", email="t@t.t")), tmp_path)
+    save_manifest(
+        create_manifest(tmp_path, ["test"], UserConfig(name="t", email="t@t.t")), tmp_path
+    )
 
     rc = cmd_add(_make_args(tmp_path, checkpoint="mace-mp-0-medium", no_verify=True))
     assert rc == 1

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -36,7 +36,7 @@ def _wire_fake_worker(monkeypatch, returncode=0):
     monkeypatch.setattr("rootstock.spawn.spawn_in_env", fake_spawn)
     monkeypatch.setattr(
         "rootstock.environment.resolve_checkpoint",
-        lambda root, ckpt: ResolvedCheckpoint(checkpoint=ckpt, env_name="mace"),
+        lambda root, ckpt, cluster=None: ResolvedCheckpoint(checkpoint=ckpt, env_name="mace"),
     )
     monkeypatch.setattr("rootstock.environment.get_env_python", lambda root, env: "python")
     monkeypatch.setattr(

--- a/tests/cli/test_smoke_test.py
+++ b/tests/cli/test_smoke_test.py
@@ -30,7 +30,7 @@ def populated_root(tmp_path: Path, monkeypatch) -> Path:
         (root / "envs" / env / "bin" / "python").touch()
 
     cfg = UserConfig(name="t", email="t@t.t")
-    manifest = create_manifest(root, "test", cfg)
+    manifest = create_manifest(root, ["test"], cfg)
 
     manifest.environments["mace"] = EnvironmentInfo(
         built_at="2026-01-01T00:00:00Z",
@@ -75,6 +75,7 @@ def _make_args(root: Path, **overrides):
     args.json = overrides.get("json", False)
     args.root = str(root)
     args.no_push = overrides.get("no_push", True)
+    args.cluster = overrides.get("cluster")
     return args
 
 
@@ -139,10 +140,10 @@ def test_smoke_test_marks_pass_and_fail(populated_root, monkeypatch):
     m = load_manifest(populated_root)
     medium = m.environments["mace"].checkpoints["mace-mp-0-medium"]
     small = m.environments["mace"].checkpoints["mace-mp-0-small"]
-    assert medium.verified_at is None
-    assert "smoke-test:" in medium.last_error
-    assert small.verified_at is not None
-    assert small.last_error is None
+    assert medium.verification("test").verified_at is None
+    assert "smoke-test:" in medium.verification("test").last_error
+    assert small.verification("test").verified_at is not None
+    assert small.verification("test").last_error is None
 
 
 def test_smoke_test_returns_zero_when_all_pass(populated_root, monkeypatch):
@@ -211,10 +212,12 @@ def test_smoke_test_emits_valid_json(populated_root, monkeypatch, capsys):
 
     out = capsys.readouterr().out.strip()
     parsed = json.loads(out)
+    assert parsed["cluster"] == "test"
     assert parsed["passed"] >= 1
     assert parsed["failed"] == 0
     assert isinstance(parsed["results"], list)
     assert all("verified_current" in r for r in parsed["results"])
+    assert all(r["cluster"] == "test" for r in parsed["results"])
 
 
 def test_smoke_test_no_manifest_returns_1(tmp_path, capsys):
@@ -225,7 +228,7 @@ def test_smoke_test_no_manifest_returns_1(tmp_path, capsys):
 def test_smoke_test_empty_selection_returns_0(tmp_path, monkeypatch):
     """Manifest exists but has no fetched checkpoints — clean exit, no failures."""
     cfg = UserConfig(name="t", email="t@t.t")
-    save_manifest(create_manifest(tmp_path, "test", cfg), tmp_path)
+    save_manifest(create_manifest(tmp_path, ["test"], cfg), tmp_path)
     monkeypatch.setattr(
         "rootstock.commands.smoke_test.update_and_push_manifest", lambda *a, **kw: True
     )
@@ -294,7 +297,7 @@ def custom_root(tmp_path: Path, monkeypatch) -> Path:
         path.write_bytes(b"weights")
 
     cfg = UserConfig(name="t", email="t@t.t")
-    manifest = create_manifest(root, "test", cfg)
+    manifest = create_manifest(root, ["test"], cfg)
     manifest.environments["uma"] = EnvironmentInfo(
         built_at="2026-01-01T00:00:00Z",
         source_hash="sha256:abc",
@@ -365,8 +368,10 @@ def test_custom_leg_verifies_and_records(custom_root, monkeypatch):
 
     m = load_manifest(custom_root)
     custom = m.environments["uma"].checkpoints["uma:custom"]
-    assert custom.verified_at is not None
-    assert custom.verified_device == "cuda"
+    record = custom.verification("test")
+    assert record.verified_at is not None
+    assert record.verified_device == "cuda"
+    assert record.last_error is None
     assert custom.last_error is None
     assert custom.fetched_at is None  # never fetched — the user supplies weights
 
@@ -389,8 +394,9 @@ def test_custom_leg_pairs_each_family_with_its_base(custom_root, monkeypatch):
     )
 
     m = load_manifest(custom_root)
-    assert m.environments["mace"].checkpoints["mace:custom"].verified_at is not None
-    assert m.environments["mace"].checkpoints["mace-off:custom"].verified_at is not None
+    ckpts = m.environments["mace"].checkpoints
+    assert ckpts["mace:custom"].verification("test").verified_at is not None
+    assert ckpts["mace-off:custom"].verification("test").verified_at is not None
 
 
 def test_custom_leg_divergence_fails_and_records_error(custom_root, monkeypatch):
@@ -404,11 +410,11 @@ def test_custom_leg_divergence_fails_and_records_error(custom_root, monkeypatch)
     assert cmd_smoke_test(_make_args(custom_root, env="uma")) == 1
 
     custom = load_manifest(custom_root).environments["uma"].checkpoints["uma:custom"]
-    assert custom.verified_at is None
-    assert "diverges" in custom.last_error
+    assert custom.verification("test").verified_at is None
+    assert "diverges" in custom.verification("test").last_error
     # The canonical baseline itself passed.
     base = load_manifest(custom_root).environments["uma"].checkpoints["uma-s-1p1"]
-    assert base.verified_at is not None
+    assert base.verification("test").verified_at is not None
 
 
 def test_custom_leg_skipped_when_baseline_fails(custom_root, monkeypatch, capsys):
@@ -492,7 +498,7 @@ def test_select_never_picks_custom_manifest_entries(custom_root):
     m.environments["uma"].checkpoints["uma:custom"] = CheckpointInfo(
         fetched_at="2026-01-02T00:00:00Z"
     )
-    selected = smoke_module._select(m, None, None)
+    selected = smoke_module._select(custom_root, m, None, None, "test")
     assert all(name != "uma:custom" for _, name, _, _ in selected)
 
 

--- a/tests/cli/test_smoke_test.py
+++ b/tests/cli/test_smoke_test.py
@@ -498,7 +498,7 @@ def test_select_never_picks_custom_manifest_entries(custom_root):
     m.environments["uma"].checkpoints["uma:custom"] = CheckpointInfo(
         fetched_at="2026-01-02T00:00:00Z"
     )
-    selected = smoke_module._select(custom_root, m, None, None, "test")
+    selected, _skips = smoke_module._select(custom_root, m, None, None, "test")
     assert all(name != "uma:custom" for _, name, _, _ in selected)
 
 

--- a/tests/cli/test_smoke_test_clusters.py
+++ b/tests/cli/test_smoke_test_clusters.py
@@ -1,12 +1,15 @@
 """``rootstock smoke-test`` on shared installs (#208).
 
 The command must refuse to guess which machine it is on, record outcomes
-under the named cluster without touching the sibling's records, and skip
-envs restricted to other clusters.
+under the named cluster without touching the sibling's records, and select
+checkpoint-first: each canonical id is tested in the env it resolves to on
+the current cluster, so a cluster-specific variant shadows the universal
+env per id.
 """
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -23,43 +26,75 @@ from rootstock.manifest import (
 )
 
 SOPHIA_STAMP = "2026-07-01T00:00:00+00:00"
+FETCH_STAMP = "2026-01-02T00:00:00Z"
+
+MACE_SOURCE = """CHECKPOINTS = {"mace-mp-0-small": "small", "mace-mp-0-medium": "medium"}
+
+def setup(checkpoint, device="cuda"):
+    return None
+"""
+
+MACE_POLARIS_SOURCE = """CLUSTERS = ["polaris"]
+CHECKPOINTS = {"mace-mp-0-medium": "medium"}
+
+def setup(checkpoint, device="cuda"):
+    return None
+"""
+
+SEVENNET_SOURCE = """CLUSTERS = ["sophia"]
+CHECKPOINTS = {"sevennet-0": "0"}
+
+def setup(checkpoint, device="cuda"):
+    return None
+"""
 
 
-@pytest.fixture
-def shared_root(tmp_path: Path, monkeypatch) -> Path:
-    """A sophia/polaris install: one universal env with a checkpoint already
-    verified on sophia, and one sophia-only env."""
-    root = tmp_path
-    for env in ("mace", "sevennet"):
-        (root / "envs" / env / "bin").mkdir(parents=True)
-        (root / "envs" / env / "bin" / "python").touch()
+def _install(root: Path, name: str, source: str) -> None:
+    env_dir = root / "envs" / name
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+    (env_dir / "env_source.py").write_text(source)
 
-    manifest = create_manifest(root, ["sophia", "polaris"], UserConfig(name="t", email="t@t.t"))
-    manifest.environments["mace"] = EnvironmentInfo(
+
+def _env_info(clusters: list[str] | None = None, checkpoints=None) -> EnvironmentInfo:
+    return EnvironmentInfo(
         built_at="2026-01-01T00:00:00Z",
         source_hash="sha256:abc",
         source="",
         python_requires=">=3.10",
         dependencies={},
+        clusters=clusters,
+        checkpoints=checkpoints or {},
+    )
+
+
+@pytest.fixture
+def shared_root(tmp_path: Path, monkeypatch) -> Path:
+    """A sophia/polaris install: universal mace (small + medium fetched,
+    medium already verified on sophia), a polaris-only variant overriding
+    medium (built, but with no manifest records yet), and a sophia-only
+    sevennet."""
+    root = tmp_path
+    _install(root, "mace", MACE_SOURCE)
+    _install(root, "mace-polaris", MACE_POLARIS_SOURCE)
+    _install(root, "sevennet", SEVENNET_SOURCE)
+
+    manifest = create_manifest(root, ["sophia", "polaris"], UserConfig(name="t", email="t@t.t"))
+    manifest.environments["mace"] = _env_info(
         checkpoints={
+            "mace-mp-0-small": CheckpointInfo(fetched_at=FETCH_STAMP),
             "mace-mp-0-medium": CheckpointInfo(
-                fetched_at="2026-01-02T00:00:00Z",
+                fetched_at=FETCH_STAMP,
                 verifications={
                     "sophia": VerificationRecord(verified_at=SOPHIA_STAMP, verified_device="cuda")
                 },
             ),
         },
     )
-    manifest.environments["sevennet"] = EnvironmentInfo(
-        built_at="2026-01-01T00:00:00Z",
-        source_hash="sha256:def",
-        source="",
-        python_requires=">=3.10",
-        dependencies={},
+    manifest.environments["mace-polaris"] = _env_info(clusters=["polaris"])
+    manifest.environments["sevennet"] = _env_info(
         clusters=["sophia"],
-        checkpoints={
-            "sevennet-0": CheckpointInfo(fetched_at="2026-01-02T00:00:00Z"),
-        },
+        checkpoints={"sevennet-0": CheckpointInfo(fetched_at=FETCH_STAMP)},
     )
     save_manifest(manifest, root)
 
@@ -117,10 +152,15 @@ def test_polaris_run_records_under_polaris_only(shared_root, monkeypatch):
     rc = cmd_smoke_test(_args(shared_root, cluster="polaris"))
     assert rc == 0
 
-    ckpt = load_manifest(shared_root).environments["mace"].checkpoints["mace-mp-0-medium"]
-    assert ckpt.verification("polaris").verified_at is not None
+    manifest = load_manifest(shared_root)
+    # The overridden id lands on the variant's record (checkpoint-first);
+    # the universal env's record gains no polaris entry.
+    variant = manifest.environments["mace-polaris"].checkpoints["mace-mp-0-medium"]
+    assert variant.verification("polaris").verified_at is not None
+    medium = manifest.environments["mace"].checkpoints["mace-mp-0-medium"]
+    assert medium.verification("polaris").verified_at is None
     # sophia's earlier result must survive the polaris run untouched.
-    assert ckpt.verification("sophia").verified_at == SOPHIA_STAMP
+    assert medium.verification("sophia").verified_at == SOPHIA_STAMP
 
 
 def test_polaris_failure_does_not_unverify_sophia(shared_root, monkeypatch):
@@ -128,10 +168,83 @@ def test_polaris_failure_does_not_unverify_sophia(shared_root, monkeypatch):
     rc = cmd_smoke_test(_args(shared_root, cluster="polaris"))
     assert rc == 1
 
-    ckpt = load_manifest(shared_root).environments["mace"].checkpoints["mace-mp-0-medium"]
-    assert ckpt.verification("polaris").verified_at is None
-    assert ckpt.verification("polaris").last_error == "smoke-test: CUDA OOM"
-    assert ckpt.verification("sophia").verified_at == SOPHIA_STAMP
+    manifest = load_manifest(shared_root)
+    variant = manifest.environments["mace-polaris"].checkpoints["mace-mp-0-medium"]
+    assert variant.verification("polaris").verified_at is None
+    assert variant.verification("polaris").last_error == "smoke-test: CUDA OOM"
+    medium = manifest.environments["mace"].checkpoints["mace-mp-0-medium"]
+    assert medium.verification("sophia").verified_at == SOPHIA_STAMP
+
+
+def test_variant_shadows_universal_per_id(shared_root, monkeypatch):
+    """polaris tests the overridden id via the variant only; the id the
+    variant doesn't declare still runs via the universal env. sophia is
+    untouched by the variant."""
+    calls = _stub_verify(monkeypatch)
+    cmd_smoke_test(_args(shared_root, cluster="polaris"))
+    assert sorted(calls) == [
+        ("mace", "mace-mp-0-small"),
+        ("mace-polaris", "mace-mp-0-medium"),
+    ]
+
+    calls.clear()
+    cmd_smoke_test(_args(shared_root, cluster="sophia"))
+    assert sorted(calls) == [
+        ("mace", "mace-mp-0-medium"),
+        ("mace", "mace-mp-0-small"),
+        ("sevennet", "sevennet-0"),
+    ]
+
+
+def test_variant_inherits_fetched_at_from_universal_record(shared_root, monkeypatch):
+    """The variant had no record of the id at all — the shared cache means
+    'fetched anywhere = fetched', and the new record inherits the donor's
+    fetch stamp instead of reading 'verified but never fetched'."""
+    _stub_verify(monkeypatch)
+    assert cmd_smoke_test(_args(shared_root, cluster="polaris")) == 0
+
+    variant = load_manifest(shared_root).environments["mace-polaris"]
+    record = variant.checkpoints["mace-mp-0-medium"]
+    assert record.fetched_at == FETCH_STAMP
+    assert record.verification("polaris").verified_at is not None
+
+
+def test_env_filter_means_resolves_to_that_env(shared_root, monkeypatch):
+    calls = _stub_verify(monkeypatch)
+    cmd_smoke_test(_args(shared_root, cluster="polaris", env="mace"))
+    # medium resolves to the variant on polaris, so --env mace keeps only small.
+    assert calls == [("mace", "mace-mp-0-small")]
+
+    calls.clear()
+    cmd_smoke_test(_args(shared_root, cluster="polaris", env="mace-polaris"))
+    assert calls == [("mace-polaris", "mace-mp-0-medium")]
+
+
+def test_ambiguous_id_is_skipped_not_fatal(shared_root, monkeypatch, capsys):
+    """Two same-specificity envs declaring one id is an authoring error; the
+    nightly run must report it and keep testing everything else."""
+    dup = 'CHECKPOINTS = {"dup-0": "0"}\n\ndef setup(checkpoint, device="cuda"):\n    return None\n'
+    _install(shared_root, "dup-a", dup)
+    _install(shared_root, "dup-b", dup)
+    manifest = load_manifest(shared_root)
+    manifest.environments["dup-a"] = _env_info(
+        checkpoints={"dup-0": CheckpointInfo(fetched_at=FETCH_STAMP)}
+    )
+    manifest.environments["dup-b"] = _env_info()
+    save_manifest(manifest, shared_root)
+
+    _stub_verify(monkeypatch)
+    rc = cmd_smoke_test(_args(shared_root, cluster="polaris", json=True))
+    assert rc == 0  # skips never affect the exit code
+
+    parsed = json.loads(capsys.readouterr().out.strip())
+    assert {r["checkpoint"] for r in parsed["results"]} == {
+        "mace-mp-0-small",
+        "mace-mp-0-medium",
+    }
+    (skip,) = parsed["skipped"]
+    assert skip["checkpoint"] == "dup-0"
+    assert "several envs" in skip["reason"]
 
 
 def test_cluster_restricted_env_is_skipped_elsewhere(shared_root, monkeypatch):
@@ -150,13 +263,8 @@ def test_single_cluster_install_needs_no_flag(tmp_path, monkeypatch):
     (root / "envs" / "mace" / "bin").mkdir(parents=True)
     (root / "envs" / "mace" / "bin" / "python").touch()
     manifest = create_manifest(root, ["della"], UserConfig(name="t", email="t@t.t"))
-    manifest.environments["mace"] = EnvironmentInfo(
-        built_at="2026-01-01T00:00:00Z",
-        source_hash="sha256:abc",
-        source="",
-        python_requires=">=3.10",
-        dependencies={},
-        checkpoints={"mace-mp-0-medium": CheckpointInfo(fetched_at="2026-01-02T00:00:00Z")},
+    manifest.environments["mace"] = _env_info(
+        checkpoints={"mace-mp-0-medium": CheckpointInfo(fetched_at=FETCH_STAMP)}
     )
     save_manifest(manifest, root)
     monkeypatch.setattr(

--- a/tests/cli/test_smoke_test_clusters.py
+++ b/tests/cli/test_smoke_test_clusters.py
@@ -1,0 +1,170 @@
+"""``rootstock smoke-test`` on shared installs (#208).
+
+The command must refuse to guess which machine it is on, record outcomes
+under the named cluster without touching the sibling's records, and skip
+envs restricted to other clusters.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rootstock.commands.smoke_test import cmd_smoke_test
+from rootstock.config import UserConfig
+from rootstock.manifest import (
+    CheckpointInfo,
+    EnvironmentInfo,
+    VerificationRecord,
+    create_manifest,
+    load_manifest,
+    save_manifest,
+)
+
+SOPHIA_STAMP = "2026-07-01T00:00:00+00:00"
+
+
+@pytest.fixture
+def shared_root(tmp_path: Path, monkeypatch) -> Path:
+    """A sophia/polaris install: one universal env with a checkpoint already
+    verified on sophia, and one sophia-only env."""
+    root = tmp_path
+    for env in ("mace", "sevennet"):
+        (root / "envs" / env / "bin").mkdir(parents=True)
+        (root / "envs" / env / "bin" / "python").touch()
+
+    manifest = create_manifest(root, ["sophia", "polaris"], UserConfig(name="t", email="t@t.t"))
+    manifest.environments["mace"] = EnvironmentInfo(
+        built_at="2026-01-01T00:00:00Z",
+        source_hash="sha256:abc",
+        source="",
+        python_requires=">=3.10",
+        dependencies={},
+        checkpoints={
+            "mace-mp-0-medium": CheckpointInfo(
+                fetched_at="2026-01-02T00:00:00Z",
+                verifications={
+                    "sophia": VerificationRecord(verified_at=SOPHIA_STAMP, verified_device="cuda")
+                },
+            ),
+        },
+    )
+    manifest.environments["sevennet"] = EnvironmentInfo(
+        built_at="2026-01-01T00:00:00Z",
+        source_hash="sha256:def",
+        source="",
+        python_requires=">=3.10",
+        dependencies={},
+        clusters=["sophia"],
+        checkpoints={
+            "sevennet-0": CheckpointInfo(fetched_at="2026-01-02T00:00:00Z"),
+        },
+    )
+    save_manifest(manifest, root)
+
+    monkeypatch.setattr(
+        "rootstock.commands.smoke_test.update_and_push_manifest",
+        lambda *a, **kw: True,
+    )
+    return root
+
+
+def _args(root: Path, **overrides):
+    class _Args:
+        pass
+
+    args = _Args()
+    args.env = overrides.get("env")
+    args.checkpoint = overrides.get("checkpoint")
+    args.device = overrides.get("device", "cuda")
+    args.verify_timeout = overrides.get("verify_timeout", 600.0)
+    args.json = overrides.get("json", False)
+    args.root = str(root)
+    args.no_push = True
+    args.cluster = overrides.get("cluster")
+    return args
+
+
+def _stub_verify(monkeypatch, ok=True, err=None):
+    calls: list[tuple[str, str]] = []
+
+    def fake_verify(*, root, env_name, checkpoint, device, setup_kwargs, cache_root, **kw):
+        calls.append((env_name, checkpoint))
+        return ok, err
+
+    monkeypatch.setattr("rootstock.commands.smoke_test.verify_checkpoint", fake_verify)
+    return calls
+
+
+def test_shared_install_requires_cluster(shared_root, monkeypatch, capsys):
+    _stub_verify(monkeypatch)
+    rc = cmd_smoke_test(_args(shared_root))
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "sophia" in err and "polaris" in err and "--cluster" in err
+
+
+def test_unknown_cluster_is_rejected(shared_root, monkeypatch, capsys):
+    _stub_verify(monkeypatch)
+    rc = cmd_smoke_test(_args(shared_root, cluster="frontier"))
+    assert rc == 2
+    assert "not one this install serves" in capsys.readouterr().err
+
+
+def test_polaris_run_records_under_polaris_only(shared_root, monkeypatch):
+    _stub_verify(monkeypatch)
+    rc = cmd_smoke_test(_args(shared_root, cluster="polaris"))
+    assert rc == 0
+
+    ckpt = load_manifest(shared_root).environments["mace"].checkpoints["mace-mp-0-medium"]
+    assert ckpt.verification("polaris").verified_at is not None
+    # sophia's earlier result must survive the polaris run untouched.
+    assert ckpt.verification("sophia").verified_at == SOPHIA_STAMP
+
+
+def test_polaris_failure_does_not_unverify_sophia(shared_root, monkeypatch):
+    _stub_verify(monkeypatch, ok=False, err="CUDA OOM")
+    rc = cmd_smoke_test(_args(shared_root, cluster="polaris"))
+    assert rc == 1
+
+    ckpt = load_manifest(shared_root).environments["mace"].checkpoints["mace-mp-0-medium"]
+    assert ckpt.verification("polaris").verified_at is None
+    assert ckpt.verification("polaris").last_error == "smoke-test: CUDA OOM"
+    assert ckpt.verification("sophia").verified_at == SOPHIA_STAMP
+
+
+def test_cluster_restricted_env_is_skipped_elsewhere(shared_root, monkeypatch):
+    calls = _stub_verify(monkeypatch)
+
+    cmd_smoke_test(_args(shared_root, cluster="polaris"))
+    assert ("sevennet", "sevennet-0") not in calls
+
+    calls.clear()
+    cmd_smoke_test(_args(shared_root, cluster="sophia"))
+    assert ("sevennet", "sevennet-0") in calls
+
+
+def test_single_cluster_install_needs_no_flag(tmp_path, monkeypatch):
+    root = tmp_path
+    (root / "envs" / "mace" / "bin").mkdir(parents=True)
+    (root / "envs" / "mace" / "bin" / "python").touch()
+    manifest = create_manifest(root, ["della"], UserConfig(name="t", email="t@t.t"))
+    manifest.environments["mace"] = EnvironmentInfo(
+        built_at="2026-01-01T00:00:00Z",
+        source_hash="sha256:abc",
+        source="",
+        python_requires=">=3.10",
+        dependencies={},
+        checkpoints={"mace-mp-0-medium": CheckpointInfo(fetched_at="2026-01-02T00:00:00Z")},
+    )
+    save_manifest(manifest, root)
+    monkeypatch.setattr(
+        "rootstock.commands.smoke_test.update_and_push_manifest", lambda *a, **kw: True
+    )
+    _stub_verify(monkeypatch)
+
+    rc = cmd_smoke_test(_args(root))
+    assert rc == 0
+    ckpt = load_manifest(root).environments["mace"].checkpoints["mace-mp-0-medium"]
+    assert ckpt.verification("della").verified_at is not None

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -10,6 +10,7 @@ from rootstock.config import UserConfig
 from rootstock.manifest import (
     CheckpointInfo,
     EnvironmentInfo,
+    VerificationRecord,
     compute_source_hash,
     create_manifest,
     save_manifest,
@@ -53,10 +54,14 @@ def test_checkpoint_line_marks_verified():
     env = _env_with_checkpoints("2026-01-01T00:00:00Z")
     ckpt = CheckpointInfo(
         fetched_at="2026-01-02T00:00:00Z",
-        verified_at="2026-01-03T00:00:00Z",
-        verified_device="cuda",
+        verifications={
+            "test": VerificationRecord(
+                verified_at="2026-01-03T00:00:00Z",
+                verified_device="cuda",
+            )
+        },
     )
-    line = _checkpoint_line(env, "medium", ckpt)
+    line = _checkpoint_line(env, "medium", ckpt, ["test"])
     assert "✓" in line
     assert "(cuda)" in line
     assert "stale" not in line
@@ -66,17 +71,21 @@ def test_checkpoint_line_marks_stale_when_env_rebuilt():
     env = _env_with_checkpoints("2026-02-01T00:00:00Z")  # newer than verify
     ckpt = CheckpointInfo(
         fetched_at="2026-01-02T00:00:00Z",
-        verified_at="2026-01-15T00:00:00Z",
-        verified_device="cuda",
+        verifications={
+            "test": VerificationRecord(
+                verified_at="2026-01-15T00:00:00Z",
+                verified_device="cuda",
+            )
+        },
     )
-    line = _checkpoint_line(env, "medium", ckpt)
+    line = _checkpoint_line(env, "medium", ckpt, ["test"])
     assert "stale" in line
 
 
 def test_checkpoint_line_marks_unverified():
     env = _env_with_checkpoints("2026-01-01T00:00:00Z")
     ckpt = CheckpointInfo(fetched_at="2026-01-02T00:00:00Z")
-    line = _checkpoint_line(env, "small", ckpt)
+    line = _checkpoint_line(env, "small", ckpt, ["test"])
     assert "not verified" in line
     assert "⚠" in line
 
@@ -85,9 +94,9 @@ def test_checkpoint_line_includes_last_error():
     env = _env_with_checkpoints("2026-01-01T00:00:00Z")
     ckpt = CheckpointInfo(
         fetched_at="2026-01-02T00:00:00Z",
-        last_error="verify: RuntimeError: bad",
+        verifications={"test": VerificationRecord(last_error="verify: RuntimeError: bad")},
     )
-    line = _checkpoint_line(env, "small", ckpt)
+    line = _checkpoint_line(env, "small", ckpt, ["test"])
     assert "last error" in line
     assert "RuntimeError" in line
 
@@ -96,15 +105,19 @@ def test_status_json_includes_verified_current(tmp_path: Path, capsys):
     """--json should add a computed verified_current bool per checkpoint."""
     env_dir = _make_built_env(tmp_path)
     cfg = UserConfig(name="t", email="t@t.t")
-    manifest = create_manifest(tmp_path, "test", cfg)
+    manifest = create_manifest(tmp_path, ["test"], cfg)
     manifest.environments["mace"] = _env_with_checkpoints(
         "2026-01-01T00:00:00Z",
         source_hash=compute_source_hash(env_dir / "env_source.py"),
         **{
             "mace-mp-0-medium": CheckpointInfo(
                 fetched_at="2026-01-02T00:00:00Z",
-                verified_at="2026-01-03T00:00:00Z",
-                verified_device="cuda",
+                verifications={
+                    "test": VerificationRecord(
+                        verified_at="2026-01-03T00:00:00Z",
+                        verified_device="cuda",
+                    )
+                },
             ),
             "mace-mp-0-small": CheckpointInfo(fetched_at="2026-01-02T00:00:00Z"),
         },
@@ -118,10 +131,12 @@ def test_status_json_includes_verified_current(tmp_path: Path, capsys):
     env = parsed["environments"]["mace"]
     assert env["in_manifest"] is True
     assert env["built_at"] == "2026-01-01T00:00:00Z"
-    assert env["checkpoints"]["mace-mp-0-medium"]["verified_current"] is True
-    assert env["checkpoints"]["mace-mp-0-small"]["verified_current"] is False
+    assert env["clusters"] is None  # unrestricted env serves every cluster
+    assert env["checkpoints"]["mace-mp-0-medium"]["verified_current"] == {"test": True}
+    assert env["checkpoints"]["mace-mp-0-small"]["verified_current"] == {"test": False}
+    assert "verifications" in env["checkpoints"]["mace-mp-0-medium"]
     assert env["declared_checkpoints"] == ["mace-mp-0-medium", "mace-mp-0-small"]
-    assert parsed["cluster"] == "test"
+    assert parsed["clusters"] == ["test"]
 
 
 def test_status_json_no_manifest(tmp_path: Path, capsys):
@@ -132,7 +147,7 @@ def test_status_json_no_manifest(tmp_path: Path, capsys):
     assert rc == 0
 
     parsed = json.loads(capsys.readouterr().out)
-    assert parsed["cluster"] is None
+    assert parsed["clusters"] is None
     env = parsed["environments"]["mace"]
     assert env["in_manifest"] is False
     assert env["built_at"] is None
@@ -144,7 +159,7 @@ def test_status_json_separates_manifest_only_envs(tmp_path: Path, capsys):
     presented as installed."""
     _make_built_env(tmp_path)
     cfg = UserConfig(name="t", email="t@t.t")
-    manifest = create_manifest(tmp_path, "test", cfg)
+    manifest = create_manifest(tmp_path, ["test"], cfg)
     manifest.environments["deleted"] = _env_with_checkpoints("2026-01-01T00:00:00Z")
     save_manifest(manifest, tmp_path)
 
@@ -160,7 +175,7 @@ def test_status_json_separates_manifest_only_envs(tmp_path: Path, capsys):
 def test_status_human_view_flags_drift_and_manifest_only(tmp_path: Path, capsys):
     _make_built_env(tmp_path)
     cfg = UserConfig(name="t", email="t@t.t")
-    manifest = create_manifest(tmp_path, "test", cfg)
+    manifest = create_manifest(tmp_path, ["test"], cfg)
     manifest.environments["mace"] = _env_with_checkpoints(
         "2026-01-01T00:00:00Z", source_hash="sha256:stale"
     )

--- a/tests/cli/test_usage_cmd.py
+++ b/tests/cli/test_usage_cmd.py
@@ -81,7 +81,7 @@ _PUSH_CONFIG = UserConfig(
 
 
 def _seed_manifest(tmp_path, config=_PUSH_CONFIG, cluster="testcluster"):
-    save_manifest(create_manifest(tmp_path, cluster, config), tmp_path)
+    save_manifest(create_manifest(tmp_path, [cluster], config), tmp_path)
 
 
 def _patch_config(monkeypatch, config=_PUSH_CONFIG):

--- a/tests/commands/test_add_split.py
+++ b/tests/commands/test_add_split.py
@@ -49,7 +49,7 @@ def fake_root(tmp_path: Path) -> Path:
     from rootstock.manifest import create_manifest, save_manifest
 
     cfg = UserConfig(name="t", email="t@t.t")
-    save_manifest(create_manifest(root, "test", cfg), root)
+    save_manifest(create_manifest(root, ["test"], cfg), root)
     return root
 
 
@@ -83,7 +83,7 @@ def test_fetch_records_fetched_at(fake_root, refresh_calls, monkeypatch):
     assert not result.already_fetched
     ckpt = _ckpt(fake_root)
     assert ckpt.fetched_at == result.fetched_at
-    assert ckpt.verified_at is None
+    assert ckpt.verification("test").verified_at is None
     assert ckpt.last_error is None
 
 
@@ -144,7 +144,9 @@ def test_fetch_fails_fast_when_env_not_built(tmp_path, refresh_calls):
     from rootstock.config import UserConfig
     from rootstock.manifest import create_manifest, save_manifest
 
-    save_manifest(create_manifest(tmp_path, "test", UserConfig(name="t", email="t@t.t")), tmp_path)
+    save_manifest(
+        create_manifest(tmp_path, ["test"], UserConfig(name="t", email="t@t.t")), tmp_path
+    )
     env_dir = tmp_path / "envs" / "mace"
     env_dir.mkdir(parents=True)
     (env_dir / "env_source.py").write_text(_MACE_ENV_SOURCE)  # declared but not built
@@ -163,10 +165,10 @@ def test_verify_records_outcome(fake_root, refresh_calls, monkeypatch):
 
     assert result.env_name == "mace"
     assert result.verified_device == "cuda"
-    ckpt = _ckpt(fake_root)
-    assert ckpt.verified_at == result.verified_at
-    assert ckpt.verified_device == "cuda"
-    assert ckpt.last_error is None
+    record = _ckpt(fake_root).verification("test")
+    assert record.verified_at == result.verified_at
+    assert record.verified_device == "cuda"
+    assert record.last_error is None
 
 
 def test_verify_failure_clears_stamps_and_raises(fake_root, refresh_calls, monkeypatch):
@@ -177,11 +179,11 @@ def test_verify_failure_clears_stamps_and_raises(fake_root, refresh_calls, monke
     with pytest.raises(OperationError, match="verify failed"):
         verify_fetched_checkpoint(fake_root, "mace-mp-0-medium")
 
-    ckpt = _ckpt(fake_root)
-    assert ckpt.verified_at is None
-    assert ckpt.verified_device is None
-    assert "CUDA OOM" in ckpt.last_error
-    assert ckpt.last_error.startswith("verify:")
+    record = _ckpt(fake_root).verification("test")
+    assert record.verified_at is None
+    assert record.verified_device is None
+    assert "CUDA OOM" in record.last_error
+    assert record.last_error.startswith("verify:")
 
 
 def test_verify_refresh_knob(fake_root, refresh_calls, monkeypatch):
@@ -210,7 +212,7 @@ def test_verify_forwards_device_and_kwargs(fake_root, refresh_calls, monkeypatch
 
     assert captured["device"] == "cuda:1"
     assert captured["setup_kwargs"] == {"task": "omat"}
-    assert _ckpt(fake_root).verified_device == "cuda:1"
+    assert _ckpt(fake_root).verification("test").verified_device == "cuda:1"
 
 
 def test_verify_forwards_timeout(fake_root, refresh_calls, monkeypatch):

--- a/tests/commands/test_prune_exec.py
+++ b/tests/commands/test_prune_exec.py
@@ -43,7 +43,7 @@ def refreshes(monkeypatch) -> list:
 def save(root: Path, environments: dict[str, EnvironmentInfo]) -> None:
     from rootstock.config import UserConfig
 
-    manifest = create_manifest(root, "test", UserConfig(name="t", email="t@t.t"))
+    manifest = create_manifest(root, ["test"], UserConfig(name="t", email="t@t.t"))
     manifest.environments = environments
     save_manifest(manifest, root)
 

--- a/tests/commands/test_prune_plan.py
+++ b/tests/commands/test_prune_plan.py
@@ -20,6 +20,7 @@ from rootstock.batch import plan_prune
 from rootstock.manifest import (
     CheckpointInfo,
     EnvironmentInfo,
+    VerificationRecord,
     compute_source_hash,
     create_manifest,
     save_manifest,
@@ -69,7 +70,7 @@ def record(
 def save(root: Path, environments: dict[str, EnvironmentInfo]) -> None:
     from rootstock.config import UserConfig
 
-    manifest = create_manifest(root, "test", UserConfig(name="t", email="t@t.t"))
+    manifest = create_manifest(root, ["test"], UserConfig(name="t", email="t@t.t"))
     manifest.environments = environments
     save_manifest(manifest, root)
 
@@ -85,8 +86,7 @@ def weight(root: Path, relpath: str, size: int = 4) -> dict:
 def fetched(*weight_entries: dict, recorded: bool = True) -> CheckpointInfo:
     return CheckpointInfo(
         fetched_at=OLD,
-        verified_at=NEWER,
-        verified_device="cuda",
+        verifications={"test": VerificationRecord(verified_at=NEWER, verified_device="cuda")},
         weight_files=list(weight_entries) if recorded else None,
     )
 

--- a/tests/commands/test_sync_clusters.py
+++ b/tests/commands/test_sync_clusters.py
@@ -1,0 +1,197 @@
+"""``rootstock sync`` on shared installs (#208).
+
+The planner's cluster behavior, mirroring the smoke-test coverage in
+tests/cli/test_smoke_test_clusters.py: verification is judged and planned
+per cluster; envs restricted by CLUSTERS are still built and downloaded
+(shared artifacts) but only verified by a machine they serve; and the
+command refuses to guess which machine it is on.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rootstock.batch import plan_sync
+from rootstock.config import UserConfig
+from rootstock.manifest import (
+    CheckpointInfo,
+    EnvironmentInfo,
+    VerificationRecord,
+    compute_source_hash,
+    create_manifest,
+    save_manifest,
+)
+from rootstock.operations import OperationError
+
+BUILT = "2026-07-01T00:00:00+00:00"
+VERIFIED = "2026-07-02T00:00:00+00:00"
+
+
+def env_source(*checkpoints: str, clusters: list[str] | None = None, malformed=False) -> str:
+    body = ""
+    if malformed:
+        body += "CLUSTERS = []\n"
+    elif clusters is not None:
+        body += f"CLUSTERS = {clusters!r}\n"
+    entries = "".join(f"    {ckpt!r}: {ckpt!r},\n" for ckpt in checkpoints)
+    body += (
+        f"CHECKPOINTS = {{\n{entries}}}\n\ndef setup(checkpoint, device='cuda'):\n    return None\n"
+    )
+    return body
+
+
+def register_and_build(root: Path, name: str, source: str, built: bool = True) -> None:
+    env_file = root / "environments" / f"{name}.py"
+    env_file.parent.mkdir(parents=True, exist_ok=True)
+    env_file.write_text(source)
+    if built:
+        env_dir = root / "envs" / name
+        (env_dir / "bin").mkdir(parents=True, exist_ok=True)
+        (env_dir / "bin" / "python").touch()
+        (env_dir / "env_source.py").write_text(source)
+
+
+def record(root: Path, name: str, checkpoints: dict[str, CheckpointInfo]) -> EnvironmentInfo:
+    return EnvironmentInfo(
+        built_at=BUILT,
+        source_hash=compute_source_hash(root / "envs" / name / "env_source.py"),
+        source="",
+        python_requires=">=3.11",
+        dependencies={},
+        checkpoints=checkpoints,
+    )
+
+
+def save(root: Path, environments: dict[str, EnvironmentInfo]) -> None:
+    manifest = create_manifest(root, ["sophia", "polaris"], UserConfig(name="t", email="t@t.t"))
+    manifest.environments = environments
+    save_manifest(manifest, root)
+
+
+def sophia_verified(fetched_at: str = VERIFIED) -> CheckpointInfo:
+    return CheckpointInfo(
+        fetched_at=fetched_at,
+        verifications={"sophia": VerificationRecord(verified_at=VERIFIED, verified_device="cuda")},
+    )
+
+
+def test_verified_on_sophia_still_plans_verify_for_polaris(tmp_path):
+    source = env_source("mace-mp-0-medium")
+    register_and_build(tmp_path, "mace", source)
+    save(tmp_path, {"mace": record(tmp_path, "mace", {"mace-mp-0-medium": sophia_verified()})})
+
+    polaris = plan_sync(tmp_path, cluster="polaris")
+    assert [(v.env_name, v.checkpoint, v.reason) for v in polaris.verifies] == [
+        ("mace", "mace-mp-0-medium", "never verified")
+    ]
+    assert polaris.downloads == []  # the fetch is shared; only the verify is owed
+
+    # sophia's own record is current — nothing to do there.
+    assert plan_sync(tmp_path, cluster="sophia").is_empty
+
+
+def test_restricted_env_verifies_only_where_served(tmp_path):
+    source = env_source("sevennet-0", clusters=["sophia"])
+    register_and_build(tmp_path, "sevennet", source)
+    save(
+        tmp_path,
+        {
+            "sevennet": record(
+                tmp_path, "sevennet", {"sevennet-0": CheckpointInfo(fetched_at=VERIFIED)}
+            )
+        },
+    )
+
+    polaris = plan_sync(tmp_path, cluster="polaris")
+    assert polaris.verifies == []
+    assert any("serves only sophia" in note for note in polaris.notes)
+
+    sophia = plan_sync(tmp_path, cluster="sophia")
+    assert [(v.env_name, v.checkpoint) for v in sophia.verifies] == [("sevennet", "sevennet-0")]
+
+
+def test_restricted_env_still_builds_and_downloads_everywhere(tmp_path):
+    # Builds and downloads produce shared artifacts (one filesystem, one
+    # weights cache) — polaris's sync still does that work for a sophia-only
+    # env; only the verify belongs to sophia's chain.
+    source = env_source("sevennet-0", clusters=["sophia"])
+    register_and_build(tmp_path, "sevennet", source, built=False)
+    save(tmp_path, {})
+
+    polaris = plan_sync(tmp_path, cluster="polaris")
+    assert [b.env_name for b in polaris.builds] == ["sevennet"]
+    assert [(d.env_name, d.checkpoint) for d in polaris.downloads] == [("sevennet", "sevennet-0")]
+    assert polaris.verifies == []
+    assert any("serves only sophia" in note for note in polaris.notes)
+
+
+def test_malformed_clusters_skips_verifies_with_note(tmp_path):
+    source = env_source("mace-mp-0-medium", malformed=True)
+    register_and_build(tmp_path, "mace", source)
+    save(
+        tmp_path,
+        {
+            "mace": record(
+                tmp_path, "mace", {"mace-mp-0-medium": CheckpointInfo(fetched_at=VERIFIED)}
+            )
+        },
+    )
+
+    plan = plan_sync(tmp_path, cluster="polaris")
+    # Never widen a broken restriction to "serves everywhere" — drop the
+    # verifies and say why.
+    assert plan.verifies == []
+    assert any("cannot parse CLUSTERS" in note for note in plan.notes)
+
+
+def test_plan_sync_shared_install_requires_cluster(tmp_path):
+    source = env_source("mace-mp-0-medium")
+    register_and_build(tmp_path, "mace", source)
+    save(tmp_path, {"mace": record(tmp_path, "mace", {"mace-mp-0-medium": sophia_verified()})})
+
+    with pytest.raises(OperationError, match="sophia, polaris"):
+        plan_sync(tmp_path)
+
+    # Without the verify phase there is nothing to attribute — no cluster needed.
+    plan = plan_sync(tmp_path, phases=("build", "download"))
+    assert plan.is_empty
+
+
+def test_cmd_sync_exits_2_without_cluster_on_shared_install(tmp_path, monkeypatch, capsys):
+    from rootstock.commands.sync import cmd_sync
+
+    save(tmp_path, {})
+
+    planned = []
+    monkeypatch.setattr("rootstock.commands.sync.plan_sync", lambda *a, **kw: planned.append(1))
+
+    class _Args:
+        pass
+
+    args = _Args()
+    args.source_dir = None
+    args.root = str(tmp_path)
+    args.cluster = None
+    args.env = None
+    args.checkpoint = None
+    args.rebuild = False
+    args.upgrade = False
+    args.phases = "build,download,verify"
+    args.jobs = 4
+    args.verify_jobs = 1
+    args.verify_timeout = 600.0
+    args.device = "cuda"
+    args.dry_run = False
+    args.json = False
+    args.fail_fast = False
+    args.no_push = True
+    args.no_perm_check = True
+
+    rc = cmd_sync(args)
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "sophia" in err and "polaris" in err and "--cluster" in err
+    assert planned == []  # refused before planning anything

--- a/tests/commands/test_sync_plan.py
+++ b/tests/commands/test_sync_plan.py
@@ -18,6 +18,7 @@ from rootstock.batch import plan_sync
 from rootstock.manifest import (
     CheckpointInfo,
     EnvironmentInfo,
+    VerificationRecord,
     compute_source_hash,
     create_manifest,
     save_manifest,
@@ -76,12 +77,15 @@ def record(
 def save(root: Path, environments: dict[str, EnvironmentInfo]) -> None:
     from rootstock.config import UserConfig
 
-    manifest = create_manifest(root, "test", UserConfig(name="t", email="t@t.t"))
+    manifest = create_manifest(root, ["test"], UserConfig(name="t", email="t@t.t"))
     manifest.environments = environments
     save_manifest(manifest, root)
 
 
-VERIFIED = CheckpointInfo(fetched_at=NEWER, verified_at=NEWER, verified_device="cuda")
+VERIFIED = CheckpointInfo(
+    fetched_at=NEWER,
+    verifications={"test": VerificationRecord(verified_at=NEWER, verified_device="cuda")},
+)
 
 
 @pytest.fixture
@@ -204,7 +208,10 @@ def test_verified_before_last_build_is_stale(tmp_path):
     source = env_source("mace-mp-0-medium")
     register(tmp_path, "mace", source)
     build(tmp_path, "mace", source)
-    stale = CheckpointInfo(fetched_at=OLD, verified_at=OLD, verified_device="cuda")
+    stale = CheckpointInfo(
+        fetched_at=OLD,
+        verifications={"test": VerificationRecord(verified_at=OLD, verified_device="cuda")},
+    )
     save(
         tmp_path,
         {"mace": record(tmp_path, "mace", built_at=NEWER, checkpoints={"mace-mp-0-medium": stale})},

--- a/tests/commands/test_weights_record.py
+++ b/tests/commands/test_weights_record.py
@@ -131,7 +131,7 @@ def fake_root(tmp_path: Path) -> Path:
     from rootstock.manifest import create_manifest, save_manifest
 
     cfg = UserConfig(name="t", email="t@t.t")
-    save_manifest(create_manifest(root, "test", cfg), root)
+    save_manifest(create_manifest(root, ["test"], cfg), root)
     return root
 
 
@@ -199,7 +199,7 @@ def test_verify_records_weight_files_even_on_failure(fake_root, no_refresh, monk
         verify_fetched_checkpoint(fake_root, "mace-mp-0-medium")
 
     ckpt = _ckpt(fake_root)
-    assert ckpt.verified_at is None
+    assert ckpt.verification("test").verified_at is None
     assert ckpt.weight_files == _FILES
 
 
@@ -223,5 +223,5 @@ def test_verify_success_records_weight_files(fake_root, no_refresh, monkeypatch)
     verify_fetched_checkpoint(fake_root, "mace-mp-0-medium")
 
     ckpt = _ckpt(fake_root)
-    assert ckpt.verified_at is not None
+    assert ckpt.verification("test").verified_at is not None
     assert ckpt.weight_files == _FILES

--- a/tests/manifest/test_built_at.py
+++ b/tests/manifest/test_built_at.py
@@ -50,7 +50,7 @@ def _make_built_env(root: Path, name: str = "mace") -> Path:
 def _manifest(root: Path, environments=None) -> Manifest:
     return Manifest(
         schema_version=SCHEMA_VERSION,
-        cluster="test",
+        clusters=["test"],
         root=str(root),
         maintainer=Maintainer(name="a", email="a@b.c"),
         rootstock_version="0.0.0",

--- a/tests/manifest/test_corruption.py
+++ b/tests/manifest/test_corruption.py
@@ -36,7 +36,7 @@ def test_corrupt_json_raises_with_path(tmp_path: Path):
 
 def test_missing_required_field_raises(tmp_path: Path):
     """Valid JSON with required keys stripped is corruption, not absence."""
-    manifest = create_manifest(tmp_path, "test", UserConfig(name="t", email="t@t.t"))
+    manifest = create_manifest(tmp_path, ["test"], UserConfig(name="t", email="t@t.t"))
     save_manifest(manifest, tmp_path)
     data = json.loads((tmp_path / "manifest.json").read_text())
     del data["maintainer"]
@@ -54,19 +54,19 @@ def test_wrong_top_level_type_raises(tmp_path: Path):
 
 
 def test_valid_manifest_still_loads(tmp_path: Path):
-    manifest = create_manifest(tmp_path, "test", UserConfig(name="t", email="t@t.t"))
+    manifest = create_manifest(tmp_path, ["test"], UserConfig(name="t", email="t@t.t"))
     save_manifest(manifest, tmp_path)
 
     loaded = load_manifest(tmp_path)
 
     assert loaded is not None
-    assert loaded.cluster == "test"
+    assert loaded.clusters == ["test"]
 
 
 def test_newer_schema_raises_manifest_error(tmp_path: Path):
     """Schema mismatches share the taxonomy: a clean ManifestError, not a
     bare RuntimeError traceback."""
-    manifest = create_manifest(tmp_path, "test", UserConfig(name="t", email="t@t.t"))
+    manifest = create_manifest(tmp_path, ["test"], UserConfig(name="t", email="t@t.t"))
     save_manifest(manifest, tmp_path)
     data = json.loads((tmp_path / "manifest.json").read_text())
     data["schema_version"] = 99

--- a/tests/manifest/test_manifest.py
+++ b/tests/manifest/test_manifest.py
@@ -1,4 +1,4 @@
-"""Tests for the v3 manifest schema."""
+"""Tests for the v6 manifest schema."""
 
 from __future__ import annotations
 
@@ -10,7 +10,9 @@ from rootstock.manifest import (
     EnvironmentInfo,
     Maintainer,
     Manifest,
+    VerificationRecord,
     is_verified,
+    manifest_push_payload,
 )
 
 
@@ -28,7 +30,7 @@ def _make_env(built_at: str = "2026-01-01T00:00:00Z", **ckpts: CheckpointInfo) -
 def _make_manifest(envs: dict[str, EnvironmentInfo] | None = None) -> Manifest:
     return Manifest(
         schema_version=SCHEMA_VERSION,
-        cluster="test",
+        clusters=["test"],
         root="/tmp/x",
         maintainer=Maintainer(name="a", email="a@b.c"),
         rootstock_version="0.0.0",
@@ -39,15 +41,19 @@ def _make_manifest(envs: dict[str, EnvironmentInfo] | None = None) -> Manifest:
 
 
 def test_schema_version_constant():
-    assert SCHEMA_VERSION == 5
+    assert SCHEMA_VERSION == 6
 
 
 def test_checkpoint_info_round_trip():
     ckpt = CheckpointInfo(
         fetched_at="2026-01-02T00:00:00Z",
-        verified_at="2026-01-03T00:00:00Z",
-        verified_device="cuda",
         last_error=None,
+        verifications={
+            "test": VerificationRecord(
+                verified_at="2026-01-03T00:00:00Z",
+                verified_device="cuda",
+            )
+        },
     )
     assert CheckpointInfo.from_dict(ckpt.to_dict()) == ckpt
 
@@ -55,9 +61,12 @@ def test_checkpoint_info_round_trip():
 def test_checkpoint_info_defaults_to_none():
     ckpt = CheckpointInfo()
     assert ckpt.fetched_at is None
-    assert ckpt.verified_at is None
-    assert ckpt.verified_device is None
     assert ckpt.last_error is None
+    assert ckpt.verifications == {}
+    # Never-verified clusters read as an empty record, not a KeyError.
+    assert ckpt.verification("test").verified_at is None
+    assert ckpt.verification("test").verified_device is None
+    assert ckpt.verification("test").last_error is None
 
 
 def test_environment_info_with_dict_checkpoints_round_trip():
@@ -92,8 +101,12 @@ def test_manifest_round_trip_preserves_checkpoint_metadata():
                 **{
                     "mace-mp-0-medium": CheckpointInfo(
                         fetched_at="2026-01-02T00:00:00Z",
-                        verified_at="2026-01-03T00:00:00Z",
-                        verified_device="cuda",
+                        verifications={
+                            "test": VerificationRecord(
+                                verified_at="2026-01-03T00:00:00Z",
+                                verified_device="cuda",
+                            )
+                        },
                     ),
                     "mace-mp-0-small": CheckpointInfo(),
                 }
@@ -102,14 +115,18 @@ def test_manifest_round_trip_preserves_checkpoint_metadata():
     )
     restored = Manifest.from_dict(m.to_dict())
     ckpts = restored.environments["mace"].checkpoints
-    assert ckpts["mace-mp-0-medium"].verified_device == "cuda"
+    assert ckpts["mace-mp-0-medium"].verification("test").verified_device == "cuda"
     assert ckpts["mace-mp-0-small"].fetched_at is None
 
 
-def test_to_dict_key_layout_is_stable():
+def test_push_payload_key_layout_is_stable():
     """Pushed manifests are consumed downstream (the Almanac renders them) —
-    the JSON key layout is a contract, not an implementation detail."""
-    data = _make_manifest({"mace": _make_env(**{"mace-mp-0-small": CheckpointInfo()})}).to_dict()
+    the wire payload keeps the flat single-cluster v5 layout; that key layout
+    is a contract, not an implementation detail."""
+    m = _make_manifest({"mace": _make_env(**{"mace-mp-0-small": CheckpointInfo()})})
+    data = manifest_push_payload(m, "test")
+    assert data["schema_version"] == 5
+    assert data["cluster"] == "test"
     assert list(data) == [
         "schema_version",
         "cluster",
@@ -186,19 +203,31 @@ def test_from_dict_rejects_missing_schema_version():
         Manifest.from_dict(no_version)
 
 
+def _verified(at: str, device: str = "cuda") -> dict[str, VerificationRecord]:
+    return {"test": VerificationRecord(verified_at=at, verified_device=device)}
+
+
 def test_is_verified_unverified_checkpoint():
     env = _make_env()
     ckpt = CheckpointInfo(fetched_at="2026-01-02T00:00:00Z")
-    assert is_verified(env, ckpt) is False
+    assert is_verified(env, ckpt, "test") is False
 
 
 def test_is_verified_after_build():
     env = _make_env(built_at="2026-01-01T00:00:00Z")
-    ckpt = CheckpointInfo(verified_at="2026-01-02T00:00:00Z", verified_device="cuda")
-    assert is_verified(env, ckpt) is True
+    ckpt = CheckpointInfo(verifications=_verified("2026-01-02T00:00:00Z"))
+    assert is_verified(env, ckpt, "test") is True
 
 
 def test_is_verified_stale_when_env_rebuilt_after_verify():
     env = _make_env(built_at="2026-02-01T00:00:00Z")
-    ckpt = CheckpointInfo(verified_at="2026-01-15T00:00:00Z", verified_device="cuda")
-    assert is_verified(env, ckpt) is False
+    ckpt = CheckpointInfo(verifications=_verified("2026-01-15T00:00:00Z"))
+    assert is_verified(env, ckpt, "test") is False
+
+
+def test_is_verified_is_per_cluster():
+    """Verification on one cluster says nothing about another (#208)."""
+    env = _make_env(built_at="2026-01-01T00:00:00Z")
+    ckpt = CheckpointInfo(verifications=_verified("2026-01-02T00:00:00Z"))
+    assert is_verified(env, ckpt, "test") is True
+    assert is_verified(env, ckpt, "other") is False

--- a/tests/manifest/test_migrations.py
+++ b/tests/manifest/test_migrations.py
@@ -23,9 +23,8 @@ from rootstock.manifest import (
 
 
 def _base(version, environments=None) -> dict:
-    return {
+    data = {
         "schema_version": version,
-        "cluster": "test",
         "root": "/tmp/x",
         "maintainer": {"name": "a", "email": "a@b.c"},
         "rootstock_version": "0.5.0",
@@ -33,6 +32,11 @@ def _base(version, environments=None) -> dict:
         "last_updated": "2026-01-01T00:00:00Z",
         "environments": environments or {},
     }
+    if int(version) >= 6:
+        data["clusters"] = ["test"]  # v6+ stores plural cluster identity
+    else:
+        data["cluster"] = "test"  # pre-v6 manifests wrote a single cluster
+    return data
 
 
 def _v2_env(checkpoints=None) -> dict:
@@ -63,6 +67,9 @@ def test_v2_environments_survive_checkpoints_dropped():
     migrated, notes = migrate_manifest_data(data)
 
     assert migrated["schema_version"] == SCHEMA_VERSION
+    # "/tmp/x" is not a registry root, so the sole cluster is the old one
+    assert migrated["clusters"] == ["test"]
+    assert "cluster" not in migrated
     env = migrated["environments"]["mace"]
     assert env["dependencies"] == {"mace-torch": "0.3.6"}
     # v2 checkpoint keys aren't canonical ids; they can't be trusted to join
@@ -76,6 +83,7 @@ def test_v2_without_checkpoints_migrates_quietly():
         "migrated manifest schema v2 -> v3",
         "migrated manifest schema v3 -> v4",
         "migrated manifest schema v4 -> v5",
+        "migrated manifest schema v5 -> v6",
     ]
 
 
@@ -105,6 +113,7 @@ def test_v3_drops_dead_status_fields():
     assert notes == [
         "migrated manifest schema v3 -> v4",
         "migrated manifest schema v4 -> v5",
+        "migrated manifest schema v5 -> v6",
     ]
     assert "mace" in Manifest.from_dict(migrated).environments
 
@@ -122,14 +131,18 @@ def test_v4_bumps_cleanly_with_checkpoints_intact():
     migrated, notes = migrate_manifest_data(data)
 
     assert migrated["schema_version"] == SCHEMA_VERSION
-    assert notes == ["migrated manifest schema v4 -> v5"]
+    assert notes == [
+        "migrated manifest schema v4 -> v5",
+        "migrated manifest schema v5 -> v6",
+    ]
     ckpt = Manifest.from_dict(migrated).environments["mace"].checkpoints["mace-mp-0-medium"]
     assert ckpt.fetched_at == "2026-01-02T00:00:00Z"
     assert ckpt.weight_files is None
     assert ckpt.weights_recorded_at is None
+    assert ckpt.verifications == {}  # never verified pre-migration
 
 
-# --- v1 -> v4 (full chain) --------------------------------------------------
+# --- v1 -> v6 (full chain) --------------------------------------------------
 
 
 def test_v1_chain_migrates_to_current():
@@ -138,9 +151,10 @@ def test_v1_chain_migrates_to_current():
     migrated, notes = migrate_manifest_data(data)
 
     assert migrated["schema_version"] == SCHEMA_VERSION
+    assert migrated["clusters"] == ["test"]
     # v1->v2 mints empty CheckpointInfo dicts; v2->v3 then drops them
     assert migrated["environments"]["mace"]["checkpoints"] == {}
-    assert len(notes) == 4
+    assert len(notes) == 5
     assert Manifest.from_dict(migrated).environments["mace"].source_hash == "sha256:abc"
 
 

--- a/tests/manifest/test_refresh_lock_hash.py
+++ b/tests/manifest/test_refresh_lock_hash.py
@@ -29,7 +29,7 @@ def _make_built_env(root: Path, name: str, with_lock: bool) -> Path:
 def _empty_manifest(root: Path) -> Manifest:
     return Manifest(
         schema_version=SCHEMA_VERSION,
-        cluster="test",
+        clusters=["test"],
         root=str(root),
         maintainer=Maintainer(name="a", email="a@b.c"),
         rootstock_version="0.0.0",

--- a/tests/manifest/test_refresh_prune.py
+++ b/tests/manifest/test_refresh_prune.py
@@ -56,7 +56,7 @@ def _record() -> EnvironmentInfo:
 def _manifest(root: Path, environments: dict) -> Manifest:
     return Manifest(
         schema_version=SCHEMA_VERSION,
-        cluster="test",
+        clusters=["test"],
         root=str(root),
         maintainer=Maintainer(name="a", email="a@b.c"),
         rootstock_version="0.0.0",

--- a/tests/manifest/test_shared_install.py
+++ b/tests/manifest/test_shared_install.py
@@ -1,0 +1,269 @@
+"""Schema v6: shared installs (#208).
+
+One manifest file per install, however many clusters mount it; verification
+per cluster; the per-cluster split happens in the push payload. These tests
+pin the v5 -> v6 migration semantics and the wire projection.
+"""
+
+from __future__ import annotations
+
+from rootstock.clusters import Cluster, get_clusters_for_root
+from rootstock.manifest import (
+    SCHEMA_VERSION,
+    CheckpointInfo,
+    EnvironmentInfo,
+    Maintainer,
+    Manifest,
+    VerificationRecord,
+    manifest_push_payload,
+    migrate_manifest_data,
+)
+
+
+def _v5(cluster="test", root="/tmp/x", environments=None) -> dict:
+    return {
+        "schema_version": 5,
+        "cluster": cluster,
+        "root": root,
+        "maintainer": {"name": "a", "email": "a@b.c"},
+        "rootstock_version": "1.3.0",
+        "python_version": "3.11",
+        "last_updated": "2026-01-01T00:00:00Z",
+        "environments": environments or {},
+    }
+
+
+def _v5_env(checkpoints=None) -> dict:
+    return {
+        "built_at": "2026-01-01T00:00:00Z",
+        "source_hash": "sha256:abc",
+        "source": "CHECKPOINTS = {}",
+        "python_requires": ">=3.11",
+        "dependencies": {"mace-torch": "0.3.6"},
+        "lock_hash": None,
+        "checkpoints": checkpoints or {},
+    }
+
+
+# --- v5 -> v6 migration -----------------------------------------------------
+
+
+def test_v5_flat_verification_moves_under_old_cluster():
+    ckpt = {
+        "fetched_at": "2026-01-02T00:00:00Z",
+        "verified_at": "2026-01-03T00:00:00Z",
+        "verified_device": "cuda",
+        "last_error": None,
+    }
+    data = _v5(environments={"mace": _v5_env({"mace-mp-0-medium": ckpt})})
+
+    migrated, _ = migrate_manifest_data(data)
+
+    assert migrated["schema_version"] == SCHEMA_VERSION
+    assert migrated["clusters"] == ["test"]
+    assert "cluster" not in migrated
+    out = migrated["environments"]["mace"]["checkpoints"]["mace-mp-0-medium"]
+    assert out["fetched_at"] == "2026-01-02T00:00:00Z"
+    assert "verified_at" not in out
+    assert out["verifications"]["test"] == {
+        "verified_at": "2026-01-03T00:00:00Z",
+        "verified_device": "cuda",
+        "last_error": None,
+    }
+    assert migrated["environments"]["mace"]["clusters"] is None
+
+
+def test_v5_download_error_stays_shared_verify_error_moves():
+    fetch_failed = {"fetched_at": None, "last_error": "download: no route to host"}
+    verify_failed = {
+        "fetched_at": "2026-01-02T00:00:00Z",
+        "verified_at": None,
+        "verified_device": None,
+        "last_error": "smoke-test: CUDA OOM",
+    }
+    data = _v5(environments={"mace": _v5_env({"a": fetch_failed, "b": verify_failed})})
+
+    migrated, _ = migrate_manifest_data(data)
+
+    a = migrated["environments"]["mace"]["checkpoints"]["a"]
+    assert a["last_error"] == "download: no route to host"
+    assert a["verifications"] == {}
+
+    b = migrated["environments"]["mace"]["checkpoints"]["b"]
+    assert b["last_error"] is None
+    assert b["verifications"]["test"]["last_error"] == "smoke-test: CUDA OOM"
+
+
+def test_v5_shared_registry_root_seeds_sibling_clusters(monkeypatch):
+    from pathlib import Path
+
+    import rootstock.clusters as clusters_module
+
+    registry = {
+        "alpha": Cluster(root=Path("/shared/rootstock")),
+        "beta": Cluster(root=Path("/shared/rootstock")),
+        "gamma": Cluster(root=Path("/elsewhere")),
+    }
+    monkeypatch.setattr(clusters_module, "CLUSTER_REGISTRY", registry)
+
+    data = _v5(cluster="beta", root="/shared/rootstock")
+    migrated, notes = migrate_manifest_data(data)
+
+    # The old identity stays first; the sibling is appended, not guessed at.
+    assert migrated["clusters"] == ["beta", "alpha"]
+    assert any("alpha" in n for n in notes)
+
+
+def test_v5_unregistered_root_migrates_to_single_cluster():
+    migrated, notes = migrate_manifest_data(_v5(cluster="della", root="/nowhere"))
+    assert migrated["clusters"] == ["della"]
+    # No sibling seeding — nothing extra to announce.
+    assert notes == ["migrated manifest schema v5 -> v6"]
+
+
+def test_migrated_v5_round_trips_through_dataclasses():
+    ckpt = {
+        "fetched_at": "2026-01-02T00:00:00Z",
+        "verified_at": "2026-01-03T00:00:00Z",
+        "verified_device": "cuda",
+        "last_error": None,
+    }
+    data = _v5(environments={"mace": _v5_env({"mace-mp-0-medium": ckpt})})
+
+    manifest = Manifest.from_dict(data)
+
+    assert manifest.clusters == ["test"]
+    record = manifest.environments["mace"].checkpoints["mace-mp-0-medium"]
+    assert record.verification("test").verified_at == "2026-01-03T00:00:00Z"
+    assert record.verification("other").verified_at is None  # empty default
+
+    again = Manifest.from_dict(manifest.to_dict())
+    assert again.to_dict() == manifest.to_dict()
+
+
+# --- push payload projection --------------------------------------------------
+
+
+def _v6_manifest() -> Manifest:
+    return Manifest(
+        schema_version=SCHEMA_VERSION,
+        clusters=["sophia", "polaris"],
+        root="/shared/rootstock",
+        maintainer=Maintainer(name="a", email="a@b.c"),
+        rootstock_version="1.4.0",
+        python_version="3.11",
+        last_updated="2026-08-01T00:00:00Z",
+        environments={
+            "mace": EnvironmentInfo(
+                built_at="2026-01-01T00:00:00Z",
+                source_hash="sha256:abc",
+                source="",
+                python_requires=">=3.11",
+                dependencies={},
+                checkpoints={
+                    "mace-mp-0-medium": CheckpointInfo(
+                        fetched_at="2026-01-02T00:00:00Z",
+                        verifications={
+                            "sophia": VerificationRecord(
+                                verified_at="2026-01-03T00:00:00Z", verified_device="cuda"
+                            ),
+                            "polaris": VerificationRecord(last_error="smoke-test: boom"),
+                        },
+                    ),
+                },
+            ),
+            "mace-polaris": EnvironmentInfo(
+                built_at="2026-01-01T00:00:00Z",
+                source_hash="sha256:def",
+                source="",
+                python_requires=">=3.11",
+                dependencies={},
+                clusters=["polaris"],
+                checkpoints={
+                    "mace-mp-0-medium": CheckpointInfo(fetched_at="2026-01-02T00:00:00Z"),
+                },
+            ),
+        },
+    )
+
+
+def test_push_payload_is_flat_per_cluster_v5():
+    payload = manifest_push_payload(_v6_manifest(), "sophia")
+
+    # The wire keeps the pre-v6 flat single-cluster shape: the backend files
+    # by payload["cluster"] and the almanac reads flat verified_* fields.
+    assert payload["schema_version"] == 5
+    assert payload["cluster"] == "sophia"
+    assert "clusters" not in payload
+
+    ckpt = payload["environments"]["mace"]["checkpoints"]["mace-mp-0-medium"]
+    assert ckpt["verified_at"] == "2026-01-03T00:00:00Z"
+    assert ckpt["verified_device"] == "cuda"
+    assert "verifications" not in ckpt
+
+
+def test_push_payload_carries_only_that_clusters_results():
+    payload = manifest_push_payload(_v6_manifest(), "polaris")
+    ckpt = payload["environments"]["mace"]["checkpoints"]["mace-mp-0-medium"]
+    assert ckpt["verified_at"] is None
+    assert ckpt["last_error"] == "smoke-test: boom"
+
+
+def test_push_payload_omits_envs_not_serving_the_cluster():
+    manifest = _v6_manifest()
+    sophia = manifest_push_payload(manifest, "sophia")
+    polaris = manifest_push_payload(manifest, "polaris")
+
+    assert set(sophia["environments"]) == {"mace"}
+    assert set(polaris["environments"]) == {"mace", "mace-polaris"}
+    # The restriction is install-internal routing, not wire vocabulary.
+    assert "clusters" not in polaris["environments"]["mace-polaris"]
+
+
+def test_push_payload_verify_error_beats_shared_download_error():
+    manifest = _v6_manifest()
+    ckpt = manifest.environments["mace"].checkpoints["mace-mp-0-medium"]
+    ckpt.last_error = "download: flaky mirror"
+
+    sophia = manifest_push_payload(manifest, "sophia")["environments"]["mace"]["checkpoints"]
+    polaris = manifest_push_payload(manifest, "polaris")["environments"]["mace"]["checkpoints"]
+
+    # sophia verified cleanly -> its payload falls back to the shared fetch error;
+    # polaris has its own verify error, which wins.
+    assert sophia["mace-mp-0-medium"]["last_error"] == "download: flaky mirror"
+    assert polaris["mace-mp-0-medium"]["last_error"] == "smoke-test: boom"
+
+
+def test_client_pushes_one_payload_per_cluster(monkeypatch):
+    from rootstock.client import RootstockClient
+    from rootstock.config import UserConfig
+
+    posted: list[dict] = []
+
+    def fake_post(self, url, payload, success_message):
+        posted.append(payload)
+        return True, success_message
+
+    monkeypatch.setattr(RootstockClient, "_post", fake_post)
+    config = UserConfig(api_key="k", api_secret="s", api_url="http://x")
+
+    ok, message = RootstockClient(config).push_manifest(_v6_manifest())
+
+    assert ok
+    assert [p["cluster"] for p in posted] == ["sophia", "polaris"]
+    assert "sophia: ok" in message and "polaris: ok" in message
+
+
+def test_get_clusters_for_root_matches_shared_roots(monkeypatch):
+    from pathlib import Path
+
+    import rootstock.clusters as clusters_module
+
+    registry = {
+        "alpha": Cluster(root=Path("/shared/rootstock")),
+        "beta": Cluster(root=Path("/shared/rootstock")),
+    }
+    monkeypatch.setattr(clusters_module, "CLUSTER_REGISTRY", registry)
+
+    assert get_clusters_for_root("/shared/rootstock") == ["alpha", "beta"]
+    assert get_clusters_for_root("/nowhere") == []

--- a/tests/manifest/test_shared_install.py
+++ b/tests/manifest/test_shared_install.py
@@ -145,6 +145,8 @@ def test_migrated_v5_round_trips_through_dataclasses():
 
 
 def _v6_manifest() -> Manifest:
+    """Universal mace (medium verified on sophia, small failed on polaris)
+    plus a polaris-only variant that records medium — the shadowing case."""
     return Manifest(
         schema_version=SCHEMA_VERSION,
         clusters=["sophia", "polaris"],
@@ -167,6 +169,11 @@ def _v6_manifest() -> Manifest:
                             "sophia": VerificationRecord(
                                 verified_at="2026-01-03T00:00:00Z", verified_device="cuda"
                             ),
+                        },
+                    ),
+                    "mace-mp-0-small": CheckpointInfo(
+                        fetched_at="2026-01-02T00:00:00Z",
+                        verifications={
                             "polaris": VerificationRecord(last_error="smoke-test: boom"),
                         },
                     ),
@@ -204,7 +211,7 @@ def test_push_payload_is_flat_per_cluster_v5():
 
 def test_push_payload_carries_only_that_clusters_results():
     payload = manifest_push_payload(_v6_manifest(), "polaris")
-    ckpt = payload["environments"]["mace"]["checkpoints"]["mace-mp-0-medium"]
+    ckpt = payload["environments"]["mace"]["checkpoints"]["mace-mp-0-small"]
     assert ckpt["verified_at"] is None
     assert ckpt["last_error"] == "smoke-test: boom"
 
@@ -222,16 +229,63 @@ def test_push_payload_omits_envs_not_serving_the_cluster():
 
 def test_push_payload_verify_error_beats_shared_download_error():
     manifest = _v6_manifest()
-    ckpt = manifest.environments["mace"].checkpoints["mace-mp-0-medium"]
+    ckpt = manifest.environments["mace"].checkpoints["mace-mp-0-small"]
     ckpt.last_error = "download: flaky mirror"
 
     sophia = manifest_push_payload(manifest, "sophia")["environments"]["mace"]["checkpoints"]
     polaris = manifest_push_payload(manifest, "polaris")["environments"]["mace"]["checkpoints"]
 
-    # sophia verified cleanly -> its payload falls back to the shared fetch error;
-    # polaris has its own verify error, which wins.
-    assert sophia["mace-mp-0-medium"]["last_error"] == "download: flaky mirror"
-    assert polaris["mace-mp-0-medium"]["last_error"] == "smoke-test: boom"
+    # sophia has no verify error -> its payload falls back to the shared fetch
+    # error; polaris has its own verify error, which wins.
+    assert sophia["mace-mp-0-small"]["last_error"] == "download: flaky mirror"
+    assert polaris["mace-mp-0-small"]["last_error"] == "smoke-test: boom"
+
+
+# --- per-id shadowing in the projection (#208, checkpoint-first) ---------------
+
+
+def test_push_payload_variant_shadows_universal_per_id():
+    manifest = _v6_manifest()
+    polaris = manifest_push_payload(manifest, "polaris")
+    sophia = manifest_push_payload(manifest, "sophia")
+
+    # polaris: the overridden id is listed under the variant only; the id the
+    # variant doesn't record stays under the universal env.
+    assert "mace-mp-0-medium" not in polaris["environments"]["mace"]["checkpoints"]
+    assert "mace-mp-0-medium" in polaris["environments"]["mace-polaris"]["checkpoints"]
+    assert "mace-mp-0-small" in polaris["environments"]["mace"]["checkpoints"]
+    # sophia's payload is untouched — the variant doesn't serve it.
+    assert "mace-mp-0-medium" in sophia["environments"]["mace"]["checkpoints"]
+    assert "mace-mp-0-small" in sophia["environments"]["mace"]["checkpoints"]
+
+
+def test_push_payload_shadowing_reads_records_not_declarations():
+    # Before the first checkpoint-first run writes the variant's record, the
+    # universal row must stay — dropping it with nothing to show under the
+    # variant would hide the id from the almanac entirely.
+    manifest = _v6_manifest()
+    manifest.environments["mace-polaris"].checkpoints.clear()
+    polaris = manifest_push_payload(manifest, "polaris")
+    assert "mace-mp-0-medium" in polaris["environments"]["mace"]["checkpoints"]
+
+
+def test_push_payload_equal_specificity_never_shadows():
+    # Two variants both serving polaris and recording the same id: an
+    # authoring error resolution rejects loudly — keep both rows rather than
+    # silently dropping one.
+    manifest = _v6_manifest()
+    manifest.environments["mace-polaris-b"] = EnvironmentInfo(
+        built_at="2026-01-01T00:00:00Z",
+        source_hash="sha256:ghi",
+        source="",
+        python_requires=">=3.11",
+        dependencies={},
+        clusters=["polaris"],
+        checkpoints={"mace-mp-0-medium": CheckpointInfo(fetched_at="2026-01-02T00:00:00Z")},
+    )
+    polaris = manifest_push_payload(manifest, "polaris")
+    assert "mace-mp-0-medium" in polaris["environments"]["mace-polaris"]["checkpoints"]
+    assert "mace-mp-0-medium" in polaris["environments"]["mace-polaris-b"]["checkpoints"]
 
 
 def test_client_pushes_one_payload_per_cluster(monkeypatch):

--- a/tests/test_env_clusters.py
+++ b/tests/test_env_clusters.py
@@ -1,0 +1,168 @@
+"""Cluster-scoped env variants (#208): CLUSTERS parsing and resolution.
+
+An env source may declare ``CLUSTERS = ["polaris"]`` to restrict itself to
+some of a shared install's clusters — the mechanism for shipping a
+polaris-only variant of an env that declares the same checkpoint ids.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rootstock.environment import (
+    CheckpointNotFoundError,
+    find_env_for_checkpoint,
+    parse_clusters_list,
+    resolve_checkpoint,
+)
+
+UNIVERSAL = """CHECKPOINTS = {"mace-mp-0-medium": "medium", "mace:custom": None}
+
+def setup(checkpoint, device="cuda"):
+    return None
+
+def setup_from_path(path, device="cuda"):
+    return None
+"""
+
+VARIANT = """CLUSTERS = ["polaris"]
+CHECKPOINTS = {"mace-mp-0-medium": "medium", "mace:custom": None}
+
+def setup(checkpoint, device="cuda"):
+    return None
+
+def setup_from_path(path, device="cuda"):
+    return None
+"""
+
+
+def _install(root: Path, name: str, source: str) -> None:
+    env_dir = root / "envs" / name
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+    (env_dir / "env_source.py").write_text(source)
+
+
+@pytest.fixture
+def shared_root(tmp_path: Path) -> Path:
+    _install(tmp_path, "mace", UNIVERSAL)
+    _install(tmp_path, "mace-polaris", VARIANT)
+    return tmp_path
+
+
+# --- parse_clusters_list -----------------------------------------------------
+
+
+def test_parse_clusters_absent_means_universal(tmp_path):
+    source = tmp_path / "env.py"
+    source.write_text(UNIVERSAL)
+    assert parse_clusters_list(source) is None
+
+
+def test_parse_clusters_list_literal(tmp_path):
+    source = tmp_path / "env.py"
+    source.write_text('CLUSTERS = ["sophia", "polaris"]\nCHECKPOINTS = {}\n')
+    assert parse_clusters_list(source) == ["sophia", "polaris"]
+
+
+@pytest.mark.parametrize(
+    "declaration",
+    [
+        "CLUSTERS = 'polaris'",  # not a list
+        "CLUSTERS = [42]",  # not string literals
+        "CLUSTERS = []",  # nobody could serve it
+        "CLUSTERS = [name for name in ()]",  # not a literal
+    ],
+)
+def test_parse_clusters_malformed_raises(tmp_path, declaration):
+    source = tmp_path / "env.py"
+    source.write_text(f"{declaration}\nCHECKPOINTS = {{}}\n")
+    with pytest.raises(ValueError):
+        parse_clusters_list(source)
+
+
+# --- resolution: specific beats universal --------------------------------------
+
+
+def test_variant_wins_on_its_cluster(shared_root):
+    env_name, _ = find_env_for_checkpoint(shared_root, "mace-mp-0-medium", "polaris")
+    assert env_name == "mace-polaris"
+
+
+def test_universal_serves_the_other_cluster(shared_root):
+    env_name, _ = find_env_for_checkpoint(shared_root, "mace-mp-0-medium", "sophia")
+    assert env_name == "mace"
+
+
+def test_no_cluster_resolves_to_universal(shared_root):
+    env_name, _ = find_env_for_checkpoint(shared_root, "mace-mp-0-medium")
+    assert env_name == "mace"
+
+
+def test_custom_ids_follow_the_same_rules(shared_root):
+    assert resolve_checkpoint(shared_root, "mace:custom", "polaris").env_name == "mace-polaris"
+    assert resolve_checkpoint(shared_root, "mace:custom", "sophia").env_name == "mace"
+
+
+def test_variant_only_id_without_cluster_asks_for_one(tmp_path):
+    _install(tmp_path, "mace-polaris", VARIANT)
+    with pytest.raises(CheckpointNotFoundError, match="cluster"):
+        find_env_for_checkpoint(tmp_path, "mace-mp-0-medium")
+
+
+def test_variant_only_id_on_wrong_cluster_errors(tmp_path):
+    _install(tmp_path, "mace-polaris", VARIANT)
+    with pytest.raises(CheckpointNotFoundError, match="sophia"):
+        find_env_for_checkpoint(tmp_path, "mace-mp-0-medium", "sophia")
+
+
+def test_same_specificity_collision_is_loud(tmp_path):
+    # Two unrestricted envs declaring the same id used to resolve by silent
+    # directory order; variants make duplicates legitimate, so ambiguity at
+    # the same specificity must be an authoring error instead.
+    _install(tmp_path, "mace-a", UNIVERSAL)
+    _install(tmp_path, "mace-b", UNIVERSAL)
+    with pytest.raises(CheckpointNotFoundError, match="several envs"):
+        find_env_for_checkpoint(tmp_path, "mace-mp-0-medium")
+    with pytest.raises(CheckpointNotFoundError, match="several envs"):
+        find_env_for_checkpoint(tmp_path, "mace-mp-0-medium", "sophia")
+
+
+def test_malformed_clusters_never_widens_a_variant(tmp_path):
+    # A broken CLUSTERS drops the env from contention rather than silently
+    # serving it everywhere.
+    broken = VARIANT.replace('CLUSTERS = ["polaris"]', "CLUSTERS = []")
+    _install(tmp_path, "mace", UNIVERSAL)
+    _install(tmp_path, "mace-polaris", broken)
+    env_name, _ = find_env_for_checkpoint(tmp_path, "mace-mp-0-medium", "polaris")
+    assert env_name == "mace"
+
+
+# --- resolve_current_cluster ----------------------------------------------------
+
+
+def test_resolve_current_cluster(tmp_path):
+    from rootstock.config import UserConfig
+    from rootstock.manifest import create_manifest, save_manifest
+    from rootstock.operations import OperationError, resolve_current_cluster
+
+    cfg = UserConfig(name="t", email="t@t.t")
+
+    solo = tmp_path / "solo"
+    save_manifest(create_manifest(solo, ["della"], cfg), solo)
+    assert resolve_current_cluster(solo) == "della"
+    assert resolve_current_cluster(solo, "della") == "della"
+
+    shared = tmp_path / "shared"
+    save_manifest(create_manifest(shared, ["sophia", "polaris"], cfg), shared)
+    assert resolve_current_cluster(shared, "polaris") == "polaris"
+    with pytest.raises(OperationError, match="sophia, polaris"):
+        resolve_current_cluster(shared)  # ambiguous — no honest default
+    with pytest.raises(OperationError, match="not one this install serves"):
+        resolve_current_cluster(shared, "frontier")  # typo protection
+
+    # No manifest, unregistered root: matches the "unknown" identity a
+    # created-on-the-fly manifest would get.
+    assert resolve_current_cluster(tmp_path / "fresh") == "unknown"

--- a/tests/test_install_state.py
+++ b/tests/test_install_state.py
@@ -45,7 +45,7 @@ def _env_record(source_hash: str = "sha256:abc") -> EnvironmentInfo:
 def _manifest(root: Path, environments: dict | None = None) -> Manifest:
     return Manifest(
         schema_version=SCHEMA_VERSION,
-        cluster="test",
+        clusters=["test"],
         root=str(root),
         maintainer=Maintainer(name="a", email="a@b.c"),
         rootstock_version="0.0.0",


### PR DESCRIPTION
Closes #208.

Sophia and Polaris mount the same Eagle root, so they shared one manifest saying `cluster: sophia`: Polaris smoke-test results were pushed under Sophia's name, each machine's nightly chain overwrote the other's verification stamps, and there was no way to ship an env that runs on one machine but not the other.

## Design

**One manifest file on disk, split at the wire.** Build/fetch state is genuinely shared (one filesystem, one weights cache), so the install keeps a single `manifest.json` — schema **v6**:

- `cluster: str` → `clusters: list[str]`
- per-checkpoint verification moves into `verifications: {cluster: {verified_at, verified_device, last_error}}`; `fetched_at` and download errors stay shared
- `EnvironmentInfo.clusters` mirrors an optional env-source `CLUSTERS` restriction (below)

**Migration is self-healing.** v5→v6 seeds sibling clusters from the registry: the deployed sophia manifest becomes `clusters: ["sophia", "polaris"]` on first touch by a v6 CLI — no manual re-init, no lost history. The mixed `last_error` splits by writer prefix (`download:` stays on the checkpoint; verify/smoke-test errors move under the old cluster, so siblings start honestly unverified).

**Wire format unchanged.** Pushes send one payload per cluster via `manifest_push_payload()` — a valid *flat v5* manifest, exactly what a dedicated single-cluster install would have written. The backend already files payloads by their `cluster` string and the almanac already has a polaris page, so **zero backend/almanac changes**. (Prod even has a stale `polaris` entry from May that this will finally refresh.)

**Verify-writers must say where they are.** `add`, `smoke-test`, and `sync` gain `--cluster`; on a shared install they refuse to guess (clear error naming the choices), while single-cluster installs need no flag. The nightly PBS/SLURM recipes gain a feature-detected `CLUSTER` knob so un-upgraded CLI generations keep running.

## Cluster-specific env variants

An env source may declare `CLUSTERS = ["polaris"]` (AST-parsed like `CHECKPOINTS`) to ship a variant with the same canonical ids and different pins. Resolution is cluster-aware: on a variant's clusters it beats the unrestricted env; elsewhere the original is untouched; same-specificity collisions error instead of resolving by directory order (previously silent first-match). smoke-test/sync skip envs the current machine doesn't serve; each cluster's pushed payload carries only the envs serving it; weights are shared for free (cache is keyed by checkpoint). `RootstockCalculator(cluster=...)` and `serve --cluster` pick the right variant. Docs in `docs/environments.md`.

## Bonus fix: usage attribution

Usage records stamped `cluster` via reverse root lookup, which returns `None` on the shared root — all ALCF usage was `cluster: null`. The calculator's `cluster=` now threads through to `record_session`, and `usage push` groups rollup rows by their own cluster instead of filing everything under one name.

## Compatibility

- The serve path never loads the manifest (resolution is from on-disk `CHECKPOINTS` tables), so pinned user clients are unaffected by the schema bump.
- Old CLIs touching a v6 manifest fail loudly with the existing "upgrade this client" error; the nightly chains self-upgrade each generation.

## Testing

- 849 passed, 3 skipped; ruff check/format and ty clean.
- New coverage: v5→v6 migration (registry seeding, error splitting), push-payload projection pinned against the wire shape, `CLUSTERS` parsing + resolution precedence, shared-install smoke-test behavior (requires `--cluster`, records under the right key without touching the sibling's, skips non-serving envs).
- E2E against reality: a copy of the deployed sophia manifest migrates to `["sophia", "polaris"]` and `smoke-test` exits 2 demanding `--cluster`; the projected payload's shape matches the current prod dump entry key-for-key (read-only curl).

🤖 Generated with [Claude Code](https://claude.com/claude-code)