### PR TITLE
Fix two chain-killing bugs in the PBS self-scheduling recipe

### DIFF
--- a/docs/nightly-smoke-testing.md
+++ b/docs/nightly-smoke-testing.md
@@ -56,7 +56,8 @@ Two recipes with placeholders:
 
 3. **Verify a full cycle.** After the first run finishes, confirm:
    - a next run is queued — `squeue --me -n rootstock-nightly` (SLURM) /
-     `qstat -u $USER` (PBS) shows a pending/queued job, and
+     `qstat -u $USER` (PBS) shows a pending job (on PBS a job with a future
+     start time sits in state `W`, waiting — not `Q`), and
    - the manifest landed — `rootstock status` shows fresh `verified_at` times.
 
 ## How the self-scheduling works
@@ -85,9 +86,13 @@ Remove the stop file to allow a fresh kickoff later.
 ### Testing without waiting a week
 
 ```bash
-RESCHEDULE_BEGIN=now+3minutes sbatch scripts/nightly_smoke_test.sbatch   # SLURM
-qsub -a $(date -d "+3 minutes" +%m%d%H%M) scripts/nightly_smoke_test.pbs  # PBS
+RESCHEDULE_BEGIN=now+3minutes sbatch scripts/nightly_smoke_test.sbatch                    # SLURM
+qsub -v RESCHEDULE_AT=$(date -d "+3 minutes" +%m%d%H%M) scripts/nightly_smoke_test.pbs    # PBS
 ```
+
+Both override when generation 1 schedules generation 2, which is the handoff
+worth testing. (On PBS, `qsub -a <time>` would only delay generation 1's own
+start and exercises nothing about the chain.)
 
 ## Knobs
 

--- a/scripts/nightly_smoke_test.pbs
+++ b/scripts/nightly_smoke_test.pbs
@@ -17,19 +17,27 @@
 # The push IS the result channel, so nothing off-cluster waits on this job.
 #
 # One-time kickoff (submit from the directory containing this script; PBS has
-# no reliable way to recover the script path mid-job, so we reference it by
-# its submit directory):
+# no reliable way to recover the script path mid-job, so the FIRST generation
+# derives it from its submit directory, and every generation after that is
+# handed it explicitly via `qsub -v SELF_PATH=...`):
 #   qsub scripts/nightly_smoke_test.pbs
 #
 # Stop the chain:
 #   touch ~/.rootstock-nightly-stop      # next run won't reschedule
-#   qstat -u $USER                       # find the queued (Q) next run
+#   qstat -u $USER                       # find the waiting (W) next run
 #   qdel <jobid>                         # delete it
+# (A job submitted with -a sits in state W, not Q, until its start time.)
 #
-# Fast end-to-end test (reschedule ~3 min out instead of next week):
-#   qsub -a $(date -d "+3 minutes" +%m%d%H%M) scripts/nightly_smoke_test.pbs
-# (passing -a on the command line just kicks off the chain sooner; subsequent
-#  runs use the cadence below.)
+# If you MOVE or RENAME this script: the waiting next job carries the old
+# path, so qdel it and resubmit once from the new location.
+#
+# Fast end-to-end test (reschedule ~3 min out instead of next week, so you can
+# watch generation 1 hand off to generation 2):
+#   qsub -v RESCHEDULE_AT=$(date -d "+3 minutes" +%m%d%H%M) scripts/nightly_smoke_test.pbs
+# (Overriding RESCHEDULE_AT exercises the real handoff. `qsub -a <time>` would
+#  only delay generation 1's start and tests nothing about the chain. Knob
+#  overrides apply to generation 1 only — except CLUSTER, which is passed down
+#  the chain; the in-script defaults govern every subsequent generation.)
 
 set -euo pipefail
 
@@ -50,22 +58,30 @@ RESCHEDULE_AT="${RESCHEDULE_AT:-$(date -d "+${CADENCE_DAYS} days ${RUN_HOUR}" +%
 STOP_FILE="${STOP_FILE:-$HOME/.rootstock-nightly-stop}"
 JOB_NAME="${JOB_NAME:-rootstock-nightly}"
 
