### PR TITLE
Warm checkpoint weights at spawn: fill prewarm_paths from manifest records (#178)

### DIFF
--- a/rootstock/environment.py
+++ b/rootstock/environment.py
@@ -183,10 +183,11 @@ def _matches_env(dir_name: str, packages: set[str], env_name: str) -> bool:
 
     Matching is exact or ``_``-boundary prefix in either direction
     (``cache/orb`` <-> ``orb_models``), after stripping the hidden-dir dot
-    (``home/.dgl`` <-> ``dgl``). Loose on purpose — over-matching one env's
-    own cache dir is harmless; the shared hub trees are excluded upstream.
+    (``home/.dgl`` <-> ``dgl``) and normalizing ``-`` to ``_``. Loose on
+    purpose — over-matching one env's own cache dir is harmless; the shared
+    hub trees are excluded upstream.
     """
-    name = dir_name.lstrip(".").lower()
+    name = dir_name.lstrip(".").lower().replace("-", "_")
     if not name:
         return False
     if name == env_name.lower() or name in packages:
@@ -199,6 +200,7 @@ def get_checkpoint_prewarm_paths(
     env_name: str,
     checkpoint_id: str,
     cache_root: Path | None = None,
+    allow_heuristic: bool = True,
 ) -> tuple[list[str], str | None]:
     """
     Resolve which model-weight paths a spawn should prewarm for a checkpoint,
@@ -206,12 +208,25 @@ def get_checkpoint_prewarm_paths(
     exists, else a best-effort scan of the shared cache for directories that
     look like this env's, else nothing.
 
+    The heuristic tier emits whole per-family cache dirs (``cache/mace``
+    holds every mace checkpoint's weights), so one unrecorded checkpoint
+    over-warms its cached siblings — a transitional cost, bounded by the
+    family and gone once the checkpoint has a record (one add/verify/
+    smoke-test pass). The tier tag in the prewarm summary is the telemetry
+    for retiring it.
+
     Args:
         root: Rootstock install root.
         env_name: The checkpoint's hosting env.
         checkpoint_id: Canonical (or ``:custom``) checkpoint id.
         cache_root: Optional split cache root (see get_model_cache_env);
             recorded paths are relative to it.
+        allow_heuristic: When False, resolve from the manifest record only.
+            Download spawns pass False: the record is written *after* a
+            download, so a first-time ``rootstock add`` would always fall
+            through to the heuristic and cold-read the whole family dir —
+            typically on a login node — for weights it may be about to
+            (re)write.
 
     Returns:
         ``(paths, tier)`` — absolute path strings (files for the manifest
@@ -230,28 +245,35 @@ def get_checkpoint_prewarm_paths(
         paths = [
             str(base / entry["path"])
             for entry in recorded
-            if isinstance(entry, dict) and entry.get("path")
+            if isinstance(entry, dict) and isinstance(entry.get("path"), str) and entry["path"]
         ]
-        if paths:
+        # An intact record whose files were all purged (scratch sweeps on
+        # Frontier/Perlmutter) must not win the tier: the worker would log
+        # "weights: 0 MB (manifest)" while cold-faulting — misattributing
+        # exactly the stall this telemetry exists to catch. One stat usually
+        # settles it (the first path exists); records self-heal on the next
+        # add/verify/smoke-test pass.
+        if any(os.path.exists(p) for p in paths):
             return paths, "manifest"
 
-    if is_custom_checkpoint(checkpoint_id):
+    if is_custom_checkpoint(checkpoint_id) or not allow_heuristic:
         return [], None
 
     packages = _env_top_level_packages(root, env_name)
     matched: list[str] = []
     home = base / "home"
-    for scan in (base / "cache", home / ".cache", home):
+    dot_cache = home / ".cache"
+    for scan in (base / "cache", dot_cache, home):
         try:
             children = sorted(scan.iterdir())
         except OSError:
             continue
         for child in children:
-            if not child.is_dir() or child == home / ".cache":
+            # Pure-string filters first: each is_dir() is a stat — an RPC
+            # per entry on cold network filesystems — so it goes last.
+            if child.name.lstrip(".").lower() in _SHARED_HUB_TREES or child == dot_cache:
                 continue
-            if child.name.lstrip(".").lower() in _SHARED_HUB_TREES:
-                continue
-            if _matches_env(child.name, packages, env_name):
+            if _matches_env(child.name, packages, env_name) and child.is_dir():
                 matched.append(str(child))
     return (matched, "heuristic") if matched else ([], "none")
 

--- a/rootstock/environment.py
+++ b/rootstock/environment.py
@@ -12,6 +12,7 @@ Running code inside an env lives in rootstock.spawn.
 from __future__ import annotations
 
 import ast
+import json
 import os
 import shutil
 from dataclasses import dataclass
@@ -128,6 +129,131 @@ def get_model_cache_env(root: Path, cache_root: Path | None = None) -> dict[str,
             env[auth_var] = os.environ[auth_var]
 
     return env
+
+
+# Cache subtrees the heuristic tier must never emit: hub caches keyed by
+# *library* name (huggingface_hub's blobs, torch.hub) hold every model
+# family's weights side by side, so any env that ships the library would
+# "match" the whole shared tree — multiplying the cold-read volume and, under
+# a job's memory cgroup, evicting the pages the worker actually needs. Files
+# inside these trees are reachable only via the manifest tier's exact records.
+_SHARED_HUB_TREES = frozenset({"huggingface", "torch"})
+
+
+def _recorded_weight_files(root: Path, env_name: str, checkpoint_id: str) -> list[dict] | None:
+    """The checkpoint's ``weight_files`` manifest record (#177), or None.
+
+    Deliberately a raw ``manifest.json`` read rather than ``load_manifest``:
+    this runs on the calculator's spawn path as an optimization hint, so it
+    must never print migration notes, take locks, or refuse a manifest
+    written by a newer rootstock — any manifest we can't make sense of just
+    means "no record" and the caller falls back a tier.
+    """
+    try:
+        with open(root / "manifest.json") as f:
+            data = json.load(f)
+        env = data.get("environments", {}).get(env_name) or {}
+        record = (env.get("checkpoints") or {}).get(checkpoint_id) or {}
+        weight_files = record.get("weight_files")
+    except (OSError, ValueError, AttributeError):
+        return None
+    return weight_files if isinstance(weight_files, list) else None
+
+
+def _env_top_level_packages(root: Path, env_name: str) -> set[str]:
+    """Lowercased top-level names the built env ships in site-packages."""
+    names: set[str] = set()
+    for site in (root / "envs" / env_name / "lib").glob("python*/site-packages"):
+        try:
+            children = list(site.iterdir())
+        except OSError:
+            continue
+        for child in children:
+            name = child.name
+            if name == "__pycache__" or name.endswith((".dist-info", ".egg-info", ".pth")):
+                continue
+            # foo.py / foo.cpython-311-x86_64.so -> foo
+            names.add(name.split(".", 1)[0].lower())
+    names.discard("")
+    return names
+
+
+def _matches_env(dir_name: str, packages: set[str], env_name: str) -> bool:
+    """True when a cache dir name plausibly belongs to this env.
+
+    Matching is exact or ``_``-boundary prefix in either direction
+    (``cache/orb`` <-> ``orb_models``), after stripping the hidden-dir dot
+    (``home/.dgl`` <-> ``dgl``). Loose on purpose — over-matching one env's
+    own cache dir is harmless; the shared hub trees are excluded upstream.
+    """
+    name = dir_name.lstrip(".").lower()
+    if not name:
+        return False
+    if name == env_name.lower() or name in packages:
+        return True
+    return any(pkg.startswith(name + "_") or name.startswith(pkg + "_") for pkg in packages)
+
+
+def get_checkpoint_prewarm_paths(
+    root: Path | str,
+    env_name: str,
+    checkpoint_id: str,
+    cache_root: Path | None = None,
+) -> tuple[list[str], str | None]:
+    """
+    Resolve which model-weight paths a spawn should prewarm for a checkpoint,
+    tiered (#178): the manifest's exact ``weight_files`` record when one
+    exists, else a best-effort scan of the shared cache for directories that
+    look like this env's, else nothing.
+
+    Args:
+        root: Rootstock install root.
+        env_name: The checkpoint's hosting env.
+        checkpoint_id: Canonical (or ``:custom``) checkpoint id.
+        cache_root: Optional split cache root (see get_model_cache_env);
+            recorded paths are relative to it.
+
+    Returns:
+        ``(paths, tier)`` — absolute path strings (files for the manifest
+        tier, directories for the heuristic tier) and the tier that produced
+        them: ``"manifest"``, ``"heuristic"``, or ``"none"`` (a canonical
+        checkpoint with no record and no heuristic match — worth surfacing in
+        the prewarm summary). ``:custom`` checkpoints with no record return
+        ``([], None)``: the user's weights file already rides
+        ``checkpoint_path`` into the prewarm, so there is nothing to report.
+    """
+    root = Path(root)
+    base = Path(cache_root) if cache_root is not None else root
+
+    recorded = _recorded_weight_files(root, env_name, checkpoint_id)
+    if recorded:
+        paths = [
+            str(base / entry["path"])
+            for entry in recorded
+            if isinstance(entry, dict) and entry.get("path")
+        ]
+        if paths:
+            return paths, "manifest"
+
+    if is_custom_checkpoint(checkpoint_id):
+        return [], None
+
+    packages = _env_top_level_packages(root, env_name)
+    matched: list[str] = []
+    home = base / "home"
+    for scan in (base / "cache", home / ".cache", home):
+        try:
+            children = sorted(scan.iterdir())
+        except OSError:
+            continue
+        for child in children:
+            if not child.is_dir() or child == home / ".cache":
+                continue
+            if child.name.lstrip(".").lower() in _SHARED_HUB_TREES:
+                continue
+            if _matches_env(child.name, packages, env_name):
+                matched.append(str(child))
+    return (matched, "heuristic") if matched else ([], "none")
 
 
 def get_env_python(root: Path | str, env_name: str) -> Path:

--- a/rootstock/prewarm.py
+++ b/rootstock/prewarm.py
@@ -176,20 +176,19 @@ def _cgroup_memory_limit(
             continue
         _, controllers, cgroup_path = parts
         if controllers == "":  # v2 unified hierarchy
-            base = Path(cgroup_root)
+            base, filename = Path(cgroup_root), "memory.max"
         elif "memory" in controllers.split(","):
-            base = Path(cgroup_root) / "memory"
+            base, filename = Path(cgroup_root) / "memory", "memory.limit_in_bytes"
         else:
             continue
         node = base / cgroup_path.lstrip("/")
         for current in (node, *node.parents):
-            for filename in ("memory.max", "memory.limit_in_bytes"):
-                try:
-                    raw = (current / filename).read_text().strip()
-                except OSError:
-                    continue
-                if raw.isdigit() and int(raw) < _CGROUP_NO_LIMIT:
-                    limits.append(int(raw))
+            try:
+                raw = (current / filename).read_text().strip()
+            except OSError:
+                raw = ""
+            if raw.isdigit() and int(raw) < _CGROUP_NO_LIMIT:
+                limits.append(int(raw))
             if current == base:
                 break
     return min(limits) if limits else None
@@ -241,13 +240,20 @@ def prewarm_from_spec(spec: dict, log=None) -> None:
 
         summary = (
             f"[Worker] Prewarmed page cache: {n_files} files, "
-            f"{n_bytes / 1e6:.0f} MB in {elapsed:.1f}s"
+            f"{_fmt_bytes(n_bytes)} in {elapsed:.1f}s"
         )
         tier = spec.get("prewarm_weights_tier")
         if tier == "none":
             summary += "; weights: none recorded"
         elif tier or weight_sized:
-            summary += f"; weights: {_fmt_bytes(weight_bytes)} ({tier or 'custom'})"
+            # No tier annotation means spawn_in_env didn't fill the paths:
+            # either the caller supplied its own prewarm_paths, or only a
+            # :custom checkpoint_path contributed. Label accordingly — this
+            # line is the field data for retiring the heuristic, so tags
+            # must not lie about provenance.
+            if not tier:
+                tier = "custom" if not spec.get("prewarm_paths") else "caller"
+            summary += f"; weights: {_fmt_bytes(weight_bytes)} ({tier})"
         print(summary, file=log, flush=True)
     except Exception as exc:  # noqa: BLE001 - never take the worker down
         try:

--- a/rootstock/prewarm.py
+++ b/rootstock/prewarm.py
@@ -44,22 +44,24 @@ def _thread_count() -> int:
     return max(1, n)
 
 
-def iter_prewarm_files(spec: dict):
-    """Yield the files worth warming for a worker spawn spec.
-
-    - every file under the env tree (the ``.so`` libraries dominate the
-      volume, but imports also open thousands of small ``.py``/``.pyc``
-      files whose cold reads are just as latency-bound — covering them adds
-      little data and removes the residual small-file tail),
-    - the user-supplied (:custom) weights file, when the spec names one,
-    - any extra files or directory trees a client lists in
-      ``spec["prewarm_paths"]`` (reserved for future use; directories are
-      walked recursively).
-    """
+def _iter_env_files(spec: dict):
+    """Every file under the env tree: the ``.so`` libraries dominate the
+    volume, but imports also open thousands of small ``.py``/``.pyc`` files
+    whose cold reads are just as latency-bound — covering them adds little
+    data and removes the residual small-file tail."""
     env_dir = spec.get("env_dir")
     if env_dir:
         yield from sorted(p for p in Path(env_dir).rglob("*") if p.is_file())
 
+
+def _iter_weight_files(spec: dict):
+    """The spawn's model-weight files, outside the env tree:
+
+    - checkpoint weight paths in ``spec["prewarm_paths"]``, filled by
+      spawn_in_env from the checkpoint's manifest record or the cache-scan
+      heuristic (#178; directories are walked recursively),
+    - the user-supplied (:custom) weights file, when the spec names one.
+    """
     extras = list(spec.get("prewarm_paths") or [])
     if spec.get("checkpoint_path"):
         extras.append(spec["checkpoint_path"])
@@ -69,6 +71,13 @@ def iter_prewarm_files(spec: dict):
             yield from sorted(p for p in path.rglob("*") if p.is_file())
         elif path.is_file():
             yield path
+
+
+def iter_prewarm_files(spec: dict):
+    """Yield the files worth warming for a worker spawn spec: the whole env
+    tree, then the checkpoint's weight files (see the helpers above)."""
+    yield from _iter_env_files(spec)
+    yield from _iter_weight_files(spec)
 
 
 def _read_file(path) -> int:
@@ -83,18 +92,13 @@ def _read_file(path) -> int:
     return n
 
 
-def prewarm_files(paths, max_workers: int | None = None) -> tuple[int, int]:
-    """Read ``paths`` concurrently, discarding the bytes.
+def _stat_files(paths) -> list[tuple[int, Path]]:
+    """Dedup ``paths`` and pair each with its size, dropping unstattable ones.
 
-    Each file is one unit of work (streamed sequentially within itself, so
-    readahead still engages), dispatched largest-first across the reader
-    pool. Duplicate paths are read once. Returns ``(n_files, n_bytes)``
-    actually read. Files that vanish or can't be opened are skipped — the
-    goal is a warm cache, not an audit.
+    The size lookup doubles as dedup + existence filter; the rglob that
+    produced these paths just stat'ed them, so the attributes are still
+    in the client's metadata cache and this pass is cheap.
     """
-    # Size lookup doubles as dedup + existence filter; the rglob that
-    # produced these paths just stat'ed them, so the attributes are still
-    # in the client's metadata cache and this pass is cheap.
     sized: list[tuple[int, Path]] = []
     seen = set()
     for path in paths:
@@ -106,7 +110,12 @@ def prewarm_files(paths, max_workers: int | None = None) -> tuple[int, int]:
             sized.append((os.stat(path).st_size, path))
         except OSError:
             continue
-    sized.sort(key=lambda item: item[0], reverse=True)
+    return sized
+
+
+def _read_sized(sized: list[tuple[int, Path]], max_workers: int | None = None) -> tuple[int, int]:
+    """Read pre-stat'ed files concurrently, largest-first; see prewarm_files."""
+    sized = sorted(sized, key=lambda item: item[0], reverse=True)
 
     if max_workers is None:
         max_workers = _thread_count()
@@ -124,13 +133,78 @@ def prewarm_files(paths, max_workers: int | None = None) -> tuple[int, int]:
     return n_files, n_bytes
 
 
+def prewarm_files(paths, max_workers: int | None = None) -> tuple[int, int]:
+    """Read ``paths`` concurrently, discarding the bytes.
+
+    Each file is one unit of work (streamed sequentially within itself, so
+    readahead still engages), dispatched largest-first across the reader
+    pool. Duplicate paths are read once. Returns ``(n_files, n_bytes)``
+    actually read. Files that vanish or can't be opened are skipped — the
+    goal is a warm cache, not an audit.
+    """
+    return _read_sized(_stat_files(paths), max_workers)
+
+
+def _fmt_bytes(n: int) -> str:
+    return f"{n / 1e9:.1f} GB" if n >= 1e9 else f"{n / 1e6:.0f} MB"
+
+
+# cgroup v1's "no limit" placeholder is PAGE_COUNTER_MAX (~2**63); anything
+# in that region is a sentinel, not a limit a job scheduler configured.
+_CGROUP_NO_LIMIT = 1 << 60
+
+
+def _cgroup_memory_limit(
+    proc_cgroup: str = "/proc/self/cgroup", cgroup_root: str = "/sys/fs/cgroup"
+) -> int | None:
+    """This process's effective cgroup memory limit in bytes, or None.
+
+    Page-cache pages are charged to the job's memory cgroup, so the limit —
+    not node RAM — is the warmth budget. Checks every ancestor of our cgroup
+    because schedulers typically set the limit on the job slice, not the
+    leaf (SLURM's ``--mem``). Handles v2 (``memory.max``) and legacy v1
+    (``memory/…/memory.limit_in_bytes``); best-effort, None on any surprise.
+    """
+    try:
+        lines = Path(proc_cgroup).read_text().splitlines()
+    except OSError:
+        return None
+    limits = []
+    for line in lines:
+        parts = line.split(":", 2)
+        if len(parts) != 3:
+            continue
+        _, controllers, cgroup_path = parts
+        if controllers == "":  # v2 unified hierarchy
+            base = Path(cgroup_root)
+        elif "memory" in controllers.split(","):
+            base = Path(cgroup_root) / "memory"
+        else:
+            continue
+        node = base / cgroup_path.lstrip("/")
+        for current in (node, *node.parents):
+            for filename in ("memory.max", "memory.limit_in_bytes"):
+                try:
+                    raw = (current / filename).read_text().strip()
+                except OSError:
+                    continue
+                if raw.isdigit() and int(raw) < _CGROUP_NO_LIMIT:
+                    limits.append(int(raw))
+            if current == base:
+                break
+    return min(limits) if limits else None
+
+
 def prewarm_from_spec(spec: dict, log=None) -> None:
     """Warm the page cache for a worker spawn spec; never raises.
 
     The one-line summary goes to ``log`` (default stderr, so it lands in
     the worker's captured output and any post-mortem) — its duration is a
     direct read on filesystem health: seconds when warm, and when cold it
-    replaces an hours-long stall with a visible, bounded read.
+    replaces an hours-long stall with a visible, bounded read. The weights
+    portion is reported separately, tagged with the tier that resolved it
+    (#178) — field data for retiring the heuristic once manifest records
+    are universal.
     """
     if os.environ.get("ROOTSTOCK_NO_PREWARM"):
         return
@@ -138,14 +212,43 @@ def prewarm_from_spec(spec: dict, log=None) -> None:
         log = sys.stderr
     try:
         began = time.monotonic()
-        n_files, n_bytes = prewarm_files(iter_prewarm_files(spec))
+        env_sized = _stat_files(_iter_env_files(spec))
+        env_paths = {path for _, path in env_sized}
+        weight_sized = [
+            item for item in _stat_files(_iter_weight_files(spec)) if item[1] not in env_paths
+        ]
+        weight_bytes = sum(size for size, _ in weight_sized)
+
+        # Cached pages are charged to the job's memory cgroup: a working set
+        # bigger than the limit means early-warmed pages are evicted before
+        # the worker reads them, silently re-paying the cold-fault tax
+        # (observed on Delta, 2026-07-29). Warn up front — before the reads —
+        # so the line survives even if the warm-up itself then stalls.
+        expected = sum(size for size, _ in env_sized) + weight_bytes
+        limit = _cgroup_memory_limit()
+        if limit is not None and expected > limit:
+            print(
+                f"[Worker] Warning: expected cold working set "
+                f"{_fmt_bytes(expected)} exceeds this job's memory limit "
+                f"{_fmt_bytes(limit)}; warmed pages will be evicted before "
+                f"the worker reads them — request more memory for the job",
+                file=log,
+                flush=True,
+            )
+
+        n_files, n_bytes = _read_sized(env_sized + weight_sized)
         elapsed = time.monotonic() - began
-        print(
+
+        summary = (
             f"[Worker] Prewarmed page cache: {n_files} files, "
-            f"{n_bytes / 1e6:.0f} MB in {elapsed:.1f}s",
-            file=log,
-            flush=True,
+            f"{n_bytes / 1e6:.0f} MB in {elapsed:.1f}s"
         )
+        tier = spec.get("prewarm_weights_tier")
+        if tier == "none":
+            summary += "; weights: none recorded"
+        elif tier or weight_sized:
+            summary += f"; weights: {_fmt_bytes(weight_bytes)} ({tier or 'custom'})"
+        print(summary, file=log, flush=True)
     except Exception as exc:  # noqa: BLE001 - never take the worker down
         try:
             print(f"[Worker] Prewarm skipped: {type(exc).__name__}: {exc}", file=log, flush=True)

--- a/rootstock/spawn.py
+++ b/rootstock/spawn.py
@@ -22,6 +22,7 @@ node-local and auto-cleaned rather than shared.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import shutil
 import tempfile
@@ -30,7 +31,9 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 
-from .environment import get_env_python, get_model_cache_env
+from .environment import get_checkpoint_prewarm_paths, get_env_python, get_model_cache_env
+
+logger = logging.getLogger(__name__)
 
 WORKER_WRAPPER = """\
 import json, os, sys
@@ -154,11 +157,15 @@ def spawn_in_env(
         env_name: Name of the pre-built environment.
         wrapper_source: One of the static wrapper sources in this module.
         payload: JSON-serializable values the wrapper reads from the sidecar.
-            ``env_dir`` is filled in here; everything else is the caller's.
-            A ``weights_capture`` entry of ``{"result_path", "cache_root"}``
-            makes the wrapper record which weight files setup() touches
-            (see weights_capture.py); the caller reads ``result_path`` after
-            the process exits.
+            ``env_dir`` is filled in here, and when the payload names a
+            ``checkpoint``, so are ``prewarm_paths``/``prewarm_weights_tier``
+            (the checkpoint's weight files from the manifest record, or a
+            heuristic cache scan — see get_checkpoint_prewarm_paths, #178);
+            a caller-supplied ``prewarm_paths`` is left alone. Everything
+            else is the caller's. A ``weights_capture`` entry of
+            ``{"result_path", "cache_root"}`` makes the wrapper record which
+            weight files setup() touches (see weights_capture.py); the
+            caller reads ``result_path`` after the process exits.
         cache_root: Optional split cache root (see get_model_cache_env).
         offline: Forbid HuggingFace Hub network access (HF_HUB_OFFLINE=1).
             Workers serve weights pre-fetched by ``rootstock add`` and often
@@ -172,6 +179,21 @@ def spawn_in_env(
     root = Path(root)
     env_python = get_env_python(root, env_name)
     env_dir = root / "envs" / env_name
+
+    # Fill the weight-prewarm hint here rather than in each caller: every
+    # spawn (calculator, verify, serve, add) benefits, and this is the same
+    # choke point that already owns env_dir and the cache env vars.
+    # Best-effort by contract — a failed lookup must never fail the spawn.
+    if payload.get("checkpoint") and "prewarm_paths" not in payload:
+        try:
+            paths, tier = get_checkpoint_prewarm_paths(
+                root, env_name, payload["checkpoint"], cache_root
+            )
+        except Exception:
+            logger.debug("prewarm path lookup failed; spawning without", exc_info=True)
+        else:
+            if tier is not None:
+                payload = {**payload, "prewarm_paths": paths, "prewarm_weights_tier": tier}
 
     env = os.environ.copy()
     env.update(get_model_cache_env(root, cache_root))

--- a/rootstock/spawn.py
+++ b/rootstock/spawn.py
@@ -184,10 +184,18 @@ def spawn_in_env(
     # spawn (calculator, verify, serve, add) benefits, and this is the same
     # choke point that already owns env_dir and the cache env vars.
     # Best-effort by contract — a failed lookup must never fail the spawn.
+    # Download spawns get the record tier only: their weight record is
+    # written after the download, so the heuristic would cold-read whole
+    # family cache dirs (typically on a login node) for weights the
+    # download may be about to (re)write.
     if payload.get("checkpoint") and "prewarm_paths" not in payload:
         try:
             paths, tier = get_checkpoint_prewarm_paths(
-                root, env_name, payload["checkpoint"], cache_root
+                root,
+                env_name,
+                payload["checkpoint"],
+                cache_root,
+                allow_heuristic=wrapper_source != DOWNLOAD_WRAPPER,
             )
         except Exception:
             logger.debug("prewarm path lookup failed; spawning without", exc_info=True)

--- a/tests/local/test_prewarm_lookup.py
+++ b/tests/local/test_prewarm_lookup.py
@@ -1,0 +1,170 @@
+"""Spawn-time resolution of a checkpoint's weight-prewarm paths (#178).
+
+Tiered: the manifest's exact ``weight_files`` record when one exists (#177),
+else a heuristic scan of the shared cache for directories that look like the
+env's, else nothing. The manifest read is deliberately raw and best-effort —
+it must never print, lock, or refuse a newer schema on the calculator's
+spawn path — so corrupt or futuristic manifests just fall back a tier.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from rootstock.environment import get_checkpoint_prewarm_paths
+
+
+def _write_manifest(root: Path, env_name: str, checkpoint: str, weight_files) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 6,
+                "environments": {
+                    env_name: {"checkpoints": {checkpoint: {"weight_files": weight_files}}}
+                },
+            }
+        )
+    )
+
+
+def _ship_packages(root: Path, env_name: str, *packages: str) -> None:
+    site = root / "envs" / env_name / "lib" / "python3.11" / "site-packages"
+    site.mkdir(parents=True, exist_ok=True)
+    for package in packages:
+        (site / package).mkdir()
+
+
+def test_manifest_record_wins(tmp_path: Path):
+    _write_manifest(
+        tmp_path,
+        "uma",
+        "uma-s-1p1",
+        [
+            {"path": "cache/huggingface/hub/models--facebook--UMA/blobs/abc", "size": 7},
+            {"path": "home/.cache/fairchem/model.pt", "size": 3},
+        ],
+    )
+    paths, tier = get_checkpoint_prewarm_paths(tmp_path, "uma", "uma-s-1p1")
+    assert tier == "manifest"
+    assert paths == [
+        str(tmp_path / "cache/huggingface/hub/models--facebook--UMA/blobs/abc"),
+        str(tmp_path / "home/.cache/fairchem/model.pt"),
+    ]
+
+
+def test_manifest_paths_join_split_cache_root(tmp_path: Path):
+    """Records are cache-root-relative so they survive split-cache installs."""
+    _write_manifest(tmp_path / "install", "uma", "uma-s-1p1", [{"path": "cache/w.pt", "size": 1}])
+    paths, tier = get_checkpoint_prewarm_paths(
+        tmp_path / "install", "uma", "uma-s-1p1", cache_root=tmp_path / "scratch-cache"
+    )
+    assert tier == "manifest"
+    assert paths == [str(tmp_path / "scratch-cache" / "cache" / "w.pt")]
+
+
+def test_no_record_falls_back_to_heuristic(tmp_path: Path):
+    _ship_packages(tmp_path, "orb", "orb_models", "dgl", "numpy")
+    for matching in ("cache/orb", "home/.dgl"):
+        (tmp_path / matching).mkdir(parents=True)
+    (tmp_path / "cache" / "some-other-env").mkdir()
+
+    paths, tier = get_checkpoint_prewarm_paths(tmp_path, "orb", "orb-v2")
+    assert tier == "heuristic"
+    # cache/orb matches orb_models at the "_" boundary; home/.dgl matches dgl
+    # after the hidden-dir dot; the unrelated dir stays out.
+    assert paths == [str(tmp_path / "cache" / "orb"), str(tmp_path / "home" / ".dgl")]
+
+
+def test_heuristic_matches_env_name_dir(tmp_path: Path):
+    _ship_packages(tmp_path, "mace")  # ships nothing that matches by package name
+    (tmp_path / "cache" / "mace").mkdir(parents=True)
+    paths, tier = get_checkpoint_prewarm_paths(tmp_path, "mace", "mace-mp-0-medium")
+    assert tier == "heuristic"
+    assert paths == [str(tmp_path / "cache" / "mace")]
+
+
+def test_heuristic_never_includes_shared_hub_trees(tmp_path: Path):
+    """huggingface/torch hub trees hold every family's weights — an env that
+    ships huggingface_hub or torch must not match the whole shared tree."""
+    _ship_packages(tmp_path, "uma", "huggingface_hub", "torch", "fairchem")
+    for shared in ("cache/huggingface", "cache/torch"):
+        (tmp_path / shared).mkdir(parents=True)
+    (tmp_path / "home" / ".cache" / "fairchem").mkdir(parents=True)
+
+    paths, tier = get_checkpoint_prewarm_paths(tmp_path, "uma", "uma-s-1p1")
+    assert tier == "heuristic"
+    assert paths == [str(tmp_path / "home" / ".cache" / "fairchem")]
+
+
+def test_heuristic_scans_home_but_skips_dot_cache_itself(tmp_path: Path):
+    """home/.cache is scanned per-child; the dir itself must not double in
+    as a whole tree (an env shipping a 'cache'-named package would match)."""
+    _ship_packages(tmp_path, "weird", "cache")
+    (tmp_path / "home" / ".cache" / "unrelated").mkdir(parents=True)
+    paths, tier = get_checkpoint_prewarm_paths(tmp_path, "weird", "weird-1")
+    assert tier == "none"
+    assert paths == []
+
+
+def test_nothing_found_reports_none(tmp_path: Path):
+    _ship_packages(tmp_path, "mace", "mace_torch")
+    paths, tier = get_checkpoint_prewarm_paths(tmp_path, "mace", "mace-mp-0-medium")
+    assert (paths, tier) == ([], "none")
+
+
+def test_custom_checkpoint_skips_heuristic(tmp_path: Path):
+    """:custom weights ride checkpoint_path into the prewarm already; with no
+    record there is nothing to resolve and nothing worth a 'none' report."""
+    _ship_packages(tmp_path, "uma", "fairchem")
+    (tmp_path / "home" / ".cache" / "fairchem").mkdir(parents=True)
+    paths, tier = get_checkpoint_prewarm_paths(tmp_path, "uma", "uma:custom")
+    assert (paths, tier) == ([], None)
+
+
+def test_custom_checkpoint_uses_record_when_present(tmp_path: Path):
+    """smoke-test records :custom loads too (#204) — an exact record beats
+    skipping even for custom ids."""
+    _write_manifest(tmp_path, "uma", "uma:custom", [{"path": "cache/base.pt", "size": 1}])
+    paths, tier = get_checkpoint_prewarm_paths(tmp_path, "uma", "uma:custom")
+    assert tier == "manifest"
+    assert paths == [str(tmp_path / "cache" / "base.pt")]
+
+
+@pytest.mark.parametrize(
+    "manifest_body",
+    ["not json at all", json.dumps({"environments": "not-a-dict"}), json.dumps([1, 2, 3])],
+)
+def test_unreadable_manifest_falls_back(tmp_path: Path, manifest_body: str):
+    (tmp_path / "manifest.json").write_text(manifest_body)
+    _ship_packages(tmp_path, "orb", "orb_models")
+    (tmp_path / "cache" / "orb").mkdir(parents=True)
+    paths, tier = get_checkpoint_prewarm_paths(tmp_path, "orb", "orb-v2")
+    assert tier == "heuristic"
+    assert paths == [str(tmp_path / "cache" / "orb")]
+
+
+def test_malformed_record_entries_are_skipped(tmp_path: Path):
+    _write_manifest(
+        tmp_path,
+        "uma",
+        "uma-s-1p1",
+        ["bare-string", {"size": 5}, {"path": "cache/ok.pt", "size": 5}],
+    )
+    paths, tier = get_checkpoint_prewarm_paths(tmp_path, "uma", "uma-s-1p1")
+    assert tier == "manifest"
+    assert paths == [str(tmp_path / "cache" / "ok.pt")]
+
+
+def test_empty_record_falls_back_to_heuristic(tmp_path: Path):
+    """#177 never writes empty records (byte floor keeps None instead), so a
+    [] here means 'unrecorded', not 'warm nothing'."""
+    _write_manifest(tmp_path, "orb", "orb-v2", [])
+    _ship_packages(tmp_path, "orb", "orb_models")
+    (tmp_path / "cache" / "orb").mkdir(parents=True)
+    paths, tier = get_checkpoint_prewarm_paths(tmp_path, "orb", "orb-v2")
+    assert tier == "heuristic"
+    assert paths == [str(tmp_path / "cache" / "orb")]

--- a/tests/local/test_prewarm_lookup.py
+++ b/tests/local/test_prewarm_lookup.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 
 from rootstock.environment import get_checkpoint_prewarm_paths
+from rootstock.manifest import SCHEMA_VERSION
 
 
 def _write_manifest(root: Path, env_name: str, checkpoint: str, weight_files) -> None:
@@ -22,13 +23,21 @@ def _write_manifest(root: Path, env_name: str, checkpoint: str, weight_files) ->
     (root / "manifest.json").write_text(
         json.dumps(
             {
-                "schema_version": 6,
+                "schema_version": SCHEMA_VERSION,
                 "environments": {
                     env_name: {"checkpoints": {checkpoint: {"weight_files": weight_files}}}
                 },
             }
         )
     )
+
+
+def _touch(base: Path, relpath: str) -> Path:
+    """Create an (empty) recorded weight file so the record reads as live."""
+    path = base / relpath
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch()
+    return path
 
 
 def _ship_packages(root: Path, env_name: str, *packages: str) -> None:
@@ -39,31 +48,83 @@ def _ship_packages(root: Path, env_name: str, *packages: str) -> None:
 
 
 def test_manifest_record_wins(tmp_path: Path):
-    _write_manifest(
-        tmp_path,
-        "uma",
-        "uma-s-1p1",
-        [
-            {"path": "cache/huggingface/hub/models--facebook--UMA/blobs/abc", "size": 7},
-            {"path": "home/.cache/fairchem/model.pt", "size": 3},
-        ],
-    )
+    records = [
+        {"path": "cache/huggingface/hub/models--facebook--UMA/blobs/abc", "size": 7},
+        {"path": "home/.cache/fairchem/model.pt", "size": 3},
+    ]
+    _write_manifest(tmp_path, "uma", "uma-s-1p1", records)
+    for record in records:
+        _touch(tmp_path, record["path"])
     paths, tier = get_checkpoint_prewarm_paths(tmp_path, "uma", "uma-s-1p1")
     assert tier == "manifest"
-    assert paths == [
-        str(tmp_path / "cache/huggingface/hub/models--facebook--UMA/blobs/abc"),
-        str(tmp_path / "home/.cache/fairchem/model.pt"),
-    ]
+    assert paths == [str(tmp_path / record["path"]) for record in records]
 
 
 def test_manifest_paths_join_split_cache_root(tmp_path: Path):
     """Records are cache-root-relative so they survive split-cache installs."""
     _write_manifest(tmp_path / "install", "uma", "uma-s-1p1", [{"path": "cache/w.pt", "size": 1}])
+    _touch(tmp_path / "scratch-cache", "cache/w.pt")
     paths, tier = get_checkpoint_prewarm_paths(
         tmp_path / "install", "uma", "uma-s-1p1", cache_root=tmp_path / "scratch-cache"
     )
     assert tier == "manifest"
     assert paths == [str(tmp_path / "scratch-cache" / "cache" / "w.pt")]
+
+
+def test_reader_finds_record_written_by_production_save(tmp_path: Path):
+    """Pin the raw reader to the shape save_manifest actually writes — the
+    hand-rolled JSON in the other tests would stay green across a schema
+    relocation of weight_files that silently broke every real spawn."""
+    from rootstock.config import UserConfig
+    from rootstock.manifest import CheckpointInfo, EnvironmentInfo, create_manifest, save_manifest
+
+    manifest = create_manifest(tmp_path, ["testcluster"], UserConfig(name="t", email="t@t.t"))
+    manifest.environments["uma"] = EnvironmentInfo(
+        built_at="2026-08-13T00:00:00Z",
+        source_hash=None,
+        source="",
+        python_requires=">=3.11",
+        dependencies={},
+        checkpoints={"uma-s-1p1": CheckpointInfo(weight_files=[{"path": "cache/w.pt", "size": 1}])},
+    )
+    save_manifest(manifest, tmp_path)
+    _touch(tmp_path, "cache/w.pt")
+
+    paths, tier = get_checkpoint_prewarm_paths(tmp_path, "uma", "uma-s-1p1")
+    assert tier == "manifest"
+    assert paths == [str(tmp_path / "cache" / "w.pt")]
+
+
+def test_dead_record_falls_back_to_heuristic(tmp_path: Path):
+    """A record whose files were all purged (scratch sweeps) must not win the
+    tier — 'weights: 0 MB (manifest)' would misattribute the cold stall."""
+    _write_manifest(tmp_path, "orb", "orb-v2", [{"path": "cache/purged.pt", "size": 1}])
+    _ship_packages(tmp_path, "orb", "orb_models")
+    (tmp_path / "cache" / "orb").mkdir(parents=True)
+    paths, tier = get_checkpoint_prewarm_paths(tmp_path, "orb", "orb-v2")
+    assert tier == "heuristic"
+    assert paths == [str(tmp_path / "cache" / "orb")]
+
+
+def test_dead_record_with_no_heuristic_match_reports_none(tmp_path: Path):
+    _write_manifest(tmp_path, "orb", "orb-v2", [{"path": "cache/purged.pt", "size": 1}])
+    _ship_packages(tmp_path, "orb")
+    assert get_checkpoint_prewarm_paths(tmp_path, "orb", "orb-v2") == ([], "none")
+
+
+def test_partially_live_record_still_wins(tmp_path: Path):
+    """One surviving file is enough — the worker's own stat pass skips the
+    dead ones, and the record self-heals on the next verify."""
+    _write_manifest(
+        tmp_path,
+        "orb",
+        "orb-v2",
+        [{"path": "cache/purged.pt", "size": 1}, {"path": "cache/alive.pt", "size": 1}],
+    )
+    _touch(tmp_path, "cache/alive.pt")
+    paths, tier = get_checkpoint_prewarm_paths(tmp_path, "orb", "orb-v2")
+    assert tier == "manifest"
+    assert len(paths) == 2
 
 
 def test_no_record_falls_back_to_heuristic(tmp_path: Path):
@@ -85,6 +146,15 @@ def test_heuristic_matches_env_name_dir(tmp_path: Path):
     paths, tier = get_checkpoint_prewarm_paths(tmp_path, "mace", "mace-mp-0-medium")
     assert tier == "heuristic"
     assert paths == [str(tmp_path / "cache" / "mace")]
+
+
+def test_heuristic_matches_hyphenated_dir_names(tmp_path: Path):
+    """Distribution-style dir names normalize '-' to '_' before matching."""
+    _ship_packages(tmp_path, "orb", "orb_models")
+    (tmp_path / "cache" / "orb-models").mkdir(parents=True)
+    paths, tier = get_checkpoint_prewarm_paths(tmp_path, "orb", "orb-v2")
+    assert tier == "heuristic"
+    assert paths == [str(tmp_path / "cache" / "orb-models")]
 
 
 def test_heuristic_never_includes_shared_hub_trees(tmp_path: Path):
@@ -116,6 +186,24 @@ def test_nothing_found_reports_none(tmp_path: Path):
     assert (paths, tier) == ([], "none")
 
 
+def test_download_lookup_skips_heuristic(tmp_path: Path):
+    """Download spawns (allow_heuristic=False) must not cold-read a whole
+    family dir for weights the download may be about to (re)write."""
+    _ship_packages(tmp_path, "orb", "orb_models")
+    (tmp_path / "cache" / "orb").mkdir(parents=True)
+    result = get_checkpoint_prewarm_paths(tmp_path, "orb", "orb-v2", allow_heuristic=False)
+    assert result == ([], None)
+
+
+def test_download_lookup_still_uses_record(tmp_path: Path):
+    """Idempotent re-adds of a fetched checkpoint keep the exact-record tier."""
+    _write_manifest(tmp_path, "orb", "orb-v2", [{"path": "cache/w.pt", "size": 1}])
+    _touch(tmp_path, "cache/w.pt")
+    paths, tier = get_checkpoint_prewarm_paths(tmp_path, "orb", "orb-v2", allow_heuristic=False)
+    assert tier == "manifest"
+    assert paths == [str(tmp_path / "cache" / "w.pt")]
+
+
 def test_custom_checkpoint_skips_heuristic(tmp_path: Path):
     """:custom weights ride checkpoint_path into the prewarm already; with no
     record there is nothing to resolve and nothing worth a 'none' report."""
@@ -126,9 +214,12 @@ def test_custom_checkpoint_skips_heuristic(tmp_path: Path):
 
 
 def test_custom_checkpoint_uses_record_when_present(tmp_path: Path):
-    """smoke-test records :custom loads too (#204) — an exact record beats
-    skipping even for custom ids."""
+    """No production path records weight_files under a :custom id today
+    (smoke-test's custom leg writes only VerificationRecords, and add
+    rejects :custom ids) — but the lookup is id-keyed shared code, so pin
+    the contract in case capture ever extends to custom loads."""
     _write_manifest(tmp_path, "uma", "uma:custom", [{"path": "cache/base.pt", "size": 1}])
+    _touch(tmp_path, "cache/base.pt")
     paths, tier = get_checkpoint_prewarm_paths(tmp_path, "uma", "uma:custom")
     assert tier == "manifest"
     assert paths == [str(tmp_path / "cache" / "base.pt")]
@@ -148,12 +239,23 @@ def test_unreadable_manifest_falls_back(tmp_path: Path, manifest_body: str):
 
 
 def test_malformed_record_entries_are_skipped(tmp_path: Path):
+    """Entries that aren't {path: str} dicts are dropped, never raised on —
+    a non-string path (e.g. {"path": 5}) must not TypeError out of the
+    documented fall-back-a-tier contract."""
     _write_manifest(
         tmp_path,
         "uma",
         "uma-s-1p1",
-        ["bare-string", {"size": 5}, {"path": "cache/ok.pt", "size": 5}],
+        [
+            "bare-string",
+            {"size": 5},
+            {"path": 5, "size": 5},
+            {"path": True},
+            {"path": ""},
+            {"path": "cache/ok.pt", "size": 5},
+        ],
     )
+    _touch(tmp_path, "cache/ok.pt")
     paths, tier = get_checkpoint_prewarm_paths(tmp_path, "uma", "uma-s-1p1")
     assert tier == "manifest"
     assert paths == [str(tmp_path / "cache" / "ok.pt")]

--- a/tests/worker/test_prewarm.py
+++ b/tests/worker/test_prewarm.py
@@ -180,6 +180,19 @@ def test_summary_tags_custom_weights(fake_env):
     assert "; weights: 0 MB (custom)" in log.getvalue()
 
 
+def test_summary_tags_caller_supplied_paths(fake_env, tmp_path: Path):
+    """Caller-supplied prewarm_paths (spawn_in_env leaves them alone, so no
+    tier key) must not masquerade as ':custom' weights — this line is the
+    telemetry for retiring the heuristic, so tags can't lie about provenance."""
+    extra = tmp_path / "caller.bin"
+    extra.write_bytes(b"c" * 512)
+    del fake_env["checkpoint_path"]
+    fake_env["prewarm_paths"] = [str(extra)]
+    log = io.StringIO()
+    prewarm_from_spec(fake_env, log=log)
+    assert "; weights: 0 MB (caller)" in log.getvalue()
+
+
 def test_summary_has_no_weights_note_without_any(fake_env):
     del fake_env["checkpoint_path"]
     log = io.StringIO()
@@ -259,11 +272,15 @@ def _sidecar(spec) -> dict:
     return json.loads(Path(spec.cmd[2]).read_text())
 
 
-def test_spawn_fills_prewarm_paths_from_manifest(built_root: Path):
-    (built_root / "manifest.json").write_text(
+def _write_record(root: Path) -> None:
+    from rootstock.manifest import SCHEMA_VERSION
+
+    (root / "cache").mkdir(exist_ok=True)
+    (root / "cache" / "w.pt").touch()
+    (root / "manifest.json").write_text(
         json.dumps(
             {
-                "schema_version": 6,
+                "schema_version": SCHEMA_VERSION,
                 "environments": {
                     "fake": {
                         "checkpoints": {
@@ -274,6 +291,10 @@ def test_spawn_fills_prewarm_paths_from_manifest(built_root: Path):
             }
         )
     )
+
+
+def test_spawn_fills_prewarm_paths_from_manifest(built_root: Path):
+    _write_record(built_root)
     with spawn_in_env(built_root, "fake", WORKER_WRAPPER, {"checkpoint": "fake-ckpt"}) as spec:
         sidecar = _sidecar(spec)
     assert sidecar["prewarm_paths"] == [str(built_root / "cache" / "w.pt")]
@@ -285,6 +306,30 @@ def test_spawn_reports_none_tier_without_record(built_root: Path):
         sidecar = _sidecar(spec)
     assert sidecar["prewarm_paths"] == []
     assert sidecar["prewarm_weights_tier"] == "none"
+
+
+def test_download_spawn_never_gets_heuristic_paths(built_root: Path):
+    """A first-time add must not cold-read whole family cache dirs (often on
+    a login node) for weights the download is about to write — its record
+    only exists after the download completes."""
+    site = built_root / "envs" / "fake" / "lib" / "python3.11" / "site-packages"
+    site.mkdir(parents=True)
+    (site / "fake").mkdir()
+    (built_root / "cache" / "fake").mkdir(parents=True)
+
+    with spawn_in_env(built_root, "fake", DOWNLOAD_WRAPPER, {"checkpoint": "fake-ckpt"}) as spec:
+        sidecar = _sidecar(spec)
+    assert "prewarm_paths" not in sidecar
+    assert "prewarm_weights_tier" not in sidecar
+
+
+def test_download_spawn_keeps_manifest_tier(built_root: Path):
+    """Idempotent re-adds of a fetched checkpoint still warm the exact record."""
+    _write_record(built_root)
+    with spawn_in_env(built_root, "fake", DOWNLOAD_WRAPPER, {"checkpoint": "fake-ckpt"}) as spec:
+        sidecar = _sidecar(spec)
+    assert sidecar["prewarm_paths"] == [str(built_root / "cache" / "w.pt")]
+    assert sidecar["prewarm_weights_tier"] == "manifest"
 
 
 def test_spawn_keeps_caller_supplied_prewarm_paths(built_root: Path):

--- a/tests/worker/test_prewarm.py
+++ b/tests/worker/test_prewarm.py
@@ -16,6 +16,7 @@ envs benefit without a rebuild).
 from __future__ import annotations
 
 import io
+import json
 import os
 import subprocess
 import sys
@@ -23,7 +24,12 @@ from pathlib import Path
 
 import pytest
 
-from rootstock.prewarm import iter_prewarm_files, prewarm_files, prewarm_from_spec
+from rootstock.prewarm import (
+    _cgroup_memory_limit,
+    iter_prewarm_files,
+    prewarm_files,
+    prewarm_from_spec,
+)
 from rootstock.spawn import DOWNLOAD_WRAPPER, WORKER_WRAPPER, spawn_in_env
 
 
@@ -144,6 +150,159 @@ def test_wrapper_runs_prewarm_end_to_end(tmp_path: Path):
     # Whole tree: libfake.so + env_source.py + bin/python (the symlinked
     # interpreter binary — warming it is a feature, not an accident).
     assert "Prewarmed page cache: 3 files" in result.stderr
+
+
+def test_summary_tags_weights_tier(fake_env, tmp_path: Path):
+    """The tier tag is the field data for retiring the heuristic (#178)."""
+    weights = tmp_path / "recorded.bin"
+    weights.write_bytes(b"w" * 2_000_000)
+    del fake_env["checkpoint_path"]
+    fake_env["prewarm_paths"] = [str(weights)]
+    fake_env["prewarm_weights_tier"] = "manifest"
+    log = io.StringIO()
+    prewarm_from_spec(fake_env, log=log)
+    assert "; weights: 2 MB (manifest)" in log.getvalue()
+
+
+def test_summary_reports_none_recorded(fake_env):
+    del fake_env["checkpoint_path"]
+    fake_env["prewarm_paths"] = []
+    fake_env["prewarm_weights_tier"] = "none"
+    log = io.StringIO()
+    prewarm_from_spec(fake_env, log=log)
+    assert "; weights: none recorded" in log.getvalue()
+
+
+def test_summary_tags_custom_weights(fake_env):
+    # fake_env carries a :custom checkpoint_path and no tier annotation.
+    log = io.StringIO()
+    prewarm_from_spec(fake_env, log=log)
+    assert "; weights: 0 MB (custom)" in log.getvalue()
+
+
+def test_summary_has_no_weights_note_without_any(fake_env):
+    del fake_env["checkpoint_path"]
+    log = io.StringIO()
+    prewarm_from_spec(fake_env, log=log)
+    assert "weights" not in log.getvalue()
+
+
+def test_working_set_warning_when_cgroup_limit_too_small(fake_env, monkeypatch: pytest.MonkeyPatch):
+    """Warming more than the job's memory cgroup holds evicts the warmed
+    pages before the worker reads them (Delta, 2026-07-29) — one line names
+    the footgun up front, before the reads start."""
+    monkeypatch.setattr("rootstock.prewarm._cgroup_memory_limit", lambda: 100)
+    log = io.StringIO()
+    prewarm_from_spec(fake_env, log=log)
+    message = log.getvalue()
+    assert "exceeds this job's memory limit" in message
+    # The warning precedes the summary so it survives a stalled warm-up.
+    assert message.index("Warning") < message.index("Prewarmed")
+
+
+def test_no_working_set_warning_within_limit(fake_env, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("rootstock.prewarm._cgroup_memory_limit", lambda: 1 << 40)
+    log = io.StringIO()
+    prewarm_from_spec(fake_env, log=log)
+    assert "Warning" not in log.getvalue()
+
+
+def _cgroup_fixture(tmp_path: Path, proc_line: str) -> tuple[str, str]:
+    proc = tmp_path / "proc_cgroup"
+    proc.write_text(proc_line + "\n")
+    sys_root = tmp_path / "sys_cgroup"
+    sys_root.mkdir()
+    return str(proc), str(sys_root)
+
+
+def test_cgroup_v2_limit_found_on_ancestor(tmp_path: Path):
+    """Schedulers set the limit on the job slice, not the leaf — the walk up
+    must find it, and the leaf's 'max' placeholder must not mask it."""
+    proc, sys_root = _cgroup_fixture(tmp_path, "0::/slurm/job_7/step_0")
+    leaf = Path(sys_root) / "slurm" / "job_7" / "step_0"
+    leaf.mkdir(parents=True)
+    (leaf / "memory.max").write_text("max\n")
+    (leaf.parent / "memory.max").write_text(str(32 * 1024**3) + "\n")
+    assert _cgroup_memory_limit(proc, sys_root) == 32 * 1024**3
+
+
+def test_cgroup_v1_limit(tmp_path: Path):
+    proc, sys_root = _cgroup_fixture(tmp_path, "4:memory:/slurm/job_9")
+    leaf = Path(sys_root) / "memory" / "slurm" / "job_9"
+    leaf.mkdir(parents=True)
+    (leaf / "memory.limit_in_bytes").write_text(str(16 * 1024**3) + "\n")
+    assert _cgroup_memory_limit(proc, sys_root) == 16 * 1024**3
+
+
+def test_cgroup_v1_no_limit_sentinel_ignored(tmp_path: Path):
+    proc, sys_root = _cgroup_fixture(tmp_path, "4:memory:/user")
+    leaf = Path(sys_root) / "memory" / "user"
+    leaf.mkdir(parents=True)
+    (leaf / "memory.limit_in_bytes").write_text("9223372036854771712\n")
+    assert _cgroup_memory_limit(proc, sys_root) is None
+
+
+def test_cgroup_absent_means_no_limit(tmp_path: Path):
+    assert _cgroup_memory_limit(str(tmp_path / "nope"), str(tmp_path)) is None
+
+
+@pytest.fixture
+def built_root(tmp_path: Path) -> Path:
+    """A minimal built env so spawn_in_env accepts the spawn."""
+    env_dir = tmp_path / "envs" / "fake"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+    return tmp_path
+
+
+def _sidecar(spec) -> dict:
+    return json.loads(Path(spec.cmd[2]).read_text())
+
+
+def test_spawn_fills_prewarm_paths_from_manifest(built_root: Path):
+    (built_root / "manifest.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 6,
+                "environments": {
+                    "fake": {
+                        "checkpoints": {
+                            "fake-ckpt": {"weight_files": [{"path": "cache/w.pt", "size": 1}]}
+                        }
+                    }
+                },
+            }
+        )
+    )
+    with spawn_in_env(built_root, "fake", WORKER_WRAPPER, {"checkpoint": "fake-ckpt"}) as spec:
+        sidecar = _sidecar(spec)
+    assert sidecar["prewarm_paths"] == [str(built_root / "cache" / "w.pt")]
+    assert sidecar["prewarm_weights_tier"] == "manifest"
+
+
+def test_spawn_reports_none_tier_without_record(built_root: Path):
+    with spawn_in_env(built_root, "fake", WORKER_WRAPPER, {"checkpoint": "fake-ckpt"}) as spec:
+        sidecar = _sidecar(spec)
+    assert sidecar["prewarm_paths"] == []
+    assert sidecar["prewarm_weights_tier"] == "none"
+
+
+def test_spawn_keeps_caller_supplied_prewarm_paths(built_root: Path):
+    payload = {"checkpoint": "fake-ckpt", "prewarm_paths": ["/explicit"]}
+    with spawn_in_env(built_root, "fake", WORKER_WRAPPER, payload) as spec:
+        sidecar = _sidecar(spec)
+    assert sidecar["prewarm_paths"] == ["/explicit"]
+    assert "prewarm_weights_tier" not in sidecar
+
+
+def test_spawn_lookup_failure_is_not_fatal(built_root: Path, monkeypatch: pytest.MonkeyPatch):
+    def boom(*args, **kwargs):
+        raise RuntimeError("lookup exploded")
+
+    monkeypatch.setattr("rootstock.spawn.get_checkpoint_prewarm_paths", boom)
+    with spawn_in_env(built_root, "fake", WORKER_WRAPPER, {"checkpoint": "fake-ckpt"}) as spec:
+        sidecar = _sidecar(spec)
+    assert "prewarm_paths" not in sidecar
 
 
 def test_spawn_stages_prewarm_module_next_to_wrapper(tmp_path: Path):


### PR DESCRIPTION
Consumes the #177 manifest weight records at spawn time — ladder rung 2 of the cold-start work (#160 → #167/#171 lineage). Closes #178.

## What

The spawn-time prewarm covers the env tree, but a checkpoint's model weights load via mmap *after* it ends and fault in at ~0.35 MB/s on cold Lustre — on Delta, uma's 14 GB fairchem cache structurally blew every warm-up timeout its siblings fit (2026-07-29 field data). This fills `spec["prewarm_paths"]` (reserved since #171) so the existing prewarm machinery streams the weights too, tiered:

1. **Manifest record** (#177) → warm exactly those files, joined to the cache root so split-cache installs (Frontier, Perlmutter) resolve correctly.
2. **No record** (worker spawns only — downloads use the record tier alone, since their record is only written after the download) → best-effort heuristic: top-level dirs of `{cache_root}/cache`, `home/.cache`, `home` whose names match a package the env ships (`_`-boundary prefix match: `cache/orb` ↔ `orb_models`, `home/.dgl` ↔ `dgl`) or the env's name. The `huggingface`/`torch` hub trees are **never** matched — they hold every family's weights side by side, and over-warming under a job's memory cgroup evicts exactly the pages the worker needs. Known transitional cost: the heuristic emits whole per-family dirs, so one unrecorded checkpoint over-warms its cached siblings (all mace ids share `cache/mace`) until one add/verify/smoke-test pass records it — the tier tag is the telemetry for retiring it. The manifest tier also requires at least one recorded path to still exist, so a scratch-purged record falls back a tier instead of logging `weights: 0 MB (manifest)` while the load cold-faults.
3. **Nothing** → today's behavior. `:custom` ids skip the heuristic (the user's weights already ride `checkpoint_path` into the prewarm), but would use a manifest record if one existed under the id (no production path writes one today — smoke-test's custom leg records only verifications).

## Where

- The lookup runs in `spawn_in_env` — the choke point every spawn path (calculator, verify, serve, add) already goes through, and the same seam the node-local staging design (#180) will redirect later. A caller-supplied `prewarm_paths` is left alone.
- It reads `manifest.json` **raw**, not via `load_manifest`: this is the first time the calculator path reads the manifest, and an optimization hint must never print migration notes, take locks, or refuse a manifest written by a newer rootstock. Anything unparseable just falls back a tier; a failed lookup never fails the spawn.

## Observability

- The prewarm summary tags the tier — `weights: 14.2 GB (manifest)` / `(heuristic)` / `weights: none recorded` — field data for retiring the heuristic once record coverage is universal, and the line keeps its filesystem-health-probe role.
- New up-front warning when the expected cold working set (env tree + weights, known before any read) exceeds the job's cgroup memory limit (v1 and v2, ancestor walk for SLURM's job-slice limits) — the eviction footgun that burned the 2026-07-29 uma run, reduced to one visible line printed *before* the reads so it survives a stalled warm-up.

## Deployment

Ships client-side (the prewarm module is staged fresh at every spawn): deployed envs benefit from a client pin bump, no env rebuilds. Backfill on an existing install = one `rootstock smoke-test` pass to write the records (#177).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

