### PR TITLE
fetch_checkpoint: fall back to VERIFY_KWARGS like the verify path

### DIFF
--- a/rootstock/operations.py
+++ b/rootstock/operations.py
@@ -39,6 +39,7 @@ from .environment import (
     parse_checkpoints_dict,
     parse_clusters_list,
     parse_custom_checkpoint_ids,
+    verify_kwargs_for,
 )
 from .exceptions import RootstockError
 from .layout import resolve_cache_root
@@ -1211,11 +1212,16 @@ def fetch_checkpoint(
     manifest's ``last_error``).
     """
     root = Path(root)
-    setup_kwargs = setup_kwargs or {}
     if cache_root is None:
         cache_root = resolve_cache_root(root)
 
     env_name = _resolve_built_env(root, checkpoint, cluster)
+
+    # No explicit kwargs → fall back to the env's declared VERIFY_KWARGS,
+    # exactly like the verify path: setup() runs the download here too, and a
+    # multi-head env (UMA's task, MACE-MH-1's head) raises without a head
+    # selection. Explicit kwargs always win.
+    setup_kwargs = setup_kwargs or verify_kwargs_for(root, env_name, checkpoint)
 
     # Unlocked peek for idempotence; every write below loads fresh inside
     # its own transaction, so a racing writer costs at most a redundant

--- a/tests/commands/test_add_split.py
+++ b/tests/commands/test_add_split.py
@@ -140,6 +140,71 @@ def test_fetch_refresh_knob(fake_root, refresh_calls, monkeypatch):
     assert len(refresh_calls) == 1
 
 
+_MULTIHEAD_ENV_SOURCE = '''\
+"""Multi-head env: setup() requires a head selection, no default."""
+
+CHECKPOINTS = {
+    "uma-s-1p1": "uma-s-1p1",
+}
+
+VERIFY_KWARGS = {
+    "uma-s-1p1": {"task": "omat"},
+}
+
+
+def setup(checkpoint, device="cuda", task=None):
+    return None
+'''
+
+
+@pytest.fixture
+def multihead_root(tmp_path: Path) -> Path:
+    """A root whose env declares VERIFY_KWARGS for its checkpoint."""
+    root = tmp_path
+    env_dir = root / "envs" / "uma"
+    (env_dir / "bin").mkdir(parents=True)
+    (env_dir / "bin" / "python").touch()
+    (env_dir / "env_source.py").write_text(_MULTIHEAD_ENV_SOURCE)
+
+    from rootstock.config import UserConfig
+    from rootstock.manifest import create_manifest, save_manifest
+
+    cfg = UserConfig(name="t", email="t@t.t")
+    save_manifest(create_manifest(root, ["test"], cfg), root)
+    return root
+
+
+def test_fetch_falls_back_to_verify_kwargs(multihead_root, refresh_calls, monkeypatch):
+    """No explicit kwargs → the env's VERIFY_KWARGS reach the download's
+    setup() call, same as the verify path (a multi-head setup() raises
+    without a head selection)."""
+    captured = {}
+
+    def fake_download(root, env_name, checkpoint, setup_kwargs, **kw):
+        captured["setup_kwargs"] = setup_kwargs
+        return True, None
+
+    monkeypatch.setattr(operations, "_run_download", fake_download)
+
+    fetch_checkpoint(multihead_root, "uma-s-1p1")
+
+    assert captured["setup_kwargs"] == {"task": "omat"}
+
+
+def test_fetch_explicit_kwargs_beat_verify_kwargs(multihead_root, refresh_calls, monkeypatch):
+    captured = {}
+
+    def fake_download(root, env_name, checkpoint, setup_kwargs, **kw):
+        captured["setup_kwargs"] = setup_kwargs
+        return True, None
+
+    monkeypatch.setattr(operations, "_run_download", fake_download)
+
+    fetch_checkpoint(multihead_root, "uma-s-1p1", setup_kwargs={"task": "omol"})
+
+    assert captured["setup_kwargs"] == {"task": "omol"}
+
+
 def test_fetch_fails_fast_when_env_not_built(tmp_path, refresh_calls):
     from rootstock.config import UserConfig
     from rootstock.manifest import create_manifest, save_manifest


### PR DESCRIPTION
## Problem

Found on the first Aurora sync (2026-08-28, rootstock 1.6.3): every multi-head checkpoint fails the sync's download phase with e.g.

```
download: ValueError: uma-s-1p1 is multi-task and has no default head
```

`fetch_checkpoint` runs the download by calling `setup(checkpoint, "cpu", **setup_kwargs)` via `_run_download`, but defaulted `setup_kwargs` to `{}` instead of falling back to the env's declared `VERIFY_KWARGS`. Since #219 made multi-head checkpoints raise when no head is selected (uma: `task=...`, mace-mh-1: `head=...`), the bare download always raises. The verify path already falls back correctly (`verify.py`).

## Fix

Resolve the hosting env first, then default `setup_kwargs` to `verify_kwargs_for(root, env_name, checkpoint)` — the same fallback the verify path uses. Explicit kwargs still win, and envs without `VERIFY_KWARGS` still get `{}`.

Regression tests added alongside the existing fetch tests in `tests/commands/test_add_split.py`: the declared `VERIFY_KWARGS` reach `_run_download`, and explicit kwargs override them.

## Notes

- This unblocks `uma-s-1p1`, `uma-s-1p2p1`, `uma-m-1p1`, and `mace-mh-1` on the aurora manifest.
- A release is needed for this to take effect on clusters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)