### PR TITLE
aurora_configs/allscaip: patch radius-graph image_id dtype for FP64 inference

### DIFF
--- a/sample_model_configurations/aurora_configs/allscaip.py
+++ b/sample_model_configurations/aurora_configs/allscaip.py
@@ -31,9 +31,10 @@
 
 Same as nvidia_configs/allscaip.py except (1) torch resolves from the Intel
 XPU wheel index, (2) fairchem-core installs from a fork with native XPU
-support, and (3) InferenceSettings defaults to float32, so we set
-base_precision_dtype=float64 to match the FP64 reference. The all-to-all
-node attention path is untested on XPU hardware.
+support, (3) InferenceSettings defaults to float32, so we set
+base_precision_dtype=float64 to match the FP64 reference, and (4) FP64
+inference needs a dtype patch in AllScAIP's radius graph (see
+_patch_image_id_dtype).
 
 Pin one PVC tile with ZE_AFFINITY_MASK in the job (the worker inherits it).
 OMol checkpoints expect `charge` and `spin` in `atoms.info`.
@@ -71,9 +72,39 @@ def _fp64_settings():
     return InferenceSettings(base_precision_dtype=torch.float64, tf32=False)
 
 
+def _patch_image_id_dtype():
+    """Work around a dtype mismatch in AllScAIP's radius graph under FP64.
+
+    biknn_radius_graph builds the PBC image-offset tensors (image_id) with
+    torch.get_default_dtype() -- float32 -- while base_precision_dtype=float64
+    casts the batch, including cell, to double, so build_radius_graph's
+    `torch.mm(image_id, cell)` raises "expected mat1 and mat2 to have the
+    same dtype, but got: float != double" (fairchem
+    models/allscaip/utils/allscaip_radius_graph.py). Not device-specific:
+    any FP64 run hits it. Cast each image_id to its cell's dtype on the way
+    into batched_radius_graph; drop this once fairchem builds image_id with
+    the cell dtype.
+    """
+    from fairchem.core.models.allscaip.utils import allscaip_radius_graph as graph_mod
+
+    if getattr(graph_mod.batched_radius_graph, "_image_id_dtype_patched", False):
+        return
+    original = graph_mod.batched_radius_graph
+
+    def patched(pos_list, cell_list, image_id_list, *args, **kwargs):
+        image_id_list = [
+            image_id.to(cell.dtype) for image_id, cell in zip(image_id_list, cell_list)
+        ]
+        return original(pos_list, cell_list, image_id_list, *args, **kwargs)
+
+    patched._image_id_dtype_patched = True
+    graph_mod.batched_radius_graph = patched
+
+
 def setup(checkpoint: str, device: str = "xpu", **kwargs):
     from fairchem.core import FAIRChemCalculator, pretrained_mlip
 
+    _patch_image_id_dtype()
     predictor = pretrained_mlip.get_predict_unit(
         CHECKPOINTS[checkpoint],
         device=_fairchem_device(device),
@@ -88,6 +119,7 @@ def setup_from_path(path: str, device: str = "xpu", **kwargs):
     from fairchem.core import FAIRChemCalculator
     from fairchem.core.units.mlip_unit import load_predict_unit
 
+    _patch_image_id_dtype()
     predictor = load_predict_unit(
         path, device=_fairchem_device(device), inference_settings=_fp64_settings()
     )


### PR DESCRIPTION
Fixes the two `allscaip` verify failures from the first Aurora sync (manifest pushed 2026-08-28T22:47Z).

## Failure

Both `allscaip-md-{conserving,direct}-all-omol` verifies died on xpu with:

```
File ".../fairchem/core/models/allscaip/utils/allscaip_radius_graph.py", line 529, in build_radius_graph
    src_pos = pos[:, None] + torch.mm(image_id, cell)[None, :]
RuntimeError: expected mat1 and mat2 to have the same dtype, but got: float != double
```

## Root cause

`biknn_radius_graph` builds its PBC image-offset tensors with `torch.get_default_dtype()` (float32) — both the PBC `torch.cartesian_prod(torch.arange(...))` path and the non-PBC identity image — while this env's `InferenceSettings(base_precision_dtype=float64)` casts the batch, including `cell`, to double. **Not XPU-specific**: any FP64 run of AllScAIP hits it. The nvidia config runs default fp32 and never trips it; eSEN's graph path doesn't share the pattern, which is why `esen` verified 3/3 on the same sync.

## Fix

A guarded wrapper around `batched_radius_graph` (applied in `setup()`/`setup_from_path()`, same precedent as the `_setup_device` monkeypatch this env carried before #220) that casts each `image_id` to its `cell`'s dtype. Droppable once fairchem builds `image_id` with the cell dtype — being reported to the fork maintainer (abagusetty) as the proper upstream fix.

## Validation

- `ruff format --check` clean; AST parses; deps unchanged (no rebuild needed — sync re-registers the source and re-verifies).
- Not yet run on Aurora hardware: the patch point matches the call site (`batched_radius_graph(pos_list, cell_list, image_id_list, ...)`, module-global lookup so the wrapper takes effect), but the proof is the next sync — the two failed verifies retry automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)