### PR TITLE
Move orbmol variants out of orb_v3 env

### DIFF
--- a/sample_model_configurations/amd_configs/orbmol.py
+++ b/sample_model_configurations/amd_configs/orbmol.py
@@ -89,7 +89,7 @@ def _fetch(url: str, dest: Path) -> None:
         tmp.unlink(missing_ok=True)
 
 
-def _make_calculator(orbff, atoms_adapter, device, edge_method, **kwargs):
+def _make_calculator(orbff, atoms_adapter, device, edge_method=None, **kwargs):
     from ase.calculators.calculator import all_changes
     from orb_models.forcefield.inference.calculator import ORBCalculator
 
@@ -102,9 +102,14 @@ def _make_calculator(orbff, atoms_adapter, device, edge_method, **kwargs):
                 atoms.info.setdefault("spin", 1)
             super().calculate(atoms, properties, system_changes)
 
-    return OrbMolCalculator(
-        orbff, atoms_adapter, device=device, edge_method=edge_method, **kwargs
-    )
+    # None = vendor default: here that's the knn_scipy pin (the library
+    # default knn_alchemi launches Warp/CUDA kernels — see module docstring);
+    # the CUDA variant resolves None to the library default instead. Named in
+    # the setup hooks (not just **kwargs) so the signature can't drift
+    # between vendor copies.
+    if edge_method is None:
+        edge_method = "knn_scipy"
+    return OrbMolCalculator(orbff, atoms_adapter, device=device, edge_method=edge_method, **kwargs)
 
 
 def setup(
@@ -112,7 +117,7 @@ def setup(
     device: str = "cuda",
     precision: str = "float32-high",
     compile: bool | None = None,
-    edge_method: str = "knn_scipy",
+    edge_method: str | None = None,
     **kwargs,
 ):
     # Extra **kwargs go to ORBCalculator (e.g. max_num_neighbors=,
@@ -140,9 +145,7 @@ def setup(
         precision=precision,
         compile=compile,
     )
-    return _make_calculator(
-        orbff, atoms_adapter, torch.device(device), edge_method, **kwargs
-    )
+    return _make_calculator(orbff, atoms_adapter, torch.device(device), edge_method, **kwargs)
 
 
 def setup_from_path(
@@ -151,7 +154,7 @@ def setup_from_path(
     arch: str = "orbmol-v2",
     precision: str = "float32-high",
     compile: bool | None = None,
-    edge_method: str = "knn_scipy",
+    edge_method: str | None = None,
     **kwargs,
 ):
     # Custom checkpoints (`:custom` ids with user weights). A weights file
@@ -177,6 +180,4 @@ def setup_from_path(
         precision=precision,
         compile=compile,
     )
-    return _make_calculator(
-        orbff, atoms_adapter, torch.device(device), edge_method, **kwargs
-    )
+    return _make_calculator(orbff, atoms_adapter, torch.device(device), edge_method, **kwargs)

--- a/sample_model_configurations/nvidia_configs/orbmol.py
+++ b/sample_model_configurations/nvidia_configs/orbmol.py
@@ -81,7 +81,7 @@ def _fetch(url: str, dest: Path) -> None:
         tmp.unlink(missing_ok=True)
 
 
-def _make_calculator(orbff, atoms_adapter, device, **kwargs):
+def _make_calculator(orbff, atoms_adapter, device, edge_method=None, **kwargs):
     from ase.calculators.calculator import all_changes
     from orb_models.forcefield.inference.calculator import ORBCalculator
 
@@ -94,6 +94,12 @@ def _make_calculator(orbff, atoms_adapter, device, **kwargs):
                 atoms.info.setdefault("spin", 1)
             super().calculate(atoms, properties, system_changes)
 
+    # None = vendor default: on CUDA that's the library's own edge_method
+    # (knn_alchemi, Warp kernels); the ROCm variant resolves None to its
+    # knn_scipy pin instead. Named in the setup hooks (not just **kwargs)
+    # so the signature can't drift between vendor copies.
+    if edge_method is not None:
+        kwargs["edge_method"] = edge_method
     return OrbMolCalculator(orbff, atoms_adapter, device=device, **kwargs)
 
 
@@ -102,6 +108,7 @@ def setup(
     device: str = "cuda",
     precision: str = "float32-high",
     compile: bool | None = None,
+    edge_method: str | None = None,
     **kwargs,
 ):
     # Extra **kwargs go to ORBCalculator (e.g. max_num_neighbors=,
@@ -129,7 +136,7 @@ def setup(
         precision=precision,
         compile=compile,
     )
-    return _make_calculator(orbff, atoms_adapter, torch.device(device), **kwargs)
+    return _make_calculator(orbff, atoms_adapter, torch.device(device), edge_method, **kwargs)
 
 
 def setup_from_path(
@@ -138,6 +145,7 @@ def setup_from_path(
     arch: str = "orbmol-v2",
     precision: str = "float32-high",
     compile: bool | None = None,
+    edge_method: str | None = None,
     **kwargs,
 ):
     # Custom checkpoints (`:custom` ids with user weights). A weights file
@@ -163,4 +171,4 @@ def setup_from_path(
         precision=precision,
         compile=compile,
     )
-    return _make_calculator(orbff, atoms_adapter, torch.device(device), **kwargs)
+    return _make_calculator(orbff, atoms_adapter, torch.device(device), edge_method, **kwargs)

--- a/sample_model_configurations/nvidia_configs/orbmol.py
+++ b/sample_model_configurations/nvidia_configs/orbmol.py
@@ -3,7 +3,9 @@
 # # sdist doesn't compile against modern GCC (vendored abseil).
 # requires-python = ">=3.12,<3.13"
 # dependencies = [
-#     "orb-models>=0.6.2",
+#     # 0.7.0 (2026-05-26) introduces orbmol_v2 and the orbmol-v1-* aliases
+#     # (orbmol-v1-conservative == orb-v3-conservative-omol).
+#     "orb-models>=0.7,<0.8",
 #     "ase>=3.25",
 #     "torch>=2.8",
 #     # Not imported here — constrains orb-models' transitive dep. setup()'s
@@ -20,13 +22,18 @@
 # url = "https://download.pytorch.org/whl/cu128"
 # explicit = true
 # ///
-"""Orb v3 env — the primary orb env, Orbital Materials' Orb v3 potentials.
+"""OrbMol env (CUDA) — Orbital Materials' molecular potentials (OMol25/OPoly26).
 
-Separate from orb.py because the v3 loaders need orb-models>=0.6.2, which
-bumped the Python floor to 3.12 and torch to 2.8; the v3 loader API also
-differs (returns a tuple, requires `atoms_adapter` on ORBCalculator, imports
-the calculator from forcefield.inference). orb.py (v2) survives only for
-orb-d3-v2, the dispersion-corrected variant with no v3 equivalent.
+orbmol-v1-conservative is upstream's alias for orb-v3-conservative-omol;
+orbmol-v2 (2026-05) adds learnable long-range electrostatics (CoulombModule).
+
+CUDA counterpart of amd_configs/orbmol.py, minus the ROCm workarounds: the
+nvalchemiops Warp kernels run natively here, so the default edge_method and
+the Particle Mesh Ewald path (orbmol-v2, periodic cells) both work.
+
+Charge/spin: these are OMol-style conditioned models — ORBCalculator raises if
+atoms.info lacks "charge"/"spin" (spin = multiplicity). Set them per structure
+via atoms.info; absent that, we default to neutral singlet (charge=0, spin=1).
 """
 
 import os
@@ -35,17 +42,11 @@ import urllib.request
 from pathlib import Path
 
 CHECKPOINTS = {
-    "orb-v3-conservative-inf-omat": "orb-v3-conservative-inf-omat",
-    "orb-v3-conservative-20-omat": "orb-v3-conservative-20-omat",
-    "orb-v3-direct-inf-omat": "orb-v3-direct-inf-omat",
-    "orb-v3-direct-20-omat": "orb-v3-direct-20-omat",
-    "orb-v3-conservative-inf-mpa": "orb-v3-conservative-inf-mpa",
-    "orb-v3-conservative-20-mpa": "orb-v3-conservative-20-mpa",
-    "orb-v3-direct-inf-mpa": "orb-v3-direct-inf-mpa",
-    "orb-v3-direct-20-mpa": "orb-v3-direct-20-mpa",
-    # Your own fine-tuned v3 weights: pair with weights= (loaded via
-    # setup_from_path).
-    "orb-v3:custom": None,
+    "orbmol-v1-conservative": "orbmol-v1-conservative",
+    "orbmol-v2": "orbmol-v2",
+    # Your own fine-tuned OrbMol weights: pair with weights= (loaded via
+    # setup_from_path); pass arch= to pick the base architecture.
+    "orbmol:custom": None,
 }
 
 
@@ -80,10 +81,33 @@ def _fetch(url: str, dest: Path) -> None:
         tmp.unlink(missing_ok=True)
 
 
-def setup(checkpoint: str, device: str = "cuda", precision: str = "float32-high", **kwargs):
+def _make_calculator(orbff, atoms_adapter, device, **kwargs):
+    from ase.calculators.calculator import all_changes
+    from orb_models.forcefield.inference.calculator import ORBCalculator
+
+    class OrbMolCalculator(ORBCalculator):
+        """ORBCalculator that defaults missing charge/spin to neutral singlet."""
+
+        def calculate(self, atoms=None, properties=None, system_changes=all_changes):
+            if atoms is not None:
+                atoms.info.setdefault("charge", 0)
+                atoms.info.setdefault("spin", 1)
+            super().calculate(atoms, properties, system_changes)
+
+    return OrbMolCalculator(orbff, atoms_adapter, device=device, **kwargs)
+
+
+def setup(
+    checkpoint: str,
+    device: str = "cuda",
+    precision: str = "float32-high",
+    compile: bool | None = None,
+    **kwargs,
+):
+    # Extra **kwargs go to ORBCalculator (e.g. max_num_neighbors=,
+    # half_supercell=); precision/compile go to the checkpoint loader.
     import torch
     from orb_models.forcefield import pretrained
-    from orb_models.forcefield.inference.calculator import ORBCalculator
 
     fn_name = CHECKPOINTS[checkpoint].replace("-", "_")
     load_fn = getattr(pretrained, fn_name)
@@ -100,37 +124,43 @@ def setup(checkpoint: str, device: str = "cuda", precision: str = "float32-high"
         _fetch(url, weights)
 
     orbff, atoms_adapter = load_fn(
-        weights_path=str(weights), device=torch.device(device), precision=precision
+        weights_path=str(weights),
+        device=torch.device(device),
+        precision=precision,
+        compile=compile,
     )
-    return ORBCalculator(orbff, atoms_adapter=atoms_adapter, device=torch.device(device), **kwargs)
+    return _make_calculator(orbff, atoms_adapter, torch.device(device), **kwargs)
 
 
 def setup_from_path(
     path: str,
     device: str = "cuda",
-    arch: str = "orb-v3-conservative-inf-omat",
+    arch: str = "orbmol-v2",
     precision: str = "float32-high",
+    compile: bool | None = None,
     **kwargs,
 ):
-    # Custom checkpoints (`:custom` ids with user weights). A weights file doesn't say
-    # which orb architecture produced it, so `arch` names the pretrained
-    # loader to instantiate — pass the right one at call time
+    # Custom checkpoints (`:custom` ids with user weights). A weights file
+    # doesn't say which architecture produced it, so `arch` names the
+    # pretrained loader to instantiate — pass the right one at call time
     # (setup_kwargs={"arch": ...} / --kwarg arch=...). Handing the loader a
     # local path also means no network and no cached_path locking (see setup()).
     import torch
     from orb_models.forcefield import pretrained
-    from orb_models.forcefield.inference.calculator import ORBCalculator
 
-    fn_name = arch.replace("-", "_")
+    fn_name = arch.replace("-", "_").replace(":", "_")
     try:
         load_fn = getattr(pretrained, fn_name)
     except AttributeError:
         raise ValueError(
-            f"unknown orb architecture {arch!r}; expected a loader name from "
-            f"orb_models.forcefield.pretrained, e.g. orb-v3-conservative-inf-omat"
+            f"unknown OrbMol architecture {arch!r}; expected a loader name from "
+            f"orb_models.forcefield.pretrained, e.g. orbmol-v2, orbmol-v1-conservative"
         ) from None
 
     orbff, atoms_adapter = load_fn(
-        weights_path=path, device=torch.device(device), precision=precision
+        weights_path=path,
+        device=torch.device(device),
+        precision=precision,
+        compile=compile,
     )
-    return ORBCalculator(orbff, atoms_adapter=atoms_adapter, device=torch.device(device), **kwargs)
+    return _make_calculator(orbff, atoms_adapter, torch.device(device), **kwargs)


### PR DESCRIPTION
This PR makes an orbmol env file for NVIDIA machines to be consistent with how we're splitting it out for AMD/Frontier.