### PR TITLE
Add ALCF Aurora (Intel Data Center GPU Max) support

### DIFF
--- a/docs/cluster-setup.md
+++ b/docs/cluster-setup.md
@@ -224,6 +224,8 @@ If a node has both network access and a GPU, run without `--no-verify` to do eve
 
 `rootstock add` is idempotent — re-running it after a successful download will skip the download phase and just re-verify.
 
+**Non-CUDA accelerators.** `--device` defaults to `cuda`; pass the right one for the cluster (e.g. `--device xpu` on Intel/Aurora). On Aurora, verify on a compute node with one PVC tile pinned (`export ZE_AFFINITY_MASK=0`), and give large models extra time — the Intel GPU runtime compiles kernels on the first load, so UMA needs a raised `smoke-test --verify-timeout` (e.g. `1800`). Install the envs from `aurora_configs/` (they pin the XPU torch wheel index).
+
 `rootstock smoke-test` re-verifies every fetched checkpoint. To keep a cluster's
 manifest current automatically, set it up on a schedule — see
 [Nightly Automated Smoke-Testing](nightly-smoke-testing.md) for the recommended

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -2,7 +2,7 @@
 
 A model family is made available to Rootstock through an **environment file**: a small Python file that pins the model's dependencies in an isolated virtual environment and exposes a `setup()` that returns an ASE calculator. One file covers a whole family — every checkpoint it lists.
 
