### PR TITLE
aurora_configs: native FairChem XPU via collaborator fork; add esen + allscaip

### DIFF
--- a/docs/environments.md
+++ b/docs/environments.md
@@ -120,7 +120,7 @@ Rebuilds (`rootstock install <name> --force`) install exactly the locked version
 # explicit = true
 ```
 
-Then `setup()` takes `device="xpu"`. See `aurora_configs/{mace,uma}.py` for complete examples (UMA also monkeypatches FairChem to accept `xpu` and forces FP64). PyTorch's XPU build ships its Intel runtime under the env's `lib/`, which the worker adds to `LD_LIBRARY_PATH` automatically.
+Then `setup()` takes `device="xpu"`. See `aurora_configs/{mace,uma,esen,allscaip}.py` for complete examples (the FairChem envs install fairchem-core from a fork with native XPU support — PyPI releases accept only `cpu`/`cuda` — and force FP64 inference). PyTorch's XPU build ships its Intel runtime under the env's `lib/`, which the worker adds to `LD_LIBRARY_PATH` automatically.
 
 ### `CHECKPOINTS` table
 

--- a/sample_model_configurations/aurora_configs/allscaip.py
+++ b/sample_model_configurations/aurora_configs/allscaip.py
@@ -3,9 +3,8 @@
 # dependencies = [
 #     "fairchem-core",
 #     "ase>=3.26",
-#     # Intel XPU (Aurora PVC) torch build. >=2.13: older XPU wheels (e.g. 2.8)
-#     # have far slower FP64 kernels -- UMA's first forward took >40 min on
-#     # 2.8.0+xpu vs ~2 min on 2.13.0+xpu (PVC tile).
+#     # Intel XPU (Aurora PVC) torch build. >=2.13: older XPU wheels have far
+#     # slower FP64 kernels (see uma.py).
 #     "torch>=2.13",
 #     # torch's XPU wheels depend on this; it lives only on the XPU index, so it
 #     # must be a direct dep for [tool.uv.sources] to route it (the index is
@@ -28,55 +27,24 @@
 # url = "https://download.pytorch.org/whl/xpu"
 # explicit = true
 # ///
-"""UMA env (Intel XPU / Aurora) - Meta's UMA foundation model via FAIRChem.
+"""AllScAIP env (Intel XPU / Aurora) - FAIRChem scalable attention MLIP.
 
-Same as nvidia_configs/uma.py except (1) torch resolves from the Intel XPU wheel
-index, (2) fairchem-core installs from a fork with native XPU support (replacing
-the monkeypatch this env previously carried), and (3) InferenceSettings defaults
-to float32, so we set base_precision_dtype=float64 to match the FP64 reference
-(fp32 is wrong at ~1e-7).
+Same as nvidia_configs/allscaip.py except (1) torch resolves from the Intel
+XPU wheel index, (2) fairchem-core installs from a fork with native XPU
+support, and (3) InferenceSettings defaults to float32, so we set
+base_precision_dtype=float64 to match the FP64 reference. The all-to-all
+node attention path is untested on XPU hardware.
 
 Pin one PVC tile with ZE_AFFINITY_MASK in the job (the worker inherits it).
-Requires HF_TOKEN for the gated facebook/UMA checkpoints (download on a login
-node; `rootstock add ... --no-verify`, then verify on a compute node).
-
-UMA is multi-task: setup() requires an explicit `task`
-(setup_kwargs={"task": ...} / --kwarg task=...) and errors without one.
-Verification picks its own head via VERIFY_KWARGS below.
+OMol checkpoints expect `charge` and `spin` in `atoms.info`.
 """
 
 CHECKPOINTS = {
-    "uma-s-1p1": "uma-s-1p1",
-    # uma-s-1p2 had a known major bug; uma-s-1p2p1 is the fixed,
-    # upstream-recommended small model and replaces it here.
-    "uma-s-1p2p1": "uma-s-1p2p1",
-    "uma-m-1p1": "uma-m-1p1",
+    "allscaip-md-conserving-all-omol": "allscaip-md-conserving-all-omol",
+    "allscaip-md-direct-all-omol": "allscaip-md-direct-all-omol",
     # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
-    "uma:custom": None,
+    "allscaip:custom": None,
 }
-
-UMA_TASKS = ("omat", "omol", "oc20", "odac", "omc")
-
-# Verification-only head selection: smoke-test and a bare `rootstock add`
-# verify with these (setup() itself has no default task).
-VERIFY_KWARGS = {
-    "uma-s-1p1": {"task": "omat"},
-    "uma-s-1p2p1": {"task": "omat"},
-    "uma-m-1p1": {"task": "omat"},
-    "uma:custom": {"task": "omat"},
-}
-
-
-def _require_task(task, checkpoint):
-    if task is None:
-        raise ValueError(
-            f"{checkpoint} is multi-task and has no default head - select one "
-            f'with setup_kwargs={{"task": ...}} (or --kwarg task=...): '
-            f"one of {', '.join(UMA_TASKS)}"
-        )
-    if task not in UMA_TASKS:
-        raise ValueError(f"unknown task {task!r}; expected one of {', '.join(UMA_TASKS)}")
-    return task
 
 
 def _fairchem_device(device: str) -> str:
@@ -103,8 +71,7 @@ def _fp64_settings():
     return InferenceSettings(base_precision_dtype=torch.float64, tf32=False)
 
 
-def setup(checkpoint: str, device: str = "xpu", task: str | None = None, **kwargs):
-    task = _require_task(task, checkpoint)
+def setup(checkpoint: str, device: str = "xpu", **kwargs):
     from fairchem.core import FAIRChemCalculator, pretrained_mlip
 
     predictor = pretrained_mlip.get_predict_unit(
@@ -112,10 +79,10 @@ def setup(checkpoint: str, device: str = "xpu", task: str | None = None, **kwarg
         device=_fairchem_device(device),
         inference_settings=_fp64_settings(),
     )
-    return FAIRChemCalculator(predictor, task_name=task, **kwargs)
+    return FAIRChemCalculator(predictor, **kwargs)
 
 
-def setup_from_path(path: str, device: str = "xpu", task: str | None = None, **kwargs):
+def setup_from_path(path: str, device: str = "xpu", **kwargs):
     # Custom checkpoints (`:custom` ids with user weights): a weights *file* loads
     # through load_predict_unit, not the registry-name lookup setup() uses.
     from fairchem.core import FAIRChemCalculator
@@ -124,4 +91,4 @@ def setup_from_path(path: str, device: str = "xpu", task: str | None = None, **k
     predictor = load_predict_unit(
         path, device=_fairchem_device(device), inference_settings=_fp64_settings()
     )
-    return FAIRChemCalculator(predictor, task_name=task, **kwargs)
+    return FAIRChemCalculator(predictor, **kwargs)

--- a/sample_model_configurations/aurora_configs/esen.py
+++ b/sample_model_configurations/aurora_configs/esen.py
@@ -3,9 +3,8 @@
 # dependencies = [
 #     "fairchem-core",
 #     "ase>=3.26",
-#     # Intel XPU (Aurora PVC) torch build. >=2.13: older XPU wheels (e.g. 2.8)
-#     # have far slower FP64 kernels -- UMA's first forward took >40 min on
-#     # 2.8.0+xpu vs ~2 min on 2.13.0+xpu (PVC tile).
+#     # Intel XPU (Aurora PVC) torch build. >=2.13: older XPU wheels have far
+#     # slower FP64 kernels (see uma.py).
 #     "torch>=2.13",
 #     # torch's XPU wheels depend on this; it lives only on the XPU index, so it
 #     # must be a direct dep for [tool.uv.sources] to route it (the index is
@@ -28,55 +27,24 @@
 # url = "https://download.pytorch.org/whl/xpu"
 # explicit = true
 # ///
-"""UMA env (Intel XPU / Aurora) - Meta's UMA foundation model via FAIRChem.
+"""eSEN env (Intel XPU / Aurora) - FAIRChem eSEN single-task checkpoints.
 
-Same as nvidia_configs/uma.py except (1) torch resolves from the Intel XPU wheel
-index, (2) fairchem-core installs from a fork with native XPU support (replacing
-the monkeypatch this env previously carried), and (3) InferenceSettings defaults
-to float32, so we set base_precision_dtype=float64 to match the FP64 reference
-(fp32 is wrong at ~1e-7).
+Same as nvidia_configs/esen.py except (1) torch resolves from the Intel XPU
+wheel index, (2) fairchem-core installs from a fork with native XPU support,
+and (3) InferenceSettings defaults to float32, so we set
+base_precision_dtype=float64 to match the FP64 reference.
 
 Pin one PVC tile with ZE_AFFINITY_MASK in the job (the worker inherits it).
-Requires HF_TOKEN for the gated facebook/UMA checkpoints (download on a login
-node; `rootstock add ... --no-verify`, then verify on a compute node).
-
-UMA is multi-task: setup() requires an explicit `task`
-(setup_kwargs={"task": ...} / --kwarg task=...) and errors without one.
-Verification picks its own head via VERIFY_KWARGS below.
+OMol checkpoints expect `charge` and `spin` in `atoms.info`.
 """
 
 CHECKPOINTS = {
-    "uma-s-1p1": "uma-s-1p1",
-    # uma-s-1p2 had a known major bug; uma-s-1p2p1 is the fixed,
-    # upstream-recommended small model and replaces it here.
-    "uma-s-1p2p1": "uma-s-1p2p1",
-    "uma-m-1p1": "uma-m-1p1",
+    "esen-md-direct-all-omol": "esen-md-direct-all-omol",
+    "esen-sm-conserving-all-omol": "esen-sm-conserving-all-omol",
+    "esen-sm-direct-all-omol": "esen-sm-direct-all-omol",
     # Your own fine-tuned weights: pair with weights= (loaded via setup_from_path).
-    "uma:custom": None,
+    "esen:custom": None,
 }
-
-UMA_TASKS = ("omat", "omol", "oc20", "odac", "omc")
-
-# Verification-only head selection: smoke-test and a bare `rootstock add`
-# verify with these (setup() itself has no default task).
-VERIFY_KWARGS = {
-    "uma-s-1p1": {"task": "omat"},
-    "uma-s-1p2p1": {"task": "omat"},
-    "uma-m-1p1": {"task": "omat"},
-    "uma:custom": {"task": "omat"},
-}
-
-
-def _require_task(task, checkpoint):
-    if task is None:
-        raise ValueError(
-            f"{checkpoint} is multi-task and has no default head - select one "
-            f'with setup_kwargs={{"task": ...}} (or --kwarg task=...): '
-            f"one of {', '.join(UMA_TASKS)}"
-        )
-    if task not in UMA_TASKS:
-        raise ValueError(f"unknown task {task!r}; expected one of {', '.join(UMA_TASKS)}")
-    return task
 
 
 def _fairchem_device(device: str) -> str:
@@ -103,8 +71,7 @@ def _fp64_settings():
     return InferenceSettings(base_precision_dtype=torch.float64, tf32=False)
 
 
-def setup(checkpoint: str, device: str = "xpu", task: str | None = None, **kwargs):
-    task = _require_task(task, checkpoint)
+def setup(checkpoint: str, device: str = "xpu", **kwargs):
     from fairchem.core import FAIRChemCalculator, pretrained_mlip
 
     predictor = pretrained_mlip.get_predict_unit(
@@ -112,10 +79,10 @@ def setup(checkpoint: str, device: str = "xpu", task: str | None = None, **kwarg
         device=_fairchem_device(device),
         inference_settings=_fp64_settings(),
     )
-    return FAIRChemCalculator(predictor, task_name=task, **kwargs)
+    return FAIRChemCalculator(predictor, **kwargs)
 
 
-def setup_from_path(path: str, device: str = "xpu", task: str | None = None, **kwargs):
+def setup_from_path(path: str, device: str = "xpu", **kwargs):
     # Custom checkpoints (`:custom` ids with user weights): a weights *file* loads
     # through load_predict_unit, not the registry-name lookup setup() uses.
     from fairchem.core import FAIRChemCalculator
@@ -124,4 +91,4 @@ def setup_from_path(path: str, device: str = "xpu", task: str | None = None, **k
     predictor = load_predict_unit(
         path, device=_fairchem_device(device), inference_settings=_fp64_settings()
     )
-    return FAIRChemCalculator(predictor, task_name=task, **kwargs)
+    return FAIRChemCalculator(predictor, **kwargs)


### PR DESCRIPTION
## What

Builds on #217/#219 to widen FairChem coverage on Aurora:

- **`aurora_configs/uma.py`**: replace the `MLIPPredictUnit._setup_device` monkeypatch with fairchem-core installed from the [`xpu-support` branch of `abagusetty/fairchem`](https://github.com/abagusetty/fairchem/tree/xpu-support), which adds native Intel-GPU support — `device="xpu"` accepted through `get_predict_unit`/`FAIRChemCalculator.from_model_checkpoint`, a `common/device_utils.py` abstraction layer, `torch.xpu` seeding/cache management, and XCCL (oneCCL) collectives. The `#219` conventions are preserved (mandatory task head, `VERIFY_KWARGS`, FP64 inference settings, `**kwargs`).
- **`aurora_configs/{esen,allscaip}.py`** (new): the other two fairchem-core v2 families, mirroring their `nvidia_configs` counterparts plus the XPU wheel index, the same FP64 settings, and an xpu `_fairchem_device()` shim — the fork normalizes indexed device strings to the bare type and resolves the actual GPU from `torch.xpu.current_device()`, so `"xpu:N"` has to travel through `torch.xpu.set_device`, same as the CUDA configs.
- `docs/environments.md`: refresh the aurora examples line (monkeypatch mention is stale).

