### PR TITLE
nvidia_configs: add deepmd env hosting the built-in DPA pretrained models

### DIFF
--- a/sample_model_configurations/nvidia_configs/deepmd.py
+++ b/sample_model_configurations/nvidia_configs/deepmd.py
@@ -1,0 +1,242 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "deepmd-kit[torch]>=3.2.0",
+#     "ase>=3.23",
+#     # deepmd-kit's torch extra pins torch==2.11.0.*. Listed here too so the
+#     # explicit cu128 index below routes it: an `explicit` index is only
+#     # consulted for packages named in `dependencies`, and PyPI's torch 2.11
+#     # wheels bundle CUDA 13, which needs a newer driver than most clusters run.
+#     "torch>=2.11,<2.12",
+# ]
+#
+# [tool.uv.sources]
+# torch = { index = "pytorch-cu128" }
+#
+# [[tool.uv.index]]
+# name = "pytorch-cu128"
+# url = "https://download.pytorch.org/whl/cu128"
+# explicit = true
+# ///
+"""DeePMD-kit env — hosts the DPA foundation models built into deepmd-kit.
+
+The upstream strings are the names deepmd-kit's own pretrained-model registry
+knows (the same ones ``dp pretrained download`` accepts). Weights are fetched
+from Hugging Face with sha256 verification into the shared model cache and
+loaded from that local file, so serving needs no network.
+
+Multitask checkpoints (the OpenLAM DPA-2.4 / DPA-3.x models) carry one
+fitting head per training dataset and require ``head=`` selecting one —
+``setup_kwargs={"head": "OMat24"}`` on RootstockCalculator, or
+``--kwarg head=OMat24`` for ``rootstock add``. Valid heads per checkpoint
+are listed in HEADS; pick the dataset closest to your system and check it
+covers your elements. Single-task checkpoints take no head.
+
+Charge and spin: checkpoints trained with frame-level charge/spin inputs
+(DPA3-Omol-Large, DPA-3.2-5M, DPA-3.3-1M) read them from
+``atoms.info["charge"]`` and ``atoms.info["spin"]`` (spin = multiplicity
+2S+1), the convention the other OMol-trained envs use. Without them the
+model's trained-in default (neutral singlet) applies. deepmd's native
+``fparam`` / ``charge_spin`` info keys still work and take precedence.
+
+Device: deepmd's PyTorch backend fixes its device at first import from the
+environment (``DEVICE=cpu`` for CPU, otherwise ``cuda:{LOCAL_RANK}``), so
+setup() sets those variables before importing deepmd.
+
+Licenses: the DPA-2 / DPA-3 checkpoints are CC-BY-4.0; the DPA4 checkpoints
+are CC-BY-NC-4.0 (non-commercial).
+"""
+
+import os
+from pathlib import Path
+
+CHECKPOINTS = {
+    # Single-task checkpoints: no head selection.
+    "dpa3-omol-large": "DPA3-Omol-Large",
+    "dpa4-nano-omat24": "DPA4-Nano-OMat24-v20260805",
+    "dpa4-mini-omat24": "DPA4-Mini-OMat24-v20260805",
+    "dpa4-neo-omat24": "DPA4-Neo-OMat24-v20260805",
+    "dpa4-air-omat24": "DPA4-Air-OMat24-v20260805",
+    "dpa4-plus-omat24": "DPA4-Plus-OMat24-v20260805",
+    # Multitask OpenLAM checkpoints: head= required (see HEADS).
+    "dpa-3.3-1m": "DPA-3.3-1M",
+    "dpa-3.2-5m": "DPA-3.2-5M",
+    "dpa-3.1-3m": "DPA-3.1-3M",
+    "dpa-2.4-7m": "DPA-2.4-7M",
+    # Your own DeePMD-kit model — a training checkpoint (.pt) or frozen model
+    # (.pth): pair with weights= (loaded via setup_from_path).
+    "dpa:custom": None,
+}
+
+# Fitting heads of the multitask checkpoints (the upstream `model-branch`
+# names). Aliases such as "Default" or "materials" are accepted too, and
+# matching is case-insensitive.
+_OPENLAM_V2_HEADS = (
+    "OMat24",
+    "OMol25",
+    "MPTrj",
+    "OC20M",
+    "OC22",
+    "ODAC23",
+    "Alex2D",
+    "MPGen_OpenCSP",
+    "Domains_Alloy",
+    "Domains_Anode",
+    "Domains_Cluster",
+    "Domains_FerroEle",
+    "Domains_SSE_PBE",
+    "Domains_SemiCond",
+    "H2O_H2O_PD",
+    "Metals_AlMgCu",
+    "Metals_AgAu_PBED3",
+    "Others_In2Se3",
+    "Alloy_APEX",
+    "SSE_ABACUS",
+    "Hybrid_Perovskite",
+    "Electrolyte",
+    "Organic_Reactions",
+)
+_OPENLAM_V1_HEADS = (
+    "Omat24",
+    "MP_traj_v024_alldata_mixu",
+    "OC20M",
+    "OC22",
+    "ODAC23",
+    "Alex2D",
+    "SPICE2",
+    "Domains_Alloy",
+    "Domains_Anode",
+    "Domains_Cluster",
+    "Domains_Drug",
+    "Domains_FerroEle",
+    "Domains_SSE_PBE",
+    "Domains_SSE_PBESol",
+    "Domains_SemiCond",
+    "Domains_Transition1x",
+    "H2O_H2O_PD",
+    "Metals_AlMgCu",
+    "Metals_Sn",
+    "Metals_Ti",
+    "Metals_V",
+    "Metals_W",
+    "Metals_AgAu_PBED3",
+    "Others_HfO2",
+    "Others_In2Se3",
+    "Alloy_tongqi",
+    "SSE_ABACUS",
+    "Hybrid_Perovskite",
+    "solvated_protein_fragments",
+    "Electrolyte",
+    "Organic_Reactions",
+)
+HEADS = {
+    "dpa-3.3-1m": _OPENLAM_V2_HEADS,
+    "dpa-3.2-5m": _OPENLAM_V2_HEADS,
+    "dpa-3.1-3m": _OPENLAM_V1_HEADS,
+    "dpa-2.4-7m": _OPENLAM_V1_HEADS,
+}
+
+# Head used when verification runs with no user selection. Users still select
+# explicitly. The custom entry's value is forwarded to whichever shipped
+# checkpoint the weights= leg borrows: single-task checkpoints ignore it.
+VERIFY_KWARGS = {
+    "dpa-3.3-1m": {"head": "OMat24"},
+    "dpa-3.2-5m": {"head": "OMat24"},
+    "dpa-3.1-3m": {"head": "Omat24"},
+    "dpa-2.4-7m": {"head": "Omat24"},
+    "dpa:custom": {"head": "OMat24"},
+}
+
+
+def _cache_dir() -> Path:
+    """Where the registry downloads land: deepmd's default layout, relocated
+    into the shared model cache."""
+    cache = Path(os.environ.get("XDG_CACHE_HOME") or Path.home() / ".cache")
+    return cache / "deepmd" / "pretrained" / "models"
+
+
+def _select_device(device: str) -> None:
+    """Point deepmd's PyTorch backend at ``device``.
+
+    The backend reads its device once, when ``deepmd.pt.utils.env`` is first
+    imported: ``DEVICE=cpu`` forces CPU, otherwise it uses
+    ``cuda:{LOCAL_RANK}`` (LOCAL_RANK defaulting to 0). There is no per-call
+    device argument, so this must run before the first deepmd import.
+    """
+    if device == "cpu":
+        os.environ["DEVICE"] = "cpu"
+    elif device.startswith("cuda:"):
+        os.environ["LOCAL_RANK"] = device.split(":", 1)[1]
+
+
+def _calculator_class():
+    """deepmd's ASE calculator, reading charge/spin the way the other envs do."""
+    from ase.calculators.calculator import all_changes
+    from deepmd.calculator import DP
+
+    class RootstockDP(DP):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            # Two ways a DPA model can take charge/spin: as the two frame
+            # parameters (DPA3-Omol-Large, DPA-3.2-5M) or through a dedicated
+            # charge/spin embedding (DPA-3.3-1M, DPA4-OMol).
+            self._charge_spin_as_fparam = self.dp.get_dim_fparam() == 2
+            self._charge_spin_embedded = self.dp.has_chg_spin_ebd()
+
+        def calculate(
+            self,
+            atoms=None,
+            properties=("energy", "forces", "virial"),
+            system_changes=all_changes,
+        ):
+            if atoms is not None and ("charge" in atoms.info or "spin" in atoms.info):
+                atoms = atoms.copy()
+                charge_spin = [
+                    float(atoms.info.get("charge", 0)),
+                    float(atoms.info.get("spin", 1)),
+                ]
+                if self._charge_spin_as_fparam:
+                    atoms.info.setdefault("fparam", charge_spin)
+                if self._charge_spin_embedded:
+                    atoms.info.setdefault("charge_spin", charge_spin)
+            super().calculate(atoms, list(properties), system_changes)
+
+    return RootstockDP
+
+
+def setup(checkpoint: str, device: str = "cuda", head: str | None = None, **kwargs):
+    """
+    Load a DeePMD-kit calculator for a built-in pretrained model.
+
+    Args:
+        checkpoint: Canonical checkpoint id, must be a key of CHECKPOINTS.
+        device: PyTorch device string (e.g., "cuda", "cuda:0", "cpu").
+        head: Fitting head of a multitask checkpoint (see HEADS). Required
+            for those; ignored by single-task checkpoints.
+
+    Returns:
+        ASE-compatible calculator.
+    """
+    if checkpoint in HEADS and head is None:
+        raise ValueError(
+            f"{checkpoint} is multitask and has no default head - select one "
+            f'with setup_kwargs={{"head": ...}}: one of {", ".join(HEADS[checkpoint])}'
+        )
+    _select_device(device)
+
+    from deepmd.pretrained.download import resolve_model_path
+
+    # Resolves the registry name to a sha256-verified local file, downloading
+    # only when it is missing from the cache (at `rootstock add` time).
+    weights = resolve_model_path(CHECKPOINTS[checkpoint], cache_dir=_cache_dir())
+    return _calculator_class()(model=str(weights), head=head, **kwargs)
+
+
+def setup_from_path(path: str, device: str = "cuda", head: str | None = None, **kwargs):
+    # Custom checkpoints (`:custom` ids with user weights): DP loads a training
+    # checkpoint (.pt) or a frozen model (.pth) straight from a path. A
+    # multitask fine-tune needs its head (setup_kwargs={"head": ...} /
+    # --kwarg head=...) unless it declares a default; single-task ones
+    # take none.
+    _select_device(device)
+    return _calculator_class()(model=path, head=head, **kwargs)