-# PBS copies the script to a spool dir, so $0 is unreliable. Reference the
-# original by submit directory (override SELF_PATH if you submit from elsewhere).
+# PBS copies the submitted script to a spool dir, so $0 is unreliable. On the
+# FIRST submission SELF_PATH is derived from the submit directory
+# ($PBS_O_WORKDIR); every generation then passes it down explicitly via
+# `qsub -v` (below) — a rescheduled job's own $PBS_O_WORKDIR is useless, it's
+# just the parent job's cwd ($HOME, since PBS starts jobs there).
 SELF_PATH="${SELF_PATH:-${PBS_O_WORKDIR:-$(pwd)}/nightly_smoke_test.pbs}"
 
 # --- Reschedule FIRST -------------------------------------------------------
 # Queue the next run before any work, so a crash in the smoke-test can't break
-# the chain. The next job sits queued (Q) until -a; qdel it to stop the chain.
+# the chain. The next job sits waiting (W) until -a; qdel it to stop the chain.
 if [[ -z "${PBS_JOBID:-}" ]]; then
   echo "not running under PBS; skipping reschedule (dry run)."
 elif [[ -e "$STOP_FILE" ]]; then
   echo "stop file present ($STOP_FILE); chain ends here."
-elif qselect -u "$USER" -N "$JOB_NAME" -s Q 2>/dev/null | grep -q .; then
-  # Belt-and-suspenders against duplicate chains.
-  echo "a '$JOB_NAME' job is already queued; not scheduling another."
+elif qselect -u "$USER" -N "$JOB_NAME" -s QW 2>/dev/null | grep -q .; then
+  # Belt-and-suspenders against duplicate chains. QW: a job with a future
+  # start time (-a) sits in state W, not Q.
+  echo "a '$JOB_NAME' job is already queued/waiting; not scheduling another."
 else
-  next_id="$(qsub -a "$RESCHEDULE_AT" "$SELF_PATH")"
+  # -v hands the next generation its own location (PBS does not propagate the
+  # environment down the chain) plus CLUSTER, which must survive to every
+  # generation on shared installs. -v passes ONLY the listed variables, so
+  # other knob overrides still die with generation 1, as before.
+  next_id="$(qsub -a "$RESCHEDULE_AT" -v SELF_PATH="$SELF_PATH",CLUSTER="$CLUSTER" "$SELF_PATH")"
   echo "scheduled next run: job $next_id (begins at $RESCHEDULE_AT)"
 fi
 


### PR DESCRIPTION
## Summary

Two latent bugs in `scripts/nightly_smoke_test.pbs` meant every PBS chain ran exactly one generation, then died silently — generation 2 crashed before its payload and never scheduled generation 3.

**Bug 1 — self-path breaks at generation 2.** The script located itself via `$PBS_O_WORKDIR`, which is only the submit directory for the *first*, human-submitted generation. For a job submitted *by another PBS job*, `PBS_O_WORKDIR` is the parent job's cwd — `$HOME`, since PBS starts jobs there and the script never `cd`s. Generation 2's `qsub` of the bogus `$HOME/...` path fails, and `set -euo pipefail` kills the job before the smoke-test runs. Fix: each generation passes the path down explicitly with `qsub -v SELF_PATH=...`; the existing `${SELF_PATH:-...}` default already honors the override. `CLUSTER` rides along in the same `-v`, since PBS doesn't propagate the environment down the chain and shared installs (sophia/polaris) need it on every generation — previously it would have silently reverted to the manifest default from generation 2 on. `-v` passes only the listed variables, so nothing else about the job environment changes.

**Bug 2 — duplicate-chain guard never matched.** The guard used `qselect ... -s Q`, but a job submitted with `-a` sits in state **W** (waiting), not Q, so the guard was a no-op. Fix: `-s QW`.

Also corrects the guidance that went with them, in the script header and `docs/nightly-smoke-testing.md`:
- Stopping a chain: look for the **waiting (W)** job, not a queued (Q) one.
- Fast end-to-end test: override `RESCHEDULE_AT` (via `qsub -v`) so generation 1 schedules generation 2 a few minutes out — that exercises the actual handoff. The previously suggested `qsub -a <time>` on the kickoff only delays generation 1's own start and tests nothing about the chain.

The SLURM sibling (`nightly_smoke_test.sbatch`) is unaffected: it recovers its path from `scontrol show job` and SLURM propagates the submit environment by default.

## Test plan

- `bash -n` on the edited script.
- The fixed pattern (explicit `-v SELF_PATH` handoff + `QW` guard) is lifted from a sibling self-scheduling chain script developed against ALCF; the running Sophia/Polaris chains will be re-kicked-off with per-cluster copies of this fix, which exercises the generation 1 → 2 handoff for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)