Out of scope: the fairchem-core 1.x OC20 stack (`escn`, `equiformer`) — no XPU path exists (CUDA-only pyg wheels), and the fork doesn't touch v1.

## Why the fork

PyPI fairchem-core (through 2.22) asserts `device in {"cpu", "cuda"}` deep in the predict unit; the monkeypatch worked around the assert but left cache management, seeding, and collectives CUDA-hardwired. The fork (3 commits ahead of upstream `main`, head `fc18598` as of 2026-08-28) does this properly and is intended for upstreaming. The git dependency is routed via `[tool.uv.sources]` with `subdirectory = "packages/fairchem-core"`; env builds lock it to a concrete SHA at install time. Once XPU support merges upstream, the source override can be deleted and the dep returned to a PyPI floor.

## Validation

- All three configs resolve with `uv lock --script` (the same resolution path `rootstock install` uses): fairchem-core `2.22.1.dev11+gfc18598`, torch `2.13.0+xpu`, triton-xpu `3.7.2`. The hatch-vcs dynamic version works from the git+subdirectory install.
- Checkpoint ids verified against the fork's `pretrained_models.json` (includes `uma-s-1p2p1`).
- `parse_checkpoints_dict` / `parse_clusters_list` / `declares_setup_from_path` pass on all aurora configs.
- **Not yet run on Intel hardware** — these are experimental; first runtime validation will follow the intel workshop loop / Aurora smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)