--- a/tests/sample_configs/test_deepmd_env.py
+++ b/tests/sample_configs/test_deepmd_env.py
@@ -1,0 +1,222 @@
+"""Tests for the deepmd env's loading contract.
+
+deepmd-kit resolves its built-in pretrained models by registry name and
+fixes its PyTorch device at first import from the environment; the env file
+routes both through Rootstock's conventions — weights into the shared cache
+via XDG_CACHE_HOME, the device from the ``device`` argument, an explicit
+``head`` for multitask checkpoints, and charge/spin read from the
+``atoms.info`` keys the other OMol-trained envs use.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+from ase import Atoms
+
+from rootstock.environment import parse_verify_kwargs
+
+_CONFIG = (
+    Path(__file__).parent.parent.parent
+    / "sample_model_configurations"
+    / "nvidia_configs"
+    / "deepmd.py"
+)
+
+
+def _load_env_module():
+    spec = importlib.util.spec_from_file_location("deepmd_env", _CONFIG)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeDeepPot:
+    def __init__(self, dim_fparam: int, chg_spin_ebd: bool):
+        self._dim_fparam = dim_fparam
+        self._chg_spin_ebd = chg_spin_ebd
+
+    def get_dim_fparam(self) -> int:
+        return self._dim_fparam
+
+    def has_chg_spin_ebd(self) -> bool:
+        return self._chg_spin_ebd
+
+
+@pytest.fixture
+def stubbed_deepmd(monkeypatch):
+    """Stub deepmd in sys.modules; capture what setup() passes to each piece."""
+    captured: dict = {"model_traits": (0, False)}
+
+    class DP:
+        def __init__(self, model, head=None, **kwargs):
+            captured["calculator"] = {"model": model, "head": head, **kwargs}
+            self.dp = _FakeDeepPot(*captured["model_traits"])
+            self.results = {}
+
+        def calculate(self, atoms=None, properties=None, system_changes=None):
+            captured["calc_info"] = dict(atoms.info)
+
+    def resolve_model_path(name, *, cache_dir=None):
+        captured["resolve"] = {"name": name, "cache_dir": cache_dir}
+        return Path(cache_dir) / f"{name}.pt"
+
+    deepmd = types.ModuleType("deepmd")
+    calculator = types.ModuleType("deepmd.calculator")
+    calculator.DP = DP
+    pretrained = types.ModuleType("deepmd.pretrained")
+    download = types.ModuleType("deepmd.pretrained.download")
+    download.resolve_model_path = resolve_model_path
+    for name, module in {
+        "deepmd": deepmd,
+        "deepmd.calculator": calculator,
+        "deepmd.pretrained": pretrained,
+        "deepmd.pretrained.download": download,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    monkeypatch.setenv("XDG_CACHE_HOME", "/shared/root/cache")
+    monkeypatch.delenv("DEVICE", raising=False)
+    monkeypatch.delenv("LOCAL_RANK", raising=False)
+    return captured
+
+
+# ---------- registry resolution + head selection --------------------------------
+
+
+def test_setup_resolves_registry_name_into_shared_cache(stubbed_deepmd):
+    module = _load_env_module()
+    module.setup("dpa-3.2-5m", device="cuda", head="OMat24")
+
+    assert stubbed_deepmd["resolve"] == {
+        "name": "DPA-3.2-5M",
+        "cache_dir": Path("/shared/root/cache/deepmd/pretrained/models"),
+    }
+    assert stubbed_deepmd["calculator"] == {
+        "model": "/shared/root/cache/deepmd/pretrained/models/DPA-3.2-5M.pt",
+        "head": "OMat24",
+    }
+
+
+def test_multitask_checkpoint_requires_head(stubbed_deepmd):
+    module = _load_env_module()
+    with pytest.raises(ValueError, match="OMat24"):
+        module.setup("dpa-3.2-5m", device="cuda")
+    assert "resolve" not in stubbed_deepmd, "must fail before touching the cache"
+
+
+def test_single_task_checkpoint_takes_no_head(stubbed_deepmd):
+    module = _load_env_module()
+    module.setup("dpa3-omol-large", device="cuda")
+    assert stubbed_deepmd["calculator"]["head"] is None
+
+
+def test_extra_kwargs_reach_the_calculator(stubbed_deepmd):
+    module = _load_env_module()
+    module.setup("dpa4-mini-omat24", device="cuda", nlist_backend="ase")
+    assert stubbed_deepmd["calculator"]["nlist_backend"] == "ase"
+
+
+def test_every_multitask_id_has_a_verify_head():
+    module = _load_env_module()
+    verify = parse_verify_kwargs(_CONFIG)
+    for ckpt, heads in module.HEADS.items():
+        assert ckpt in module.CHECKPOINTS
+        head = verify[ckpt]["head"]
+        assert head.lower() in {h.lower() for h in heads}
+    for ckpt in module.CHECKPOINTS:
+        if ckpt not in module.HEADS and ckpt != "dpa:custom":
+            assert ckpt not in verify, f"{ckpt} is single-task and needs no verify head"
+
+
+# ---------- device selection ----------------------------------------------------
+
+
+def test_indexed_cuda_device_sets_local_rank(stubbed_deepmd, monkeypatch):
+    module = _load_env_module()
+    module.setup("dpa3-omol-large", device="cuda:2")
+    import os
+
+    assert os.environ["LOCAL_RANK"] == "2"
+    assert "DEVICE" not in os.environ
+
+
+def test_cpu_device_sets_deepmd_device_env(stubbed_deepmd):
+    module = _load_env_module()
+    module.setup("dpa3-omol-large", device="cpu")
+    import os
+
+    assert os.environ["DEVICE"] == "cpu"
+
+
+# ---------- custom weights -------------------------------------------------------
+
+
+def test_setup_from_path_loads_the_file_directly(stubbed_deepmd):
+    module = _load_env_module()
+    module.setup_from_path("/scratch/me/ft.pt", device="cpu", head="MyHead")
+    assert "resolve" not in stubbed_deepmd
+    assert stubbed_deepmd["calculator"] == {"model": "/scratch/me/ft.pt", "head": "MyHead"}
+
+
+# ---------- charge/spin translation --------------------------------------------
+
+
+def _water():
+    atoms = Atoms("H2O", positions=[[0, 0, 0], [0.96, 0, 0], [0.24, 0.93, 0]])
+    atoms.info["charge"] = 1
+    atoms.info["spin"] = 2
+    return atoms
+
+
+def test_charge_spin_become_fparam_for_fparam_models(stubbed_deepmd):
+    stubbed_deepmd["model_traits"] = (2, False)
+    module = _load_env_module()
+    calc = module.setup("dpa3-omol-large", device="cpu")
+    atoms = _water()
+    calc.calculate(atoms)
+
+    assert stubbed_deepmd["calc_info"]["fparam"] == [1.0, 2.0]
+    assert "charge_spin" not in stubbed_deepmd["calc_info"]
+    assert "fparam" not in atoms.info, "the caller's atoms must not be mutated"
+
+
+def test_charge_spin_become_charge_spin_for_embedding_models(stubbed_deepmd):
+    stubbed_deepmd["model_traits"] = (0, True)
+    module = _load_env_module()
+    calc = module.setup("dpa-3.3-1m", device="cpu", head="OMat24")
+    calc.calculate(_water())
+
+    assert stubbed_deepmd["calc_info"]["charge_spin"] == [1.0, 2.0]
+    assert "fparam" not in stubbed_deepmd["calc_info"]
+
+
+def test_explicit_fparam_wins_over_charge_spin(stubbed_deepmd):
+    stubbed_deepmd["model_traits"] = (2, False)
+    module = _load_env_module()
+    calc = module.setup("dpa3-omol-large", device="cpu")
+    atoms = _water()
+    atoms.info["fparam"] = [0.0, 1.0]
+    calc.calculate(atoms)
+    assert stubbed_deepmd["calc_info"]["fparam"] == [0.0, 1.0]
+
+
+def test_models_without_charge_spin_inputs_are_left_alone(stubbed_deepmd):
+    stubbed_deepmd["model_traits"] = (0, False)
+    module = _load_env_module()
+    calc = module.setup("dpa4-mini-omat24", device="cpu")
+    calc.calculate(_water())
+    assert "fparam" not in stubbed_deepmd["calc_info"]
+    assert "charge_spin" not in stubbed_deepmd["calc_info"]
+
+
+def test_atoms_without_charge_spin_pass_through_untouched(stubbed_deepmd):
+    stubbed_deepmd["model_traits"] = (2, True)
+    module = _load_env_module()
+    calc = module.setup("dpa3-omol-large", device="cpu")
+    calc.calculate(Atoms("H2", positions=[[0, 0, 0], [0.74, 0, 0]]))
+    assert stubbed_deepmd["calc_info"] == {}


### PR DESCRIPTION
## What

Adds `sample_model_configurations/nvidia_configs/deepmd.py`, a DeePMD-kit environment, plus `tests/sample_configs/test_deepmd_env.py`. Several groups we are onboarding (Delta especially) run DeePMD-kit and fine-tune DPA3; this closes the "DeePMD isn't in the catalog" gap.

Ten canonical ids, all mapped to names in deepmd-kit's **built-in pretrained registry** (`deepmd/pretrained/registry.py`, the same names `dp pretrained download` accepts, each with HF + mirror URLs and a sha256):

| id | upstream | notes |
|---|---|---|
| `dpa3-omol-large` | `DPA3-Omol-Large` | single-task, OMol25, charge/spin via fparam |
| `dpa4-{nano,mini,neo,air,plus}-omat24` | `DPA4-<Size>-OMat24-v20260805` | single-task, DPA4/SeZM, OMat24 |
| `dpa-3.3-1m`, `dpa-3.2-5m`, `dpa-3.1-3m`, `dpa-2.4-7m` | `DPA-3.3-1M` … | multitask OpenLAM, `head=` required |
| `dpa:custom` | — | any `.pt` checkpoint / frozen `.pth` via `weights=` |

## Design

- **Deps**: `deepmd-kit[torch]>=3.2.0` (released 2026-08-19; first release with the DPA4 loaders and the full registry). The `[torch]` extra pins `torch==2.11.0.*`; torch is listed explicitly so it routes through the cu128 index, since PyPI's 2.11 wheels bundle CUDA 13. `uv lock --script` resolves universally (83 packages: torch 2.11.0+cu128, deepmd-kit 3.2.0, e3nn, vesin, nvalchemi-toolkit-ops 0.4.1, mpich).
- **Fetch**: `setup()` calls deepmd's `resolve_model_path(name, cache_dir=$XDG_CACHE_HOME/deepmd/pretrained/models)` and hands `DP()` the local path. A cache hit only re-hashes the file (read-only), so serve time never writes to the shared install and needs no network.
- **Heads**: the multitask ids raise without `head=` (same rule as uma `task` / mace-mh-1 `head` from #219), even though deepmd itself would silently pick the `Default` alias (OMat24) on 3.2-5M / 3.3-1M. `HEADS` lists valid branches per id; `VERIFY_KWARGS` selects OMat24 (covers verify's H2O) for the four multitask ids and for `dpa:custom`.
- **Custom family is `dpa`**, not `deepmd`: the smoke-test weights= leg finds its baseline by id prefix (`_family_of`), and every shipped id starts with `dpa`. The first declared id (`dpa3-omol-large`) is single-task so that leg needs no head.
- **Device**: deepmd's PyTorch backend has no device argument; it reads `DEVICE=cpu` or `cuda:{LOCAL_RANK}` at first import. `setup()` sets `LOCAL_RANK` for `cuda:N` (correct under an existing `CUDA_VISIBLE_DEVICES` mask, unlike overwriting it) and `DEVICE=cpu` for CPU, before importing deepmd. Works because the worker imports no torch before `setup()`.
- **Charge/spin**: two upstream mechanisms exist — `fparam=[charge, spin]` (DPA3-Omol-Large, DPA-3.2-5M) and a `charge_spin` embedding (DPA-3.3-1M, DPA4-OMol). A thin `DP` subclass fills whichever the loaded model uses from `atoms.info["charge"]` / `["spin"]`, matching the other OMol-trained envs; explicit `fparam` / `charge_spin` keys win; absent both, the model's trained-in neutral-singlet default applies.

## Not verified yet

Not built or verified on any cluster. Delta is the natural first target (most of the DeePMD groups are there). Expect the first verify to surface something, per `docs/environments.md`.

## Deliberately left out

- DPA4-OMol25 sizes, DPA4C (needs the `pt-expt` backend / `.pt2` export), DPA4-Beta, and `DPA-3.1-3M-FT` (the Matbench-Discovery `.pth`): on HF but not in deepmd's registry, so they would need a second fetch path.
- No `amd_configs` / `aurora_configs` counterpart (ROCm/XPU untested).
- Licenses: DPA-2/3 checkpoints are CC-BY-4.0; the DPA4 checkpoints are CC-BY-NC-4.0.

## Tests

`uv run pytest tests/sample_configs` — 152 passed (13 new: registry resolution into the shared cache, mandatory head, device env contract, custom-path loading, charge/spin translation for both mechanisms, VERIFY_KWARGS ↔ HEADS consistency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
