### PR TITLE
Point sophia/polaris at the catalyst world-shared serving root

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,11 +118,13 @@ predate the declaration. Most clusters use the same path for both.
 | Cluster | Install Root | Cache Root (if split) |
 |---------|--------------|-----------------------|
 | `della` | `/scratch/gpfs/ROSENGROUP/common/rootstock` | (same as install root) |
-| `sophia` | `/eagle/projects/Rootstock/rootstock` | (same as install root) |
-| `polaris` | `/eagle/projects/Rootstock/rootstock` (shared with sophia) | (same as install root) |
+| `sophia` | `/lus/eagle/projects/catalyst/world-shared/rootstock` | (same as install root) |
+| `polaris` | `/lus/eagle/projects/catalyst/world-shared/rootstock` (shared with sophia) | (same as install root) |
 | `perlmutter` | `/global/cfs/cdirs/m5268/rootstock` | `/pscratch/sd/o/oprice/rootstock-cache` |
 | `delta` | `/work/hdd/data/rootstock` | (same as install root) |
 | `frontier` | `/sw/frontier/ums/ums047/rootstock` | `/lustre/orion/ums047/world-shared/rootstock-cache` |
+
+The sophia/polaris registry path is a world-shared *serving copy*, periodically rsync'd from the `/eagle/projects/Rootstock/rootstock` build root (not world-readable); admin sync/smoke-test jobs target the build root via explicit `--root`/`ROOTSTOCK_ROOT`.
 
 sophia/polaris share one install and one manifest (`clusters: ["sophia", "polaris"]`), but verification records and pushed manifests are per-cluster; verify-recording commands there need `--cluster`. An env source may declare `CLUSTERS = ["polaris"]` to ship a cluster-specific variant (see `docs/environments.md`); smoke-test selection and the pushed payloads are checkpoint-first — each id is tested and reported via the env it resolves to on that cluster.
 

--- a/rootstock/clusters.py
+++ b/rootstock/clusters.py
@@ -37,13 +37,16 @@ CLUSTER_REGISTRY: dict[str, Cluster] = {
     "della": Cluster(
         root=Path("/scratch/gpfs/ROSENGROUP/common/rootstock"),
     ),
-    "sophia": Cluster(
-        root=Path("/eagle/projects/Rootstock/rootstock"),
-    ),
+    # sophia/polaris resolve the world-shared serving copy, periodically
+    # rsync'd from the /eagle/projects/Rootstock build root (which is not
+    # world-readable; admin jobs target it via explicit --root/ROOTSTOCK_ROOT).
     # Polaris mounts the same Eagle filesystem as Sophia, so both ALCF
     # machines share one install.
+    "sophia": Cluster(
+        root=Path("/lus/eagle/projects/catalyst/world-shared/rootstock"),
+    ),
     "polaris": Cluster(
-        root=Path("/eagle/projects/Rootstock/rootstock"),
+        root=Path("/lus/eagle/projects/catalyst/world-shared/rootstock"),
     ),
     "perlmutter": Cluster(
         root=Path("/global/cfs/cdirs/m5268/rootstock"),

--- a/scripts/runbooks/sophia-polaris-delta.md
+++ b/scripts/runbooks/sophia-polaris-delta.md
@@ -7,7 +7,10 @@ tree once, but run the compute-node check on both machines.
 ## 0. Setup
 
 ```bash
-# sophia/polaris:
+# sophia/polaris — audit the serving copy users resolve (owned by the
+# catalyst project, not us; findings there go to its owner, not setup-perms):
+#   ROOT=/lus/eagle/projects/catalyst/world-shared/rootstock    GROUP=<catalyst project group>
+# sophia/polaris build root (ours; admin jobs only, not world-readable by design):
 #   ROOT=/eagle/projects/Rootstock/rootstock    GROUP=Rootstock
 # delta:
 #   ROOT=/work/hdd/data/rootstock      GROUP=<delta project group>


### PR DESCRIPTION
## Summary

ALCF declined our request to make `/eagle/projects/Rootstock` world-readable. The compromise (2026-08-04): a collaborator who owns the `catalyst` project periodically rsyncs our build root into `/lus/eagle/projects/catalyst/world-shared/rootstock`, and that world-readable serving copy is what users should resolve. This supersedes #207, which pointed the registry at the build root before this arrangement existed.

- `CLUSTER_REGISTRY`: `sophia` and `polaris` now resolve `/lus/eagle/projects/catalyst/world-shared/rootstock`, with a comment explaining the serving-copy/build-root split.
- `CLAUDE.md`: Known Clusters table updated, plus a sentence on the two-root arrangement.
- `scripts/runbooks/sophia-polaris-delta.md`: setup example now lists both roots — the serving copy is the audit target for user-facing readability (findings there go to its owner, since we can't write to it), the build root stays for admin work.

The build root `/eagle/projects/Rootstock/rootstock` remains where admin sync/smoke-test jobs run; they pass explicit `--root`/`ROOTSTOCK_ROOT` and are unaffected.

## Test plan

- `uv run pytest tests/test_clusters.py tests/cache/test_cache_root.py` — 41 passed (no test hardcodes the ALCF path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)