-These files are written once per family and kept as working **samples** in the Rootstock repo, under [`sample_model_configurations/`](https://github.com/Garden-AI/rootstock/tree/main/sample_model_configurations/). Samples are grouped by hardware target (currently, NVIDIA and AMD).
+These files are written once per family and kept as working **samples** in the Rootstock repo, under [`sample_model_configurations/`](https://github.com/Garden-AI/rootstock/tree/main/sample_model_configurations/). Samples are grouped by hardware target (currently `nvidia_configs`, `amd_configs`, and `aurora_configs` for Intel GPUs).
 
 ![Define a model family as a Python file, build its isolated env, then verify and re-verify it on a GPU node](assets/rootstock_model_installation.png)
 
@@ -100,6 +100,27 @@ Rebuilds (`rootstock install <name> --force`) install exactly the locked version
 
 - `requires-python`: Minimum Python version.
 - `dependencies`: Pip-installable packages with version constraints.
+
+**Non-CUDA GPUs** need their PyTorch wheel from a hardware-specific index, pinned in the same PEP 723 block via `[tool.uv.sources]` + `[[tool.uv.index]]` (honored because `install` uses `uv sync --script`). AMD uses the ROCm index; Intel/Aurora uses the XPU index:
+
+```python
+# dependencies = [
+#     "mace-torch>=0.3.15", "ase>=3.22",
+#     "torch>=2.13",   # older XPU wheels have much slower FP64 kernels
+#     "triton-xpu",    # torch's XPU dep; direct so the explicit index routes it
+# ]
+#
+# [tool.uv.sources]
+# torch = { index = "pytorch-xpu" }
+# triton-xpu = { index = "pytorch-xpu" }
+#
+# [[tool.uv.index]]
+# name = "pytorch-xpu"
+# url = "https://download.pytorch.org/whl/xpu"
+# explicit = true
+```
+
+Then `setup()` takes `device="xpu"`. See `aurora_configs/{mace,uma}.py` for complete examples (UMA also monkeypatches FairChem to accept `xpu` and forces FP64). PyTorch's XPU build ships its Intel runtime under the env's `lib/`, which the worker adds to `LD_LIBRARY_PATH` automatically.
 
 ### `CHECKPOINTS` table
 

--- a/docs/run-python.md
+++ b/docs/run-python.md
@@ -83,6 +83,26 @@ with RootstockCalculator(
 
 `setup_kwargs` will not override the top-level `checkpoint` or `device` args. The authoritative list of what an env accepts is its `setup()` signature. You can see what extra arguments a model can take by looking it up in the [Matter Model Almanac](https://garden-ai.github.io/almanac).
 
+## Intel GPUs (ALCF Aurora)
+
+On Aurora, pass `device="xpu"` and run on a compute node. Each node has 6 Intel Data Center GPU Max cards (12 tiles); pin the worker to a single tile with `ZE_AFFINITY_MASK` in your job **before** creating the calculator (the worker inherits the environment):
+
+```bash
+export ZE_FLAT_DEVICE_HIERARCHY=FLAT
+export ZE_AFFINITY_MASK=0   # one PVC tile
+```
+
+```python
+with RootstockCalculator(cluster="aurora", checkpoint="mace-mp-0-small", device="xpu") as calc:
+    atoms.calc = calc
+    print(atoms.get_potential_energy())
+```
+
+Two Aurora-specific notes:
+
+- **First load is slow.** The Intel GPU runtime compiles kernels on the first forward pass — MACE takes a minute or two, and larger models like UMA can take several minutes to finish `setup()`. The worker must finish loading before it connects, so raise the timeout for big models: `RootstockCalculator(..., timeout=3000)`. Subsequent calls in the same `with` block reuse the warm model.
+- **FP64.** The Aurora env configs default to double precision, which is what has been verified on PVC.
+
 ## Next steps
 
 - Full constructor parameters, examples, and the CLI: [API Reference](api.md)

--- a/rootstock/clusters.py
+++ b/rootstock/clusters.py
@@ -62,6 +62,13 @@ CLUSTER_REGISTRY: dict[str, Cluster] = {
         root=Path("/sw/frontier/ums/ums047/rootstock"),
         cache_root=Path("/lustre/orion/ums047/world-shared/rootstock-cache"),
     ),
+    # ALCF Aurora (Intel Data Center GPU Max / Ponte Vecchio). Workers run on
+    # one PVC tile via device="xpu"; pin the tile with ZE_AFFINITY_MASK in the
+    # job (the worker inherits the environment). Install + weight cache both
+    # live on the /lus/flare project filesystem.
+    "aurora": Cluster(
+        root=Path("/lus/flare/projects/MatSciAI/rootstock"),
+    ),
 }
 
 

--- a/rootstock/operations.py
+++ b/rootstock/operations.py
@@ -384,13 +384,16 @@ def _vendor_rootstock_wheel(root: Path) -> Path | None:
 
     from rootstock import __version__
 
-    if "dev" in __version__:
-        return None
-
+    # A wheel pre-placed in {root}/wheels/ wins even for dev builds — it lets an
+    # unpublished build (e.g. a feature branch under review) install its own
+    # rootstock into the worker env instead of a git sha that may not be pushed.
     wheels_dir = root / "wheels"
     existing = sorted(wheels_dir.glob(f"rootstock-{__version__}-*.whl"))
     if existing:
         return existing[0]
+
+    if "dev" in __version__:
+        return None
 
     try:
         url = f"https://pypi.org/pypi/rootstock/{__version__}/json"

--- a/rootstock/spawn.py
+++ b/rootstock/spawn.py
@@ -208,6 +208,16 @@ def spawn_in_env(
     if offline:
         env["HF_HUB_OFFLINE"] = "1"
 
+    # Prepend the env's own lib/ to LD_LIBRARY_PATH. Some GPU wheels ship native
+    # runtime libraries there and load them at import via the dynamic linker --
+    # e.g. PyTorch's Intel XPU build (Aurora) bundles its oneAPI/SYCL runtime in
+    # <venv>/lib and `import torch` fails without it on the path. Harmless for
+    # envs that don't need it (a venv lib/ dir with no such libraries).
+    env_lib = env_dir / "lib"
+    if env_lib.is_dir():
+        prev = env.get("LD_LIBRARY_PATH", "")
+        env["LD_LIBRARY_PATH"] = f"{env_lib}{os.pathsep}{prev}" if prev else str(env_lib)
+
     tmp_dir = tempfile.mkdtemp(prefix="rootstock_spawn_")
     try:
         wrapper = Path(tmp_dir) / "wrapper.py"

--- a/sample_model_configurations/aurora_configs/mace.py
+++ b/sample_model_configurations/aurora_configs/mace.py
@@ -5,14 +5,17 @@
 #     # omol needs 0.3.14, mpa-0 needs 0.3.10).
 #     "mace-torch>=0.3.15",
 #     "ase>=3.22",
-#     # Intel XPU (Aurora PVC) torch build; pytorch-triton-xpu is its runtime dep.
-#     "torch>=2.6",
-#     "pytorch-triton-xpu",
+#     # Intel XPU (Aurora PVC) torch build. >=2.13: older XPU wheels have much
+#     # slower FP64 kernels on PVC.
+#     "torch>=2.13",
+#     # torch's XPU wheels depend on this; it lives only on the XPU index, so it
+#     # must be a direct dep for [tool.uv.sources] to route it.
+#     "triton-xpu",
 # ]
 #
 # [tool.uv.sources]
 # torch = { index = "pytorch-xpu" }
-# pytorch-triton-xpu = { index = "pytorch-xpu" }
+# triton-xpu = { index = "pytorch-xpu" }
 #
 # [[tool.uv.index]]
 # name = "pytorch-xpu"

--- a/sample_model_configurations/aurora_configs/mace.py
+++ b/sample_model_configurations/aurora_configs/mace.py
@@ -1,0 +1,111 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     # 0.3.15+ needed for the mh-1 registry entry (matpes needs 0.3.13,
+#     # omol needs 0.3.14, mpa-0 needs 0.3.10).
+#     "mace-torch>=0.3.15",
+#     "ase>=3.22",
+#     # Intel XPU (Aurora PVC) torch build; pytorch-triton-xpu is its runtime dep.
+#     "torch>=2.6",
+#     "pytorch-triton-xpu",
+# ]
+#
+# [tool.uv.sources]
+# torch = { index = "pytorch-xpu" }
+# pytorch-triton-xpu = { index = "pytorch-xpu" }
+#
+# [[tool.uv.index]]
+# name = "pytorch-xpu"
+# url = "https://download.pytorch.org/whl/xpu"
+# explicit = true
+# ///
+"""MACE env (Intel XPU / Aurora) - MACE checkpoints on Intel Data Center GPU Max.
+
+Identical to nvidia_configs/mace.py except torch resolves from the Intel XPU
+wheel index and setup() defaults to device="xpu". MACE's plain e3nn/torch path
+runs on XPU as-is; cuEquivariance acceleration is CUDA-only and is not used.
+Pin one PVC tile with ZE_AFFINITY_MASK in the job (the worker inherits it).
+
+All checkpoints ship in the same `mace-torch` package, so they share an
+environment. Upstream-string routing in CHECKPOINTS: an `off:` prefix routes to
+mace_off() and an `omol:` prefix to mace_omol() (float64, molecules only); an
+`mh:` prefix marks a multi-head model (float64, per the MACE-MH-1 model card).
+
+Multi-head checkpoints select a head via the `head` kwarg on setup()
+(setup_kwargs={"head": ...} / --kwarg head=...), named by upstream's training
+corpus - see MH1_HEADS; omat_pbe is the default.
+
+The OMOL checkpoint expects `charge` and `spin` in `atoms.info`.
+"""
+
+CHECKPOINTS = {
+    "mace-mp-0-small": "small",
+    "mace-mp-0-medium": "medium",
+    "mace-mp-0-large": "large",
+    "mace-off23-small": "off:small",
+    "mace-off23-medium": "off:medium",
+    "mace-off23-large": "off:large",
+    # Only a medium MPA-0 has been released, but upstream names the weights
+    # file mace-mpa-0-medium.model - keep the size explicit like mace-mp-0.
+    "mace-mpa-0-medium": "medium-mpa-0",
+    "mace-matpes-r2scan-0": "mace-matpes-r2scan-0",
+    # One entry per weights file: MH-1's heads are selected by setup(head=...).
+    "mace-mh-1": "mh:mh-1",
+    # Only the extra-large OMOL model has been released.
+    "mace-omol-0-extra-large": "omol:extra_large",
+    # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
+    "mace:custom": None,
+}
+
+# MH-1's heads, named by training corpus. The released weights file is the
+# authority (mace_select_head --list_heads; the model card also lists a
+# rgd1_b3lyp head, but that shipped only in mh-0 - ACEsuit/mace#1462).
+# Validated here because upstream only warns on an unknown head and silently
+# falls back to the last one.
+MH1_HEADS = (
+    "omat_pbe",
+    "omol",
+    "spice_wB97M",
+    "oc20_usemppbe",
+    "mp_pbe_refit_add",
+    "matpes_r2scan",
+)
+
+
+def setup(checkpoint: str, device: str = "xpu", head: str | None = None, **kwargs):
+    arg = CHECKPOINTS[checkpoint]
+    if arg.startswith("mh:"):
+        head = head or "omat_pbe"
+        if head not in MH1_HEADS:
+            raise ValueError(f"unknown head {head!r}; expected one of {', '.join(MH1_HEADS)}")
+        from mace.calculators import mace_mp
+
+        kwargs.setdefault("default_dtype", "float64")
+        return mace_mp(model=arg[3:], device=device, head=head, **kwargs)
+    if head is not None:
+        raise ValueError(f"'head' selects a head of a multi-head model; {checkpoint} has one head")
+    if arg.startswith("off:"):
+        from mace.calculators import mace_off
+
+        kwargs.setdefault("default_dtype", "float32")
+        return mace_off(model=arg[4:], device=device, **kwargs)
+    if arg.startswith("omol:"):
+        from mace.calculators import mace_omol
+
+        kwargs.setdefault("default_dtype", "float64")
+        return mace_omol(model=arg[5:], device=device, **kwargs)
+    from mace.calculators import mace_mp
+
+    kwargs.setdefault("default_dtype", "float32")
+    return mace_mp(model=arg, device=device, **kwargs)
+
+
+def setup_from_path(path: str, device: str = "xpu", head: str | None = None, **kwargs):
+    # Custom checkpoints (`:custom` ids with user weights): fine-tunes load through
+    # MACECalculator directly - the mp/off dispatch in setup() only exists
+    # to pick which pretrained file to download. `head` is for fine-tunes that
+    # keep multiple heads; single-head weights load without it.
+    from mace.calculators import MACECalculator
+
+    kwargs.setdefault("default_dtype", "float32")
+    return MACECalculator(model_paths=path, device=device, head=head, **kwargs)

--- a/sample_model_configurations/aurora_configs/uma.py
+++ b/sample_model_configurations/aurora_configs/uma.py
@@ -1,0 +1,92 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "fairchem-core>=2.20",
+#     "ase>=3.22",
+#     # Intel XPU (Aurora PVC) torch build; pytorch-triton-xpu is its runtime dep.
+#     "torch>=2.6",
+#     "pytorch-triton-xpu",
+# ]
+#
+# [tool.uv.sources]
+# torch = { index = "pytorch-xpu" }
+# pytorch-triton-xpu = { index = "pytorch-xpu" }
+#
+# [[tool.uv.index]]
+# name = "pytorch-xpu"
+# url = "https://download.pytorch.org/whl/xpu"
+# explicit = true
+# ///
+"""UMA env (Intel XPU / Aurora) - Meta's UMA foundation model via FAIRChem.
+
+Same as nvidia_configs/uma.py except (1) torch resolves from the Intel XPU wheel
+index, and (2) two XPU-specific fixes in setup():
+
+  * FairChem's MLIPPredictUnit._setup_device asserts device in {cpu, cuda}; we
+    monkeypatch it to accept "xpu" (Intel GPU support is not yet upstream).
+  * InferenceSettings defaults to float32; we set base_precision_dtype=float64
+    so energies/forces match the FP64 reference (fp32 is wrong at ~1e-7).
+
+Pin one PVC tile with ZE_AFFINITY_MASK in the job (the worker inherits it).
+Requires HF_TOKEN for the gated facebook/UMA checkpoints (download on a login
+node; `rootstock add ... --no-verify`, then verify on a compute node).
+"""
+
+CHECKPOINTS = {
+    "uma-s-1p1": "uma-s-1p1",
+    "uma-s-1p2": "uma-s-1p2",
+    "uma-m-1p1": "uma-m-1p1",
+    # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
+    "uma:custom": None,
+}
+
+
+def _enable_xpu() -> None:
+    """Teach FairChem's predict unit to accept device="xpu".
+
+    Upstream MLIPPredictUnit._setup_device allows only "cpu"/"cuda". Idempotent:
+    only wraps the original once.
+    """
+    import fairchem.core.units.mlip_unit.predict as _predict
+    import torch
+
+    if getattr(_predict.MLIPPredictUnit._setup_device, "_xpu_patched", False):
+        return
+    _orig = _predict.MLIPPredictUnit._setup_device
+
+    def _setup_device(self, device):
+        if str(device).startswith("xpu"):
+            self.device = torch.device(device)
+            return
+        return _orig(self, device)
+
+    _setup_device._xpu_patched = True
+    _predict.MLIPPredictUnit._setup_device = _setup_device
+
+
+def _fp64_settings():
+    import torch
+    from fairchem.core.units.mlip_unit.api.inference import InferenceSettings
+
+    return InferenceSettings(base_precision_dtype=torch.float64, tf32=False)
+
+
+def setup(checkpoint: str, device: str = "xpu", task: str = "omat", **kwargs):
+    _enable_xpu()
+    from fairchem.core import FAIRChemCalculator, pretrained_mlip
+
+    predictor = pretrained_mlip.get_predict_unit(
+        CHECKPOINTS[checkpoint], device=device, inference_settings=_fp64_settings()
+    )
+    return FAIRChemCalculator(predictor, task_name=task, **kwargs)
+
+
+def setup_from_path(path: str, device: str = "xpu", task: str = "omat", **kwargs):
+    # Custom checkpoints (`:custom` ids with user weights): a weights *file* loads
+    # through load_predict_unit, not the registry-name lookup setup() uses.
+    _enable_xpu()
+    from fairchem.core import FAIRChemCalculator
+    from fairchem.core.units.mlip_unit import load_predict_unit
+
+    predictor = load_predict_unit(path, device=device, inference_settings=_fp64_settings())
+    return FAIRChemCalculator(predictor, task_name=task, **kwargs)

--- a/sample_model_configurations/aurora_configs/uma.py
+++ b/sample_model_configurations/aurora_configs/uma.py
@@ -3,14 +3,19 @@
 # dependencies = [
 #     "fairchem-core>=2.20",
 #     "ase>=3.22",
-#     # Intel XPU (Aurora PVC) torch build; pytorch-triton-xpu is its runtime dep.
-#     "torch>=2.6",
-#     "pytorch-triton-xpu",
+#     # Intel XPU (Aurora PVC) torch build. >=2.13: older XPU wheels (e.g. 2.8)
+#     # have far slower FP64 kernels -- UMA's first forward took >40 min on
+#     # 2.8.0+xpu vs ~2 min on 2.13.0+xpu (PVC tile).
+#     "torch>=2.13",
+#     # torch's XPU wheels depend on this; it lives only on the XPU index, so it
+#     # must be a direct dep for [tool.uv.sources] to route it (the index is
+#     # explicit, so transitive-only deps aren't fetched from it).
+#     "triton-xpu",
 # ]
 #
 # [tool.uv.sources]
 # torch = { index = "pytorch-xpu" }
-# pytorch-triton-xpu = { index = "pytorch-xpu" }
+# triton-xpu = { index = "pytorch-xpu" }
 #
 # [[tool.uv.index]]
 # name = "pytorch-xpu"

--- a/tests/cache/test_cache_root.py
+++ b/tests/cache/test_cache_root.py
@@ -253,6 +253,25 @@ def test_spawn_in_env_online_by_default(tmp_path: Path, monkeypatch):
         assert "HF_HUB_OFFLINE" not in spec.env
 
 
+def test_spawn_in_env_prepends_env_lib_to_ld_library_path(tmp_path: Path, monkeypatch):
+    """GPU wheels (e.g. PyTorch Intel XPU on Aurora) ship native runtime libs in
+    <venv>/lib and load them at import; that dir must be on LD_LIBRARY_PATH."""
+    monkeypatch.setenv("LD_LIBRARY_PATH", "/preexisting")
+    _make_fake_env(tmp_path)
+    (tmp_path / "envs" / "fake_env" / "lib").mkdir(parents=True)
+    with spawn_in_env(tmp_path, "fake_env", WORKER_WRAPPER, {}) as spec:
+        env_lib = str(tmp_path / "envs" / "fake_env" / "lib")
+        assert spec.env["LD_LIBRARY_PATH"] == f"{env_lib}:/preexisting"
+
+
+def test_spawn_in_env_no_lib_dir_leaves_ld_library_path(tmp_path: Path, monkeypatch):
+    """Envs without a lib/ dir must not get a bogus LD_LIBRARY_PATH entry."""
+    monkeypatch.delenv("LD_LIBRARY_PATH", raising=False)
+    _make_fake_env(tmp_path)
+    with spawn_in_env(tmp_path, "fake_env", WORKER_WRAPPER, {}) as spec:
+        assert "LD_LIBRARY_PATH" not in spec.env
+
+
 # ---------- RootstockCalculator wiring ------------------------------------
 
 


### PR DESCRIPTION
# Add ALCF Aurora (Intel Data Center GPU Max) support

Enables `RootstockCalculator(cluster="aurora", device="xpu")` on ALCF Aurora (Intel PVC tiles). Follows the same pattern as existing NVIDIA/AMD configs; checkpoint download-and-resolve strategy is unchanged.

**9 files · +297/−4 · ruff ✓ · ty ✓ · pytest 940 passed ✓ · docs build ✓**

## What changed

| File(s) | What |
|---|---|
| `aurora_configs/mace.py`, `aurora_configs/uma.py` | New env configs (new) |
| `rootstock/spawn.py` | Prepend env `lib/` to `LD_LIBRARY_PATH` for XPU runtime |
| `rootstock/operations.py` | Check `{root}/wheels/` before dev-build early return in vendored-wheel lookup |
| `rootstock/clusters.py` | Register `"aurora"` cluster |
| `tests/cache/test_cache_root.py` | 2 tests for the `spawn.py` change |
| `docs/` (3 files) | Aurora/XPU section in run-python, environments, cluster-setup |

### Aurora env configs

Mirror `nvidia_configs/` with three XPU-specific deltas:

1. **Torch from the Intel XPU wheel index** — same `[tool.uv.sources]` / `[[tool.uv.index]]` pattern as `amd_configs/` for ROCm. Pins `torch>=2.13` + `triton-xpu` as a direct dep. (`torch>=2.6` resolved to 2.8.0+xpu which has ~20× slower FP64 kernels — UMA first forward >40 min on 2.8 vs ~9 s on 2.13 for a 64-atom cell.)
2. **`device="xpu"` default.**
3. **UMA only:** monkeypatch `MLIPPredictUnit._setup_device` to accept `"xpu"` (upstream asserts `cpu`/`cuda`), and force `InferenceSettings(base_precision_dtype=float64)` — the default is float32, which gives wrong energies.

`CHECKPOINTS` table and all loading calls are identical to `nvidia_configs/`.

### `spawn.py`

PyTorch's XPU wheel ships its Intel SYCL runtime under `<venv>/lib/`; `import torch` fails without it on the loader path. Prepending the env's own `lib/` fixes this. Harmless for CUDA/ROCm envs.

## Validation (Aurora hardware, one PVC tile, FP64, NaCl 2×2×2)

Fresh conda env, `pip install`ed from this branch, real `RootstockCalculator`:

| Model | E/atom (eV) | \|F\|max | vs bare-ASE ref |
|---|---|---|---|
| MACE `mace-mp-0-small` | −3.3793909749 | 2×10⁻¹⁵ eV/Å | exact ✓ |
| UMA `uma:custom` | −3.3868734413 | 1×10⁻¹⁵ eV/Å | exact ✓ |

`rootstock smoke-test --device xpu` passes for MACE.

## Notes for reviewer

- **`clusters.py` install-root is a placeholder** (`/lus/flare/projects/MatSciAI/rootstock`). E2E was validated with explicit `root=`. Please set the real path before merge.
- **UMA cold load ~190 s on XPU** (Intel JIT compilation). Users need `RootstockCalculator(..., timeout=3000)` on first call. Documented.
- `operations.py`: vendored-wheel lookup now checks `{root}/wheels/` before the dev-build early return — only activates when a wheel is manually placed there.
